### PR TITLE
Correct filename case

### DIFF
--- a/disassembly/bank1C.asm
+++ b/disassembly/bank1C.asm
@@ -7,10 +7,10 @@ org $1C8000
   db $BA, $CB, $AA, $CF, $80, $16, $60, $B9 ; $1C8010 |
   
   
-  incbin "Samples/Athletic/18_HORN.brr"		  ; $1C0818 | UNUSED!!!
-  incbin "Samples/Athletic/19_CLARINET.brr" ; $1C8771 |
-  incbin "Samples/Athletic/1A_TROMBONE.brr" ; $1C87F8 | UNUSED!!!
-  incbin "Samples/Athletic/1B_BRASS.brr"    ; $1C9272 |
+  incbin "samples/athletic/18_HORN.brr"		  ; $1C0818 | UNUSED!!!
+  incbin "samples/athletic/19_CLARINET.brr" ; $1C8771 |
+  incbin "samples/athletic/1A_TROMBONE.brr" ; $1C87F8 | UNUSED!!!
+  incbin "samples/athletic/1B_BRASS.brr"    ; $1C9272 |
   
 ; athletic music
   db $00, $00, $00, $04, $A8, $00, $00, $3D ; $1C9698 |

--- a/disassembly/bank1D.asm
+++ b/disassembly/bank1D.asm
@@ -9,20 +9,20 @@
   db $02, $83, $E3, $83, $FE, $83, $21, $9D ; $1CBEB8 |
   db $A8, $9D, $98, $BC, $20, $7D, $00, $40 ; $1CBEC0 |
   
-  incbin "Samples/Ending/00_PIANOLOW.BRR"           ; $1CBEC8 |
-  incbin "Samples/Ending/01_MAPBRASS.BRR"           ; $1CC066 |
-  incbin "Samples/Ending/02_FRENCHHORN.BRR"         ; $1CCE01 |
-  incbin "Samples/Ending/03_HARP.BRR"               ; $1CDC74 |
-  incbin "Samples/Ending/04_TUBULARBELL.BRR"        ; $1CDD43 |
-  incbin "Samples/Ending/05_PANFLUTE.BRR"           ; $1CE511 |
-  incbin "Samples/Ending/06_PIZZSTRINGS.BRR"        ; $1CE976 |
-  incbin "Samples/Ending/07_TIMPANI.BRR"            ; $1CEC19 |
-  incbin "Samples/Ending/08_ORCBRASS.BRR":0-844     ; $1CF7BC |
+  incbin "samples/ending/00_PIANOLOW.brr"           ; $1CBEC8 |
+  incbin "samples/ending/01_MAPBRASS.brr"           ; $1CC066 |
+  incbin "samples/ending/02_FRENCHHORN.brr"         ; $1CCE01 |
+  incbin "samples/ending/03_HARP.brr"               ; $1CDC74 |
+  incbin "samples/ending/04_TUBULARBELL.brr"        ; $1CDD43 |
+  incbin "samples/ending/05_PANFLUTE.brr"           ; $1CE511 |
+  incbin "samples/ending/06_PIZZSTRINGS.brr"        ; $1CE976 |
+  incbin "samples/ending/07_TIMPANI.brr"            ; $1CEC19 |
+  incbin "samples/ending/08_ORCBRASS.brr":0-844     ; $1CF7BC |
 org $1D8000 
-  incbin "Samples/Ending/08_ORCBRASS.BRR":844-A0E   
-  incbin "Samples/Ending/09_GLOCKENSPIEL.BRR"       ; $1D81C8 |
-  incbin "Samples/Ending/0A_PIANOHIGH.BRR"          ; $1D82C2 |
-  incbin "Samples/Ending/0B_CELLO.BRR"              ; $1D9C70 |
+  incbin "samples/ending/08_ORCBRASS.brr":844-A0E   
+  incbin "samples/ending/09_GLOCKENSPIEL.brr"       ; $1D81C8 |
+  incbin "samples/ending/0A_PIANOHIGH.brr"          ; $1D82C2 |
+  incbin "samples/ending/0B_CELLO.brr"              ; $1D9C70 |
   
   ; filler
   db $FF                                    ; $1DBBE7 |
@@ -1281,9 +1281,9 @@ org $1D8000
   
   
   
-  incbin "Samples/Swamp/18_SHAKERS.brr"         ;$1DE291 |
-  incbin "Samples/Swamp/19_GUIRO.brr"           ;$1DE5D7 |  
-  incbin "Samples/Swamp/1B_ALTGUITARSTRUM.brr"  ;$1DE817 | Uploads twice (1A, 1B) to the SPC700, used on 1B
+  incbin "samples/swamp/18_SHAKERS.brr"         ;$1DE291 |
+  incbin "samples/swamp/19_GUIRO.brr"           ;$1DE5D7 |  
+  incbin "samples/swamp/1B_ALTGUITARSTRUM.brr"  ;$1DE817 | Uploads twice (1A, 1B) to the SPC700, used on 1B
                                                 
   
  
@@ -1301,10 +1301,10 @@ org $1D8000
   db $75, $C8, $60, $CB, $20, $12, $60, $B9 ; $1DEC95 |
   
   
-  incbin "Samples/Flower/18_KICK.brr"           ; $1DEC9D |
-  incbin "Samples/Flower/19_CLOSEDHIHAT.brr"    ; $1DF32D |
-  incbin "Samples/Flower/1A_OPENHIHAT.brr"      ; $1DF62D |
-  incbin "Samples/Flower/1B_HARMONICA.brr"      ; $1DFBB2 |
+  incbin "samples/flower/18_KICK.brr"           ; $1DEC9D |
+  incbin "samples/flower/19_CLOSEDHIHAT.brr"    ; $1DF32D |
+  incbin "samples/flower/1A_OPENHIHAT.brr"      ; $1DF62D |
+  incbin "samples/flower/1B_HARMONICA.brr"      ; $1DFBB2 |
   
   
   ;filler 

--- a/disassembly/bank1E.asm
+++ b/disassembly/bank1E.asm
@@ -9,13 +9,13 @@ org $1DFEC1
   db $FD, $C0, $47, $C5, $70, $21, $80, $A4 ; $1DFEE1 |
   db $FF, $FF, $FF							            ; $1DFEE9 |
   
-  incbin "Samples/BigBowser/16_ALTPOP.BRR":0-114    ;this is literally a copy of the SFX popping sample set up to overwrite the popping sample . . . . .
+  incbin "samples/bigbowser/16_ALTPOP.brr":0-114    ;this is literally a copy of the SFX popping sample set up to overwrite the popping sample . . . . .
 
 org $1E8000
-  incbin "Samples/BigBowser/16_ALTPOP.BRR":114-7BC  ;it's byte-for-byte identical to the regular one.
-  incbin "Samples/BigBowser/18_KICK.BRR"        ; $1E86A8 | gets duplicated into 17, too
-  incbin "Samples/BigBowser/19_RIDECYMBAL.BRR"  ; $1E8D38 |
-  incbin "Samples/BigBowser/1B_DISTGUITAR.BRR"  ; $1E9B66 | also copied in full to 1A
+  incbin "samples/bigbowser/16_ALTPOP.brr":114-7BC  ;it's byte-for-byte identical to the regular one.
+  incbin "samples/bigbowser/18_KICK.brr"        ; $1E86A8 | gets duplicated into 17, too
+  incbin "samples/bigbowser/19_RIDECYMBAL.brr"  ; $1E8D38 |
+  incbin "samples/bigbowser/1B_DISTGUITAR.brr"  ; $1E9B66 | also copied in full to 1A
 
   ;filler		
   db $FF, $FF, $FF, $FF, $FF, $FF, $FF      ; $1EA052 |
@@ -2534,10 +2534,10 @@ org $1E8000
   db $03, $BC, $F3, $BF, $03, $BC, $F3, $BF ; $1EEE62 |
   db $29, $C0, $16, $C7, $70, $14, $60, $B9 ; $1EEE6A |
   
-  incbin Samples/Castle/18_PIZZSTRINGS.brr     ; $1EEE72 |
-  incbin Samples/Castle/1A_MAPBRASS.brr        ; $1EF115 | Duplicated into 19 in full upon SPC upload, only used from 1A.
-  incbin Samples/Castle/1B_STRINGS.brr:0-AC5   ; $1EF53B |
+  incbin samples/castle/18_PIZZSTRINGS.brr     ; $1EEE72 |
+  incbin samples/castle/1A_MAPBRASS.brr        ; $1EF115 | Duplicated into 19 in full upon SPC upload, only used from 1A.
+  incbin samples/castle/1B_STRINGS.brr:0-AC5   ; $1EF53B |
  org $1F8000
-  incbin Samples/Castle/1B_STRINGS.brr:AC5-D9B ; $1F8000 | Split in two for crossbanking
+  incbin samples/castle/1B_STRINGS.brr:AC5-D9B ; $1F8000 | Split in two for crossbanking
 ; continued into bank $1F
 

--- a/disassembly/bank1F.asm
+++ b/disassembly/bank1F.asm
@@ -31,33 +31,33 @@ org $1F82D6     ;$1F8000-$1F82D5 are part of a brr. See Bank1E.asm
 ;a bug in the SPC chip that causes a popping sound if a sample is interrupted by new sample data, as it basically
 ;makes the pop silent as a workaround. Note that this header byte can be $00 too!
   
-incbin Samples/Global/00_ROCKROLL.brr       ; $1F834E |
-incbin Samples/Global/01_CRY.brr            ; $1F872C |
-incbin Samples/Global/02_BONGO.brr          ; $1F9C95 |
-incbin Samples/Global/03_VIBRAPHONE.brr     ; $1FA826 |
-incbin Samples/Global/04_SLAPBASS.brr       ; $1FA9BB |
-incbin Samples/Global/05_WARNING.brr        ; $1FAB35 |
-incbin Samples/Global/06_PERCORGAN.brr      ; $1FAF6D |
-incbin Samples/Global/07_COWBELL.brr        ; $1FAFD0 |
+incbin samples/global/00_ROCKROLL.brr       ; $1F834E |
+incbin samples/global/01_CRY.brr            ; $1F872C |
+incbin samples/global/02_BONGO.brr          ; $1F9C95 |
+incbin samples/global/03_VIBRAPHONE.brr     ; $1FA826 |
+incbin samples/global/04_SLAPBASS.brr       ; $1FA9BB |
+incbin samples/global/05_WARNING.brr        ; $1FAB35 |
+incbin samples/global/06_PERCORGAN.brr      ; $1FAF6D |
+incbin samples/global/07_COWBELL.brr        ; $1FAFD0 |
     
-incbin Samples/Global/08_GUITARSTRUM.brr    ; $1FB3A5 |
-incbin Samples/Global/09_MOTOR.brr          ; $1FBB4F |
-incbin Samples/Global/0A_TRUMPET.brr        ; $1FBC9F |
-incbin Samples/Global/0B_BOING.brr          ; $1FC6B3 |
-incbin Samples/Global/0C_LICK.brr           ; $1FCAEB |
-incbin Samples/Global/0D_DOORSLAM.brr       ; $1FCF86 |
-incbin Samples/Global/0E_GLOCKENSPIEL.brr   ; $1FD4E7 |
-incbin Samples/Global/0F_ORCHIT.brr         ; $1FD5E3 |
+incbin samples/global/08_GUITARSTRUM.brr    ; $1FB3A5 |
+incbin samples/global/09_MOTOR.brr          ; $1FBB4F |
+incbin samples/global/0A_TRUMPET.brr        ; $1FBC9F |
+incbin samples/global/0B_BOING.brr          ; $1FC6B3 |
+incbin samples/global/0C_LICK.brr           ; $1FCAEB |
+incbin samples/global/0D_DOORSLAM.brr       ; $1FCF86 |
+incbin samples/global/0E_GLOCKENSPIEL.brr   ; $1FD4E7 |
+incbin samples/global/0F_ORCHIT.brr         ; $1FD5E3 |
   
-incbin Samples/Global/10_RECORDER.brr       ; $1FDF34 |
-incbin Samples/Global/11_SNARE.brr          ; $1FDF6A |
-incbin Samples/Global/12_VIOLIN.brr         ; $1FE5FD |
-incbin Samples/Global/13_JAZZGUITAR.brr     ; $1FE633 |
+incbin samples/global/10_RECORDER.brr       ; $1FDF34 |
+incbin samples/global/11_SNARE.brr          ; $1FDF6A |
+incbin samples/global/12_VIOLIN.brr         ; $1FE5FD |
+incbin samples/global/13_JAZZGUITAR.brr     ; $1FE633 |
 
-incbin Samples/Global/14_PIRANHABITE.brr    ; $1FE7D1 |
-incbin Samples/Global/15_SHYGUYSTOMP.brr    ; $1FED32 |
-incbin Samples/Global/16_POP.brr            ; $1FF107 |
-incbin Samples/Global/17_SPLASH.brr         ; $1FF8C3 |
+incbin samples/global/14_PIRANHABITE.brr    ; $1FE7D1 |
+incbin samples/global/15_SHYGUYSTOMP.brr    ; $1FED32 |
+incbin samples/global/16_POP.brr            ; $1FF107 |
+incbin samples/global/17_SPLASH.brr         ; $1FF8C3 |
 
   ;this is also uploaded to the SPC700 for some reason . . .
   ;possibly to make it easier to round the BRRs? 

--- a/disassembly/bank21.asm
+++ b/disassembly/bank21.asm
@@ -1,18 +1,18 @@
 ; Waves crashing SFX (BRR)
 org $20B0B6  
-	incbin "Samples/TitleScreen/00_WAVES.BRR"			; $20B0B6 |
-	incbin "Samples/TitleScreen/01_GULLS.BRR":0-10D1	; $20EF2F |
+	incbin "samples/titlescreen/00_WAVES.brr"			; $20B0B6 |
+	incbin "samples/titlescreen/01_GULLS.brr":0-10D1	; $20EF2F |
 org $218000
-	incbin "Samples/TitleScreen/01_GULLS.BRR":10D1-1B48	; $218000 | Bank-Crossing requires a split
-	incbin "Samples/TitleScreen/02_XYLOPHONE.BRR"  		; $218A77 |
-	incbin "Samples/TitleScreen/03_VIBRAPHONE.BRR" 		; $219422 | Used for menu sfx on the title screen
-	incbin "Samples/TitleScreen/04_PANFLUTE.BRR"		; $2195B7 |
-	incbin "Samples/TitleScreen/05_ALTRECORDER.BRR"		; $219A1C | Unused!
-	incbin "Samples/TitleScreen/06_SLAPBASS.BRR"		; $219A52 |
-	incbin "Samples/TitleScreen/07_BONGO.BRR"			; $219BCC |
-	incbin "Samples/TitleScreen/08_SHAKERS.BRR"			; $21A75D |
-	incbin "Samples/TitleScreen/09_MUSICBOX.BRR"		; $21AAA2 |
-	incbin "Samples/TitleScreen/0A_MBOXMECHANISM.BRR"	; $21B015 |
+	incbin "samples/titlescreen/01_GULLS.brr":10D1-1B48	; $218000 | Bank-Crossing requires a split
+	incbin "samples/titlescreen/02_XYLOPHONE.brr"  		; $218A77 |
+	incbin "samples/titlescreen/03_VIBRAPHONE.brr" 		; $219422 | Used for menu sfx on the title screen
+	incbin "samples/titlescreen/04_PANFLUTE.brr"		; $2195B7 |
+	incbin "samples/titlescreen/05_ALTRECORDER.brr"		; $219A1C | Unused!
+	incbin "samples/titlescreen/06_SLAPBASS.brr"		; $219A52 |
+	incbin "samples/titlescreen/07_BONGO.brr"			; $219BCC |
+	incbin "samples/titlescreen/08_SHAKERS.brr"			; $21A75D |
+	incbin "samples/titlescreen/09_MUSICBOX.brr"		; $21AAA2 |
+	incbin "samples/titlescreen/0A_MBOXMECHANISM.brr"	; $21B015 |
   
   ;filler
   


### PR DESCRIPTION
Some paths in includes are incorrectly capitalized, so it doesn't compile on case sensitive systems such as linux.