### PR TITLE
Replace a great number of raw addresses with labels

### DIFF
--- a/disassembly/bank00.asm
+++ b/disassembly/bank00.asm
@@ -1295,39 +1295,126 @@ CODE_00899F:
   REP #$20                                  ; $0089C9 |
   RTL                                       ; $0089CB |
 
-; pointer table (address - 1)
-; main ambient sprite routines
-ambient_sprite_main_routines:
-  dw $8CBE, $8D03, $8D36, $8D74             ; $0089CC |
-  dw $8D8E, $8DA4, $8DB1, $8DE6             ; $0089D4 |
-  dw $8DF7, $8E15, $8E36, $8E5D             ; $0089DC |
-  dw $8E7D, $8EEE, $8EFD, $8F0A             ; $0089E4 |
-  dw $8F3A, $8F69, $8F9A, $8FD1             ; $0089EC |
-  dw $9006, $9027, $9098, $90B9             ; $0089F4 |
-  dw $90C2, $AD09, $90F5, $912C             ; $0089FC |
-  dw $9153, $9518, $917A, $919F             ; $008A04 |
-  dw $91C6, $9219, $9253, $927C             ; $008A0C |
-  dw $92ED, $9375, $93A3, $93DD             ; $008A14 |
-  dw $9432, $9518, $9547, $955E             ; $008A1C |
-  dw $92AC, $92A4, $955E, $9518             ; $008A24 |
-  dw $9518, $9518, $9518, $9547             ; $008A2C |
-  dw $A7D9, $9530, $961A, $9530             ; $008A34 |
-  dw $9645, $95CB, $9530, $986C             ; $008A3C |
-  dw $986C, $9518, $958C, $986C             ; $008A44 |
-  dw $9575, $9575, $9518, $9547             ; $008A4C |
-  dw $9415, $9ADC, $9B12, $9530             ; $008A54 |
-  dw $9518, $9530, $9530, $955E             ; $008A5C |
-  dw $9B54, $9518, $9B87, $9BBB             ; $008A64 |
-  dw $9BE2, $9C1C, $9E91, $9518             ; $008A6C |
-  dw $9518, $951C, $A192, $A192             ; $008A74 |
-  dw $A550, $A56E, $A599, $9ADC             ; $008A7C |
-  dw $A6A8, $A6CD, $A834, $A6A8             ; $008A84 |
-  dw $A725, $9B54, $A758, $A775             ; $008A8C |
-  dw $9518, $A78C, $A7A3, $A7F6             ; $008A94 |
-  dw $9530, $9518, $A80D, $9518             ; $008A9C |
-  dw $8D95, $9219, $9518, $9518             ; $008AA4 |
-  dw $98AB, $9912, $9997, $9A18             ; $008AAC |
-  dw $9A65                                  ; $008AB4 |
+; ambient sprite routines
+; ambient sprite indices start from 1BA
+ambient_sprite_routines:
+  dw ambient_water_splash_transition-1      ; $0089CC | 1BA
+  dw ambient_water_splash_swimming-1        ; $0089CE | 1BB
+  dw ambient_bubble_in_water-1              ; $0089D0 | 1BC
+  dw ambient_eggshell-1                     ; $0089D2 | 1BD
+  dw ambient_small_bopping_ani-1            ; $0089D4 | 1BE
+  dw ambient_score_sprites-1                ; $0089D6 | 1BF
+  dw ambient_salvo_slime_smoke_puff-1       ; $0089D8 | 1C0
+  dw CODE_008DE7-1                          ; $0089DA | 1C1 - ?
+  dw ambient_transform_smoke_puff-1         ; $0089DC | 1C2
+  dw ambient_terrain_destroy_smoke_puff-1   ; $0089DE | 1C3
+  dw CODE_008E37-1                          ; $0089E0 | 1C4 - ?
+  dw ambient_train_enter_track_ani-1        ; $0089E2 | 1C5
+  dw ambient_train_transformation_smoke-1   ; $0089E4 | 1C6
+  dw ambient_floating_log_lava_drop-1       ; $0089E6 | 1C7
+  dw CODE_008EFE-1                          ; $0089E8 | 1C8 - ?
+  dw CODE_008F0B-1                          ; $0089EA | 1C9 - ?
+  dw ambient_snow_puff-1                    ; $0089EC | 1CA
+  dw CODE_008F6A-1                          ; $0089EE | 1CB - ?
+  dw ambient_dr_freezegood_bop-1            ; $0089F0 | 1CC
+  dw ambient_sparkles_1-1                   ; $0089F2 | 1CD
+  dw CODE_009007-1                          ; $0089F4 | 1CE - ?
+  dw CODE_009028-1                          ; $0089F6 | 1CF - ?
+  dw ambient_bubble_pop-1                   ; $0089F8 | 1D0
+  dw CODE_0090BA-1                          ; $0089FA | 1D1
+  dw ambient_lemon_drop_splatter-1          ; $0089FC | 1D2
+  dw ambient_bowser_aiming_reticle-1        ; $0089FE | 1D3
+  dw ambient_smoke_puff_1-1                 ; $008A00 | 1D4
+  dw ambient_bill_blaster_explosion-1       ; $008A02 | 1D5
+  dw ambient_lava_flames-1                  ; $008A04 | 1D6
+  dw CODE_009519-1                          ; $008A06 | 1D7 - bandit sweat drops
+  dw ambient_smoke_puff_ground-1            ; $008A08 | 1D8
+  dw CODE_0091A0-1                          ; $008A0A | 1D9 - ?
+  dw CODE_0091C7-1                          ; $008A0C | 1DA - ?
+  dw CODE_00921A-1                          ; $008A0E | 1DB - ?
+  dw ambient_ground_pound_smash_ani-1       ; $008A10 | 1DC
+  dw ambient_sparkles_2-1                   ; $008A12 | 1DD
+  dw CODE_0092EE-1                          ; $008A14 | 1DE - ?
+  dw ambient_smoke_puff_2-1                 ; $008A16 | 1DF
+  dw ambient_smoke_puff_lick-1              ; $008A18 | 1E0
+  dw ambient_baby_mario_bubble_burst-1      ; $008A1A | 1E1
+  dw ambient_aiming_reticle-1               ; $008A1C | 1E2
+  dw CODE_009519-1                          ; $008A1E | 1E3 - ?
+  dw CODE_009548-1                          ; $008A20 | 1E4 - Coin sparkle
+  dw CODE_00955F-1                          ; $008A22 | 1E5 - ?
+  dw ambient_large_smoke_puff-1             ; $008A24 | 1E6
+  dw CODE_0092A5-1                          ; $008A26 | 1E7 - checkered block activation splash effect
+  dw CODE_00955F-1                          ; $008A28 | 1E8 - Eggo-Dill (sprite $0EE) explosion splash
+  dw CODE_009519-1                          ; $008A2A | 1E9 - slugger hitting egg splash effect
+  dw CODE_009519-1                          ; $008A2C | 1EA - spear guy (sprites $0FB, $0FC) shield
+  dw CODE_009519-1                          ; $008A2E | 1EB - spear guy (sprites $0FB, $0FC) spear
+  dw CODE_009519-1                          ; $008A30 | 1EC - sparkle from bomb (sprite $060) falling
+  dw CODE_009548-1                          ; $008A32 | 1ED - Bomb (sprite $060) explosion
+  dw ambient_explosion_splash-1             ; $008A34 | 1EE
+  dw CODE_009531-1                          ; $008A36 | 1EF - Baron Von Zeppelin explosion
+  dw ambient_ice_watermelon_sparkle-1       ; $008A38 | 1F0
+  dw CODE_009531-1                          ; $008A3A | 1F1 - ?
+  dw ambient_ice_shards-1                   ; $008A3C | 1F2
+  dw ambient_crate_smash_planks-1           ; $008A3E | 1F3
+  dw CODE_009531-1                          ; $008A40 | 1F4 - flan (sprite $111) droplents
+  dw ambient_smoke_puff_3-1                 ; $008A42 | 1F5 - smoke from Snifit (sprite $113) breathing before shooting
+  dw ambient_smoke_puff_3-1                 ; $008A44 | 1F6 - puff from Snifit shooting
+  dw CODE_009519-1                          ; $008A46 | 1F7 - stilt guy's (sprite $0F2) stilt after jumping on it
+  dw ambient_lakitu_cloud_puff-1            ; $008A48 | 1F8
+  dw ambient_smoke_puff_3-1                 ; $008A4A | 1F9 - Puff from sprite $11A grabbing egg
+  dw ambient_lava_drop_fire-1               ; $008A4C | 1FA - from horiz lava drop (sprite $12F)
+  dw ambient_lava_drop_fire-1               ; $008A4E | 1FB - from vert lava drop (sprite $130)
+  dw CODE_009519-1                          ; $008A50 | 1FC - Fang (sprites $13D, $13E) path
+  dw CODE_009548-1                          ; $008A52 | 1FD - ?
+  dw CODE_009416-1                          ; $008A54 | 1FE - ?
+  dw CODE_009ADD-1                          ; $008A56 | 1FF - ?
+  dw ambient_arrow_cloud_arrow-1            ; $008A58 | 200
+  dw CODE_009531-1                          ; $008A5A | 201 - water splash (passing through current on ground/wall)
+  dw CODE_009519-1                          ; $008A5C | 202 - ?
+  dw CODE_009531-1                          ; $008A5E | 203 - ?
+  dw CODE_009531-1                          ; $008A60 | 204 - splash when hit by Spray fish's (sprite $143) water jet
+  dw CODE_00955F-1                          ; $008A62 | 205 - droplets when hit by Spray fish's jet
+  dw CODE_009B55-1                          ; $008A64 | 206 - bubbles at end of spray fish water jet
+  dw CODE_009519-1                          ; $008A66 | 207 - ?
+  dw ambient_bopping_ani-1                  ; $008A68 | 208
+  dw ambient_blowhard_stun_stars-1          ; $008A6A | 209
+  dw ambient_colored_block_break_puff-1     ; $008A6C | 20A
+  dw CODE_009C1D-1                          ; $008A6E | 20B - ?
+  dw ambient_break_stone_block_smoke_puff-1 ; $008A70 | 20C
+  dw CODE_009519-1                          ; $008A72 | 20D - Thunder Lakitu fireball growing
+  dw CODE_009519-1                          ; $008A74 | 20E - Thunder Lakitu fireball smoke puffs
+  dw ambient_lakitu_fireball_gen_flames-1   ; $008A76 | 20F
+  dw ambient_feather_like-1                 ; $008A78 | 210 - Crazee Dayzee petals
+  dw ambient_feather_like-1                 ; $008A7A | 211 - Para-koopa feathers
+  dw ambient_crazee_daisy_music_note-1      ; $008A7C | 212
+  dw ambient_ice_melting_ani-1              ; $008A7E | 213
+  dw ambient_snow_falling-1                 ; $008A80 | 214
+  dw CODE_009ADD-1                          ; $008A82 | 215
+  dw ambient_enemy_bopped_bones-1           ; $008A84 | 216 - Skeleton Goonie wings when jumped on
+  dw ambient_salvo_slime_drops-1            ; $008A86 | 217
+  dw ambient_baby_bowser_egg_explosion-1    ; $008A88 | 218
+  dw ambient_enemy_bopped_bones-1           ; $008A8A | 219 - Baby Mouser skull when jumped on
+  dw ambient_cork_smoke_puff-1              ; $008A8C | 21A
+  dw CODE_009B55-1                          ; $008A8E | 21B - Hot lips lava
+  dw CODE_00A759-1                          ; $008A90 | 21C - ?
+  dw CODE_00A776-1                          ; $008A92 | 21D - ?
+  dw CODE_009519-1                          ; $008A94 | 21E - Lava splash when spit lava hits Yoshi
+  dw CODE_00A78D-1                          ; $008A96 | 21F - ?
+  dw ambient_kamek_magic_sparkle-1          ; $008A98 | 220
+  dw ambient_froggy_stomach_acid_puff-1     ; $008A9A | 221
+  dw CODE_009531-1                          ; $008A9C | 222 - ?
+  dw CODE_009519-1                          ; $008A9E | 223 - Hookbill shell shards
+  dw ambient_red_switch_arrow-1             ; $008AA0 | 224
+  dw CODE_009519-1                          ; $008AA2 | 225
+  dw ambient_coin_get-1                     ; $008AA4 | 226
+  dw CODE_00921A-1                          ; $008AA6 | 227 - kamek 'anger' droplets (during baby bowser scene)
+  dw CODE_009519-1                          ; $008AA8 | 228 - ?
+  dw CODE_009519-1                          ; $008AAA | 229 - melon seed after hitting blocks
+  dw ambient_minigame_coin_cannon_puff-1    ; $008AAC | 22A
+  dw ambient_minigame_win_star_rising-1     ; $008AAE | 22B - spawns 22D
+  dw ambient_minigame_balloon_bop_loader-1  ; $008AB0 | 22C
+  dw ambient_minigame_win_full_star-1       ; $008AB2 | 22D
+  dw ambient_minigame_balloon_bop_effect-1  ; $008AB4 | 22E
 
 handle_ambient_sprites:
   PHB                                       ; $008AB6 |
@@ -1358,7 +1445,7 @@ execute_ambient_sprite_routine:
   ASL A                                     ; $008ADA |
   REP #$10                                  ; $008ADB |
   TAY                                       ; $008ADD |
-  LDA ambient_sprite_main_routines-$374,y   ; $008ADE |
+  LDA ambient_sprite_routines-($1BA*2),y    ; $008ADE |
   SEP #$10                                  ; $008AE1 |
   PHA                                       ; $008AE3 |
   RTS                                       ; $008AE4 |
@@ -1594,14 +1681,19 @@ CODE_008C7C:
   STA $7142,x                               ; $008C87 |
   RTS                                       ; $008C8A |
 
+DATA_008C8B:
   dw $0007, $0008, $0009, $000A             ; $008C8B |
   dw $0009, $0008, $0007, $0006             ; $008C93 |
   dw $0005, $0004, $0003, $0002             ; $008C9B |
-  dw $0001, $0003, $0004, $0005             ; $008CA3 |
-  dw $0004, $0003, $0003, $0003             ; $008CAB |
-  dw $0003, $0003, $0003, $0003             ; $008CB3 |
-  dw $0003, $0003                           ; $008CBB |
+  dw $0001                                  ; $008CA3 |
 
+DATA_008CA5:
+  dw $0003, $0004, $0005, $0004             ; $008CA5 |
+  dw $0003, $0003, $0003, $0003             ; $008CAD |
+  dw $0003, $0003, $0003, $0003             ; $008CB5 |
+  dw $0003                                  ; $008CBD |
+
+ambient_water_splash_transition:
   JSR CODE_008AE5                           ; $008CBF |
   LDA $7782,x                               ; $008CC2 |
   BNE CODE_008CDF                           ; $008CC5 |
@@ -1614,35 +1706,39 @@ CODE_008C7C:
 CODE_008CCF:
   STA $7E4C,x                               ; $008CCF |
   TAY                                       ; $008CD2 |
-  LDA $8C8B,y                               ; $008CD3 |
+  LDA DATA_008C8B,y                         ; $008CD3 |
   STA $73C2,x                               ; $008CD6 |
-  LDA $8CA5,y                               ; $008CD9 |
+  LDA DATA_008CA5,y                         ; $008CD9 |
   STA $7782,x                               ; $008CDC |
 
 CODE_008CDF:
   RTS                                       ; $008CDF |
 
+DATA_008CE0:
   dw $0000, $0002, $0001, $0001             ; $008CE0 |
   dw $0000, $0000, $0001, $0000             ; $008CE8 |
   dw $0000, $0000, $0000, $FFFF             ; $008CF0 |
   dw $0000, $0000, $FFFF, $FFFF             ; $008CF8 |
   dw $FFFE, $0000                           ; $008D00 |
 
+ambient_water_splash_swimming:
   JSR CODE_008AE5                           ; $008D04 |
-  LDA $7782,x                               ; $008D07 |
+  LDA $7782,x                               ; $008D07 | won't be 0 here, previous routine aborts by pulling return value if it is
   ASL A                                     ; $008D0A |
   TAY                                       ; $008D0B |
-  LDA $8CDE,y                               ; $008D0C |
+  LDA DATA_008CE0-2,y                       ; $008D0C |
   CLC                                       ; $008D0F |
   ADC $7142,x                               ; $008D10 |
   STA $7142,x                               ; $008D13 |
   RTS                                       ; $008D16 |
 
+DATA_008D17:
   dw $0001, $0000, $0000, $0000             ; $008D17 |
   dw $0000, $0000, $FFFF, $0000             ; $008D1F |
   dw $FFFF, $0000, $0000, $0000             ; $008D27 |
   dw $0000, $0000, $0001, $0000             ; $008D2F |
 
+ambient_bubble_in_water:
   JSR CODE_008AE5                           ; $008D37 |
   LDA $7822,x                               ; $008D3A |
   AND #$00FF                                ; $008D3D |
@@ -1668,10 +1764,11 @@ CODE_008D65:
   TAY                                       ; $008D69 |
   LDA $70A2,x                               ; $008D6A |
   CLC                                       ; $008D6D |
-  ADC $8D17,y                               ; $008D6E |
+  ADC DATA_008D17,y                         ; $008D6E |
   STA $70A2,x                               ; $008D71 |
   RTS                                       ; $008D74 |
 
+ambient_eggshell:
   JSR CODE_008AE5                           ; $008D75 |
   LDA $7782,x                               ; $008D78 |
   BNE CODE_008D89                           ; $008D7B |
@@ -1683,12 +1780,17 @@ CODE_008D65:
 CODE_008D89:
   RTS                                       ; $008D89 |
 
+DATA_008D8A:
   db $40,$40,$FF,$00,$00                    ; $008D8A |
 
+ambient_small_bopping_ani:
   JSR CODE_008AE5                           ; $008D8F |
   INC $73C2,x                               ; $008D92 |
   RTS                                       ; $008D95 |
 
+; red coin when collected
+; objects to coins at goal
+ambient_coin_get:
   JSR CODE_008AEC                           ; $008D96 |
   LDA $14                                   ; $008D99 |
   LSR A                                     ; $008D9B |
@@ -1698,12 +1800,17 @@ CODE_008D89:
   STA $73C2,x                               ; $008DA1 |
   RTS                                       ; $008DA4 |
 
+; +1 star sprite, 1up sprite
+ambient_score_sprites:
   JSR CODE_008AEC                           ; $008DA5 |
   RTS                                       ; $008DA8 |
 
-  db $02, $01, $00, $FF, $00, $06, $06, $06 ; $008DA9 |
-  db $03                                    ; $008DB1 |
+DATA_008DA9:
+  db $02, $01, $00, $FF, $00                ; $008DA9 |
+DATA_008DAE:
+  db $06, $06, $06, $03                     ; $008DAE |
 
+ambient_salvo_slime_smoke_puff:
   JSR CODE_008AE5                           ; $008DB2 |
   SEP #$20                                  ; $008DB5 |
   LDY $7E4C,x                               ; $008DB7 |
@@ -1719,11 +1826,11 @@ CODE_008D89:
   STA $7000,x                               ; $008DCE |
 
 CODE_008DD1:
-  LDA $8DAE,y                               ; $008DD1 |
+  LDA DATA_008DAE,y                         ; $008DD1 |
   STA $7782,x                               ; $008DD4 |
 
 CODE_008DD7:
-  LDA $8DA9,y                               ; $008DD7 |
+  LDA DATA_008DA9,y                         ; $008DD7 |
   STA $73C2,x                               ; $008DDA |
   BMI CODE_008DE1                           ; $008DDD |
   LDA #$06                                  ; $008DDF |
@@ -1735,6 +1842,7 @@ CODE_008DE4:
   REP #$20                                  ; $008DE4 |
   RTS                                       ; $008DE6 |
 
+CODE_008DE7:
   JSR CODE_008AE5                           ; $008DE7 |
   SEP #$20                                  ; $008DEA |
   LDA $7782,x                               ; $008DEC |
@@ -1745,6 +1853,7 @@ CODE_008DE4:
   REP #$20                                  ; $008DF5 |
   RTS                                       ; $008DF7 |
 
+ambient_transform_smoke_puff:
   DEC $7782,x                               ; $008DF8 |
   LDA $7782,x                               ; $008DFB |
   BNE CODE_008E03                           ; $008DFE |
@@ -1763,6 +1872,7 @@ CODE_008E0B:
   REP #$20                                  ; $008E13 |
   RTS                                       ; $008E15 |
 
+ambient_terrain_destroy_smoke_puff:
   JSR CODE_008AE5                           ; $008E16 |
   LDY $73C2,x                               ; $008E19 |
   LDA $7782,x                               ; $008E1C |
@@ -1780,6 +1890,7 @@ CODE_008E2F:
 
   db $09, $07, $06, $03, $02, $01, $00      ; $008E30 |
 
+CODE_008E37:
   JSR CODE_008AE5                           ; $008E37 |
   SEP #$20                                  ; $008E3A |
   LDY $7E4C,x                               ; $008E3C |
@@ -1800,6 +1911,7 @@ CODE_008E55:
 
   db $06, $06, $06, $06, $04, $03           ; $008E58 |
 
+ambient_train_enter_track_ani:
   JSR CODE_008AE5                           ; $008E5E |
   SEP #$20                                  ; $008E61 |
   LDY $73C2,x                               ; $008E63 |
@@ -1817,6 +1929,7 @@ CODE_008E77:
 
   db $06, $06, $05, $05                     ; $008E7A |
 
+ambient_train_transformation_smoke:
   JSR CODE_008AE5                           ; $008E7E |
   SEP #$20                                  ; $008E81 |
   LDY $73C2,x                               ; $008E83 |
@@ -1873,6 +1986,7 @@ CODE_008EB8:
   TYX                                       ; $008EED |
   RTS                                       ; $008EEE |
 
+ambient_floating_log_lava_drop:
   JSR CODE_008AE5                           ; $008EEF |
   LDA $71E2,x                               ; $008EF2 |
   BMI CODE_008EFD                           ; $008EF5 |
@@ -1882,6 +1996,7 @@ CODE_008EB8:
 CODE_008EFD:
   RTS                                       ; $008EFD |
 
+CODE_008EFE:
   JSR CODE_008AE5                           ; $008EFE |
   LDA $7782,x                               ; $008F01 |
   LSR A                                     ; $008F04 |
@@ -1890,6 +2005,7 @@ CODE_008EFD:
   STA $73C2,x                               ; $008F07 |
   RTS                                       ; $008F0A |
 
+CODE_008F0B:
   JSR CODE_008AE5                           ; $008F0B |
   LDA $7782,x                               ; $008F0E |
   CMP #$0008                                ; $008F11 |
@@ -1915,6 +2031,7 @@ CODE_008F2E:
   db $02, $02, $02, $01, $01, $01, $03, $03 ; $008F2F |
   db $03, $02, $02, $02                     ; $008F37 |
 
+ambient_snow_puff:
   JSR CODE_008AE5                           ; $008F3B |
   LDA $7782,x                               ; $008F3E |
   BNE CODE_008F5B                           ; $008F41 |
@@ -1936,6 +2053,7 @@ CODE_008F5B:
   db $05, $04, $03, $01, $01, $02, $01, $03 ; $008F5C |
   db $03, $03, $03, $03, $04, $04           ; $008F64 |
 
+CODE_008F6A:
   JSR CODE_008AE5                           ; $008F6A |
   LDA $7782,x                               ; $008F6D |
   BNE CODE_008F8A                           ; $008F70 |
@@ -1955,6 +2073,7 @@ CODE_008F8A:
   db $08, $07, $06, $05, $04, $03, $02, $01 ; $008F8B |
   db $40, $02, $02, $02, $02, $02, $02, $02 ; $008F93 |
 
+ambient_dr_freezegood_bop:
   JSR CODE_008AE5                           ; $008F9B |
   LDA $7782,x                               ; $008F9E |
   BNE CODE_008FBB                           ; $008FA1 |
@@ -1975,6 +2094,10 @@ CODE_008FBB:
   db $03, $02, $01, $04, $04, $04, $04, $04 ; $008FC4 |
   db $04, $03, $03, $02, $02, $01           ; $008FCC |
 
+; generated by getting a flower,
+; hitting ? cloud, GOAL disappearing,
+; using key
+ambient_sparkles_1:
   LDY $7E4E,x                               ; $008FD2 |
   BEQ CODE_008FE4                           ; $008FD5 |
   LDA $0B8F                                 ; $008FD7 |
@@ -2072,6 +2195,7 @@ CODE_00907A:
   db $02, $01, $05, $05, $05, $04, $04, $04 ; $00908D |
   db $03, $03, $02, $02                     ; $009095 |
 
+ambient_bubble_pop:
   JSR CODE_008AE5                           ; $009099 |
   LDA $7782,x                               ; $00909C |
   BNE CODE_0090B9                           ; $00909F |
@@ -2088,11 +2212,14 @@ CODE_00907A:
 CODE_0090B9:
   RTS                                       ; $0090B9 |
 
+; related to salvo slime boss
+CODE_0090BA:
   JSR CODE_008AEC                           ; $0090BA |
   RTS                                       ; $0090BD |
 
   db $06, $04, $04, $03, $03                ; $0090BE |
 
+ambient_lemon_drop_splatter:
   JSR CODE_008AE5                           ; $0090C3 |
   LDA $7782,x                               ; $0090C6 |
   BNE CODE_0090DF                           ; $0090C9 |
@@ -2112,7 +2239,10 @@ CODE_0090DF:
   db $0B, $0A, $09, $08, $07, $06, $05, $04 ; $0090E0 |
   db $03, $02, $01, $06, $06, $06, $06, $06 ; $0090E8 |
   db $06, $06, $03, $03, $03, $03           ; $0090F0 |
-
+; generated by winged clouds,
+; sprites to coins at goal,
+; transformation bubble when reappearing
+ambient_smoke_puff_1:
   LDY $7E4E,x                               ; $0090F6 |
   BEQ CODE_009100                           ; $0090F9 |
   JSR CODE_008AF2                           ; $0090FB |
@@ -2140,6 +2270,7 @@ CODE_009120:
   db $06, $05, $04, $03, $02, $01, $04, $08 ; $009121 |
   db $08, $08, $04, $02                     ; $009129 |
 
+ambient_bill_blaster_explosion:
   JSR CODE_008AE5                           ; $00912D |
   LDA $7782,x                               ; $009130 |
   BNE CODE_00914D                           ; $009133 |
@@ -2158,6 +2289,7 @@ CODE_00914D:
 
   db $03, $02, $01, $06, $04, $02           ; $00914E |
 
+ambient_lava_flames:
   JSR CODE_008AE5                           ; $009154 |
   LDA $7782,x                               ; $009157 |
   BNE CODE_009174                           ; $00915A |
@@ -2176,6 +2308,9 @@ CODE_009174:
 
   db $03, $02, $01, $06, $04, $02           ; $009175 |
 
+; puff from ground (pushing crates/pots,
+; baby bowser sliding)
+ambient_smoke_puff_ground:
   JSR CODE_008AE5                           ; $00917B |
   LDA $7782,x                               ; $00917E |
   BNE CODE_00919B                           ; $009181 |
@@ -2194,6 +2329,7 @@ CODE_00919B:
 
   db $02, $01, $0C, $08                     ; $00919C |
 
+CODE_0091A0:
   JSR CODE_008AE5                           ; $0091A0 |
   LDA $7782,x                               ; $0091A3 |
   BNE CODE_0091C0                           ; $0091A6 |
@@ -2212,6 +2348,7 @@ CODE_0091C0:
 
   db $03, $02, $01, $08, $08, $04           ; $0091C1 |
 
+CODE_0091C7:
   JSR CODE_008C12                           ; $0091C7 |
   LDA $75A0,x                               ; $0091CA |
   CMP $71E0,x                               ; $0091CD |
@@ -2254,6 +2391,7 @@ CODE_009213:
 
   db $03, $02, $01, $08, $08, $08           ; $009214 |
 
+CODE_00921A:
   JSR CODE_008C12                           ; $00921A |
   JSR CODE_008AF2                           ; $00921D |
   LDA $7782,x                               ; $009220 |
@@ -2275,6 +2413,7 @@ CODE_00923D:
   db $03, $02, $01, $01, $01, $01, $01, $01 ; $009246 |
   db $01, $01, $01, $01, $01, $02           ; $00924E |
 
+ambient_ground_pound_smash_ani:
   JSR CODE_008AE5                           ; $009254 |
   LDA $7782,x                               ; $009257 |
   BNE CODE_009274                           ; $00925A |
@@ -2293,6 +2432,13 @@ CODE_009274:
 
   db $04, $03, $02, $01, $06, $06, $06, $06 ; $009275 |
 
+
+; handles a lot of 'sparkles':
+; ground pound in air, baby mario flying
+; at goal, kamek magic, boss explosion,
+; transformation bubbles, minigame items,
+; stars
+ambient_sparkles_2:
   JSR CODE_008AE5                           ; $00927D |
   LDA $7782,x                               ; $009280 |
   BNE CODE_00929D                           ; $009283 |
@@ -2309,10 +2455,15 @@ CODE_009274:
 CODE_00929D:
   RTS                                       ; $00929D |
 
-  db $03, $03, $03, $03, $03, $03, $03, $AD ; $00929E |
-  db $8F, $0B, $F0, $03                     ; $0092A6 |
+DATA_00929E:
+  db $03, $03, $03, $03, $03, $03, $03      ; $00929E |
 
+CODE_0092A5:
+  LDA $0B8F                                 ; $0092A5 |
+  BEQ ambient_large_smoke_puff              ; $0092A8 |
   JSR CODE_008C12                           ; $0092AA |
+
+ambient_large_smoke_puff:
   JSR CODE_008AF2                           ; $0092AD |
   LDA $7782,x                               ; $0092B0 |
   BNE CODE_0092CB                           ; $0092B3 |
@@ -2322,7 +2473,7 @@ CODE_00929D:
   LDY $7E4C,x                               ; $0092BC |
   TYA                                       ; $0092BF |
   STA $73C2,x                               ; $0092C0 |
-  LDA $929E,y                               ; $0092C3 |
+  LDA DATA_00929E,y                         ; $0092C3 |
   STA $7782,x                               ; $0092C6 |
   REP #$20                                  ; $0092C9 |
 
@@ -2335,6 +2486,7 @@ CODE_0092CB:
   db $FE, $FF, $04, $00, $FE, $FF, $FC, $FF ; $0092E4 |
   db $FB, $FF                               ; $0092EC |
 
+CODE_0092EE:
   LDY $7E4E,x                               ; $0092EE |
   LDA !s_spr_facing_dir,y                   ; $0092F1 |
   STA $00                                   ; $0092F4 |
@@ -2411,7 +2563,9 @@ CODE_009370:
   RTS                                       ; $009370 |
 
   db $03, $02, $01, $00, $04                ; $009371 |
-
+; thrown egg, egg-spitting flower
+; lava death, burt flying away
+ambient_smoke_puff_2:
   LDY $7E4E,x                               ; $009376 |
   BEQ CODE_009380                           ; $009379 |
   JSR CODE_008AF2                           ; $00937B |
@@ -2438,6 +2592,9 @@ CODE_00939F:
 
   db $04, $03, $02, $01                     ; $0093A0 |
 
+; smoke puff generated when licking
+; something Yoshi can't eat
+ambient_smoke_puff_lick:
   JSR CODE_008AE5                           ; $0093A4 |
   LDA $7782,x                               ; $0093A7 |
   BNE CODE_0093C3                           ; $0093AA |
@@ -2459,6 +2616,7 @@ CODE_0093C3:
   db $03, $03, $02, $02, $02, $01, $03, $01 ; $0093D4 |
   db $01, $01                               ; $0093DC |
 
+ambient_baby_mario_bubble_burst:
   JSR CODE_008AF2                           ; $0093DE |
   LDA $7782,x                               ; $0093E1 |
   BNE CODE_00940F                           ; $0093E4 |
@@ -2488,6 +2646,7 @@ CODE_00940F:
 
   db $02, $04, $06, $0A, $06, $04           ; $009410 |
 
+CODE_009416:
   JSR CODE_008AE5                           ; $009416 |
   LDA $7782,x                               ; $009419 |
   BNE CODE_009432                           ; $00941C |
@@ -2504,6 +2663,7 @@ CODE_009426:
 CODE_009432:
   RTS                                       ; $009432 |
 
+ambient_aiming_reticle:
   LDA $7322,x                               ; $009433 |
   BPL CODE_009446                           ; $009436 |
   LDA $61CE                                 ; $009438 |
@@ -2620,9 +2780,11 @@ CODE_009515:
   STA $7E4C,x                               ; $009515 |
   RTS                                       ; $009518 |
 
+CODE_009519:
   JSR CODE_008AEC                           ; $009519 |
   RTS                                       ; $00951C |
 
+ambient_lakitu_fireball_gen_flames:
   JSR CODE_008AE5                           ; $00951D |
   LDA $7782,x                               ; $009520 |
   BNE CODE_00952D                           ; $009523 |
@@ -2636,7 +2798,7 @@ CODE_00952D:
 CODE_00952E:
   JMP CODE_008AF8                           ; $00952E |
 
-; an ambient sprite main routine
+CODE_009531:
   JSR CODE_008AE5                           ; $009531 |
   LDA $7782,x                               ; $009534 |
   BNE CODE_009544                           ; $009537 |
@@ -2651,7 +2813,7 @@ CODE_009544:
 CODE_009545:
   JMP CODE_008AF8                           ; $009545 |
 
-; an ambient sprite main routine
+CODE_009548:
   JSR CODE_008AE5                           ; $009548 |
   LDA $7782,x                               ; $00954B |
   BNE CODE_00955B                           ; $00954E |
@@ -2666,6 +2828,7 @@ CODE_00955B:
 CODE_00955C:
   JMP CODE_008AF8                           ; $00955C |
 
+CODE_00955F:
   JSR CODE_008AE5                           ; $00955F |
   LDA $7782,x                               ; $009562 |
   BNE CODE_009572                           ; $009565 |
@@ -2680,6 +2843,7 @@ CODE_009572:
 CODE_009573:
   JMP CODE_008AF8                           ; $009573 |
 
+ambient_lava_drop_fire:
   JSR CODE_008AE5                           ; $009576 |
   LDA $7782,x                               ; $009579 |
   BNE CODE_009589                           ; $00957C |
@@ -2694,6 +2858,7 @@ CODE_009589:
 CODE_00958A:
   JMP CODE_008AF8                           ; $00958A |
 
+ambient_lakitu_cloud_puff:
   JSR CODE_008AE5                           ; $00958D |
   LDA $7782,x                               ; $009590 |
   BNE CODE_0095A0                           ; $009593 |
@@ -2716,6 +2881,7 @@ CODE_0095A1:
   db $00, $00, $00, $00, $00, $00, $00, $00 ; $0095C0 |
   db $00, $80, $00, $80                     ; $0095C8 |
 
+ambient_crate_smash_planks:
   LDA $7322,x                               ; $0095CC |
   BMI CODE_0095F3                           ; $0095CF |
   LDY $7E4E,x                               ; $0095D1 |
@@ -2752,6 +2918,7 @@ CODE_009613:
 
   db $04, $03, $02, $01, $00, $00, $00      ; $009614 |
 
+ambient_ice_watermelon_sparkle:
   JSR CODE_008AE5                           ; $00961B |
   LDA $7782,x                               ; $00961E |
   BNE CODE_00963A                           ; $009621 |
@@ -2771,6 +2938,7 @@ CODE_00963A:
   db $04, $04, $04, $04, $04, $04, $04, $03 ; $00963B |
   db $03, $02, $02                          ; $009643 |
 
+ambient_ice_shards:
   PHX                                       ; $009646 |
   TXA                                       ; $009647 |
   AND #$00FF                                ; $009648 |
@@ -2883,6 +3051,7 @@ CODE_009687:
 
   db $08, $30, $44, $06, $00                ; $009868 |
 
+ambient_smoke_puff_3:
   JSR CODE_008AE5                           ; $00986D |
   LDA $7782,x                               ; $009870 |
   BNE CODE_009883                           ; $009873 |
@@ -2901,6 +3070,7 @@ CODE_009883:
   dw $0004, $0005, $0006, $0000             ; $00989C |
   dw $0001, $0002, $0001, $0003             ; $0098A4 |
 
+ambient_minigame_coin_cannon_puff:
   PHX                                       ; $0098AC |
   LDA $78C0,x                               ; $0098AD |
   STA !gsu_r1                               ; $0098B0 |  r1
@@ -2945,6 +3115,7 @@ CODE_00990F:
   STA $7782,x                               ; $00990F |
   RTS                                       ; $009912 |
 
+ambient_minigame_win_star_rising:
   JSR CODE_008AE5                           ; $009913 |
   LDA #$0001                                ; $009916 |
   STA $7782,x                               ; $009919 |
@@ -2997,6 +3168,7 @@ CODE_00995F:
   dw $0008, $0009, $000A, $000B             ; $00998A |
   dw $000C, $000E, $000D                    ; $009992 |
 
+ambient_minigame_balloon_bop_loader:
   JSR CODE_008AE5                           ; $009998 |
   LDA #$0002                                ; $00999B |
   STA $7782,x                               ; $00999E |
@@ -3052,6 +3224,7 @@ CODE_009A07:
   db $02, $03, $03, $03, $03, $20, $03, $03 ; $009A10 |
   db $03                                    ; $009A18 |
 
+ambient_minigame_win_full_star:
   JSR CODE_008AE5                           ; $009A19 |
   LDA #$0002                                ; $009A1C |
   STA $7782,x                               ; $009A1F |
@@ -3089,6 +3262,7 @@ CODE_009A61:
   STX $7E4A                                 ; $009A62 |
   RTS                                       ; $009A65 |
 
+ambient_minigame_balloon_bop_effect:
   JSR CODE_008AE5                           ; $009A66 |
   LDA #$0002                                ; $009A69 |
   STA $7782,x                               ; $009A6C |
@@ -3138,12 +3312,15 @@ CODE_009ABF:
   RTL                                       ; $009AD8 |
 
 DATA_009AD9:
-  db $40, $00, $C0, $FF, $20, $F2, $8A, $BD ; $009AD9 |
-  db $8E, $7E, $D0, $03                     ; $009AE1 |
+  db $40, $00, $C0, $FF                     ; $009AD9 |
 
-; dead code?
+CODE_009ADD:
+  JSR CODE_008AF2                           ; $009ADD |
+  LDA $7E8E,x                               ; $009AE0 |
+  BNE CODE_009AE8                           ; $009AE3 |
   JMP CODE_008AF8                           ; $009AE5 |
-; dead code?
+
+CODE_009AE8:
   CMP #$0040                                ; $009AE8 |
   BPL CODE_009AFA                           ; $009AEB |
   LDY #$FF                                  ; $009AED |
@@ -3168,8 +3345,8 @@ CODE_009AFA:
 
 CODE_009B12:
   RTS                                       ; $009B12 |
-; end dead code
 
+ambient_arrow_cloud_arrow:
   JSR CODE_008AE5                           ; $009B13 |
   LDY $7462,x                               ; $009B16 |
   CPY #$FF                                  ; $009B19 |
@@ -3204,21 +3381,30 @@ CODE_009B4F:
 CODE_009B52:
   RTS                                       ; $009B52 |
 
-  db $0C, $10, $20, $E5, $8A, $BD, $82, $77 ; $009B53 |
-  db $D0, $14, $DE, $C2, $73, $10, $03      ; $009B5B |
+DATA_009B53:
+  db $0C, $10                               ; $009B53 |
 
+CODE_009B55:
+  JSR CODE_008AE5                           ; $009B55 |
+  LDA $7782,x                               ; $009B58 |
+  BNE Return_009B71                         ; $009B5B |
+  DEC $73C2,x                               ; $009B5D |
+  BPL CODE_009B65                           ; $009B60 |
   JMP CODE_008AF8                           ; $009B62 |
 
+CODE_009B65:
   LDY $73C2,x                               ; $009B65 |
-  LDA $9B53,y                               ; $009B68 |
+  LDA DATA_009B53,y                         ; $009B68 |
   AND #$00FF                                ; $009B6B |
   STA $7782,x                               ; $009B6E |
+Return_009B71:
   RTS                                       ; $009B71 |
 
   db $03, $03, $03, $03, $03, $03, $03, $03 ; $009B72 |
   db $03, $02, $02, $02, $02, $02, $02, $02 ; $009B7A |
   db $02, $02, $02, $02, $02, $02           ; $009B82 |
 
+ambient_bopping_ani:
   JSR CODE_008AE5                           ; $009B88 |
   SEP #$20                                  ; $009B8B |
   LDA $7782,x                               ; $009B8D |
@@ -3250,6 +3436,7 @@ CODE_009BB6:
   REP #$20                                  ; $009BB9 |
   RTS                                       ; $009BBB |
 
+ambient_blowhard_stun_stars:
   JSR CODE_008AE5                           ; $009BBC |
   LDA $7782,x                               ; $009BBF |
   BNE CODE_009BC7                           ; $009BC2 |
@@ -3270,6 +3457,7 @@ CODE_009BDD:
 
   db $08, $06, $04, $02, $02                ; $009BDE |
 
+ambient_colored_block_break_puff:
   JSR CODE_008AE5                           ; $009BE3 |
   LDA $7782,x                               ; $009BE6 |
   BNE CODE_009C10                           ; $009BE9 |
@@ -3298,6 +3486,7 @@ CODE_009C10:
   db $03, $03, $03, $03, $03, $03           ; $009C11 |
   db $03, $02, $02, $02, $02, $02           ; $009C17 |
 
+CODE_009C1D:
   PHX                                       ; $009C1D |
   TXA                                       ; $009C1E |
   AND #$00FF                                ; $009C1F |
@@ -3423,6 +3612,7 @@ CODE_009C5E:
   db $03, $20, $44, $06, $00, $05, $25, $4F ; $009E88 |
   db $44, $00                               ; $009E90 |
 
+ambient_break_stone_block_smoke_puff:
   PHX                                       ; $009E92 |
   TXA                                       ; $009E93 |
   AND #$00FF                                ; $009E94 |
@@ -3568,6 +3758,7 @@ CODE_009ED2:
   db $04, $04, $04, $04, $04, $04, $04, $03 ; $00A184 |
   db $03, $03, $02, $02, $01, $01, $01      ; $00A18C |
 
+ambient_feather_like:
   PHX                                       ; $00A193 |
   TXA                                       ; $00A194 |
   STA !gsu_r10                              ; $00A195 |  r10
@@ -3741,8 +3932,10 @@ CODE_00A1D1:
 
   db $F9, $27, $01, $40, $00                ; $00A548 |
 
+DATA_00A54D:
   dw $F800, $0800                           ; $00A54D |
 
+ambient_crazee_daisy_music_note:
   JSR CODE_008AE5                           ; $00A551 |
   LDY #$00                                  ; $00A554 |
   LDA $7142,x                               ; $00A556 |
@@ -3752,12 +3945,14 @@ CODE_00A1D1:
   INY                                       ; $00A55F |
 
 CODE_00A560:
-  LDA $A54D,y                               ; $00A560 |
+  LDA DATA_00A54D,y                         ; $00A560 |
   STA $75A2,x                               ; $00A563 |
   RTS                                       ; $00A566 |
 
+DATA_00A567:
   db $07, $07, $05, $04, $04, $04, $04, $04 ; $00A567 |
 
+ambient_ice_melting_ani:
   JSR CODE_008AE5                           ; $00A56F |
   LDA $7782,x                               ; $00A572 |
   BNE CODE_00A58B                           ; $00A575 |
@@ -3767,7 +3962,7 @@ CODE_00A560:
 
 CODE_00A57F:
   LDY $73C2,x                               ; $00A57F |
-  LDA $A567,y                               ; $00A582 |
+  LDA DATA_00A567,y                         ; $00A582 |
   AND #$00FF                                ; $00A585 |
   STA $7782,x                               ; $00A588 |
 
@@ -3777,6 +3972,7 @@ CODE_00A58B:
   db $06, $06, $06, $06, $06, $05, $05, $05 ; $00A58C |
   db $05, $05, $05, $04, $04, $04           ; $00A594 |
 
+ambient_snow_falling:
   PHX                                       ; $00A59A |
   TXA                                       ; $00A59B |
   AND #$00FF                                ; $00A59C |
@@ -3862,6 +4058,7 @@ CODE_00A5DB:
   db $04, $1F, $F7, $46, $00                ; $00A69F |
   db $04, $21, $E1, $06, $00                ; $00A6A4 |
 
+ambient_enemy_bopped_bones:
   JSR CODE_008AE5                           ; $00A6A9 |
   LDA $7782,x                               ; $00A6AC |
   BNE CODE_00A6B4                           ; $00A6AF |
@@ -3884,6 +4081,7 @@ CODE_00A6CB:
 CODE_00A6CD:
   RTS                                       ; $00A6CD |
 
+ambient_salvo_slime_drops:
   JSR CODE_008AE5                           ; $00A6CE |
   LDA $7820,x                               ; $00A6D1 |
   AND #$0001                                ; $00A6D4 |
@@ -3914,33 +4112,44 @@ CODE_00A6FA:
 CODE_00A701:
   RTS                                       ; $00A701 |
 
+DATA_00A702:
   db $0A, $09, $08, $07, $06, $05, $04, $03 ; $00A702 |
   db $02, $01, $00, $00                     ; $00A70A |
 
+DATA_00A70E:
   db $04, $04, $03, $03, $02, $02, $01, $01 ; $00A70E |
   db $01, $01, $01, $01                     ; $00A716 |
 
+DATA_00A71A:
   db $01, $01, $01, $01, $01, $01, $01, $01 ; $00A71A |
-  db $01, $01, $FF, $01, $20, $E5, $8A, $BD ; $00A722 |
-  db $82, $77, $D0, $21, $DE, $4C, $7E, $10 ; $00A72A |
-  db $03                                    ; $00A732 |
+  db $01, $01, $FF, $01                     ; $00A722 |
 
+ambient_cork_smoke_puff:
+  JSR CODE_008AE5                           ; $00A726 |
+  LDA $7782,x                               ; $00A729 |
+  BNE CODE_00A74F                           ; $00A72C |
+  DEC $7E4C,x                               ; $00A72E |
+  BPL CODE_00A736                           ; $00A731 |
   JMP CODE_008AF8                           ; $00A733 |
 
+CODE_00A736:
   SEP #$20                                  ; $00A736 |
   LDY $7E4C,x                               ; $00A738 |
-  LDA $A702,y                               ; $00A73B |
+  LDA DATA_00A702,y                         ; $00A73B |
   STA $73C2,x                               ; $00A73E |
-  LDA $A70E,y                               ; $00A741 |
+  LDA DATA_00A70E,y                         ; $00A741 |
   STA $7782,x                               ; $00A744 |
-  LDA $A71A,y                               ; $00A747 |
+  LDA DATA_00A71A,y                         ; $00A747 |
   STA $7462,x                               ; $00A74A |
   REP #$20                                  ; $00A74D |
+CODE_00A74F:
   RTS                                       ; $00A74F |
 
+DATA_00A750:
   db $03, $03, $03, $03, $03, $03, $03, $02 ; $00A750 |
   db $02                                    ; $00A758 |
 
+CODE_00A759:
   JSR CODE_008AE5                           ; $00A759 |
   LDA $7782,x                               ; $00A75C |
   BNE CODE_00A775                           ; $00A75F |
@@ -3950,13 +4159,14 @@ CODE_00A701:
 
 CODE_00A769:
   LDY $73C2,x                               ; $00A769 |
-  LDA $A750,y                               ; $00A76C |
+  LDA DATA_00A750,y                         ; $00A76C |
   AND #$00FF                                ; $00A76F |
   STA $7782,x                               ; $00A772 |
 
 CODE_00A775:
   RTS                                       ; $00A775 |
 
+CODE_00A776:
   JSR CODE_008AE5                           ; $00A776 |
   LDA $7782,x                               ; $00A779 |
   BNE CODE_00A78C                           ; $00A77C |
@@ -3971,6 +4181,7 @@ CODE_00A786:
 CODE_00A78C:
   RTS                                       ; $00A78C |
 
+CODE_00A78D:
   JSR CODE_008AE5                           ; $00A78D |
   LDA $7782,x                               ; $00A790 |
   BNE CODE_00A7A3                           ; $00A793 |
@@ -3985,6 +4196,7 @@ CODE_00A79D:
 CODE_00A7A3:
   RTS                                       ; $00A7A3 |
 
+ambient_kamek_magic_sparkle:
   JSR CODE_008AE5                           ; $00A7A4 |
   LDA $7782,x                               ; $00A7A7 |
   BNE CODE_00A7D0                           ; $00A7AA |
@@ -4006,9 +4218,13 @@ CODE_00A7A3:
 CODE_00A7D0:
   RTS                                       ; $00A7D0 |
 
+DATA_00A7D1:
   db $03, $03, $02, $02, $02, $01, $01, $01 ; $00A7D1 |
   db $02                                    ; $00A7D9 |
 
+; splash effect from milde (sprite $0108)
+; or 1up balloon (sprite $08B) explosion
+ambient_explosion_splash:
   JSR CODE_008AE5                           ; $00A7DA |
   LDA $7782,x                               ; $00A7DD |
   BNE CODE_00A7F6                           ; $00A7E0 |
@@ -4018,13 +4234,14 @@ CODE_00A7D0:
 
 CODE_00A7EA:
   LDY $73C2,x                               ; $00A7EA |
-  LDA $A7D1,y                               ; $00A7ED |
+  LDA DATA_00A7D1,y                         ; $00A7ED |
   AND #$00FF                                ; $00A7F0 |
   STA $7782,x                               ; $00A7F3 |
 
 CODE_00A7F6:
   RTS                                       ; $00A7F6 |
 
+ambient_froggy_stomach_acid_puff:
   JSR CODE_008AE5                           ; $00A7F7 |
   LDA $7782,x                               ; $00A7FA |
   BNE CODE_00A80D                           ; $00A7FD |
@@ -4039,6 +4256,7 @@ CODE_00A807:
 CODE_00A80D:
   RTS                                       ; $00A80D |
 
+ambient_red_switch_arrow:
   JSR CODE_008AF2                           ; $00A80E |
   RTS                                       ; $00A811 |
 
@@ -4050,6 +4268,7 @@ CODE_00A80D:
   db $02, $02, $02, $02, $02, $02, $02, $02 ; $00A82C |
   db $02                                    ; $00A834 |
 
+ambient_baby_bowser_egg_explosion:
   LDY $7E4C,x                               ; $00A835 |
   LDA $A811,y                               ; $00A838 |
   BMI CODE_00A890                           ; $00A83B |
@@ -4367,6 +4586,7 @@ CODE_00A8AD:
   db $08, $FB, $E0, $02, $00                ; $00AD00 |
   db $03, $03, $7B, $07, $00                ; $00AD05 |
 
+ambient_bowser_aiming_reticle:
   LDA $7322,x                               ; $00AD0A |
   BMI CODE_00AD61                           ; $00AD0D |
   REP #$10                                  ; $00AD0F |

--- a/disassembly/bank01.asm
+++ b/disassembly/bank01.asm
@@ -7745,7 +7745,7 @@ main_gamemode_0F:
 .sprite_processing
   JSL spr_edge_despawn_draw_check_warp      ; $01C202 | screen edge, despawn & draw sprites
   JSL draw_player                           ; $01C206 | yoshi drawing (OAM placing)
-  JSL $04DD9E                               ; $01C20A |
+  JSL main_player                           ; $01C20A |
   JSL $0397DF                               ; $01C20E |
   JSR CODE_01D6B1                           ; $01C212 |
   LDA !r_header_level_mode                  ; $01C215 |

--- a/disassembly/bank01.asm
+++ b/disassembly/bank01.asm
@@ -112,7 +112,7 @@ CODE_0180B9:
   LDX #$08                                  ; $0180E5 |
   LDA #$9208                                ; $0180E7 |
   JSL r_gsu_init_1                          ; $0180EA | GSU
-  JSL $00BE39                               ; $0180EE |
+  JSL CODE_00BE39                           ; $0180EE |
 
 ; DMA args
   dl $7E51E4, $7036BA                       ; $0180F2 |
@@ -256,7 +256,7 @@ hookbill_decompress_gfx:
   LDX #$0070                                ; $018226 |
   STX $0001                                 ; $018229 |
   LDX #$6800                                ; $01822C |
-  JSL $00BEA6                               ; $01822F |
+  JSL CODE_00BEA6                           ; $01822F |
   SEP #$10                                  ; $018233 |
 
 CODE_018235:
@@ -839,7 +839,7 @@ CODE_018A29:
   JSR CODE_018CC7                           ; $018A29 |
 
 CODE_018A2C:
-  JSL $03AF23                               ; $018A2C |
+  JSL CODE_03AF23                           ; $018A2C |
   TXY                                       ; $018A30 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $018A31 |
   ASL A                                     ; $018A33 |
@@ -3301,7 +3301,7 @@ CODE_019D6F:
   STA $0001                                 ; $019D7F |
   LDY $0C18                                 ; $019D82 |
   LDA $00                                   ; $019D85 |
-  JSL $00BF86                               ; $019D87 |
+  JSL CODE_00BF86                           ; $019D87 |
   LDA $00                                   ; $019D8B |
   CLC                                       ; $019D8D |
   ADC $0C18                                 ; $019D8E |
@@ -3357,7 +3357,7 @@ hookbill_begin_init2:
   STA $0C18                                 ; $019DF5 |
   LDA #$0800                                ; $019DF8 |
   LDX #$0000                                ; $019DFB |
-  JSL $00BF4A                               ; $019DFE |
+  JSL CODE_00BF4A                           ; $019DFE |
   SEP #$10                                  ; $019E02 |
   LDX $12                                   ; $019E04 |
   RTS                                       ; $019E06 |
@@ -3384,7 +3384,7 @@ CODE_019E1C:
   ADC #$0008                                ; $019E29 |
   STA $02                                   ; $019E2C |
   LDA #$0008                                ; $019E2E |
-  JSL $00BF16                               ; $019E31 |
+  JSL CODE_00BF16                           ; $019E31 |
   DEC $04                                   ; $019E35 |
   BNE CODE_019E1C                           ; $019E37 |
   SEP #$10                                  ; $019E39 |
@@ -3989,7 +3989,7 @@ boss_closer_ptr:
   db $04,$0A,$0A,$06                        ; $01A2D1 |
 
 main_boss_closer:
-  JSL $03AF23                               ; $01A2D5 |
+  JSL CODE_03AF23                           ; $01A2D5 |
   LDA !s_spr_timer_1,x                      ; $01A2D9 |
   BNE .run_state                            ; $01A2DC |
   STZ $617A                                 ; $01A2DE |
@@ -5061,11 +5061,11 @@ CODE_01AA8D:
 CODE_01AA9C:
   RTS                                       ; $01AA9C |
 
-; do nothing
+init_splashed_flan:
   RTL                                       ; $01AA9D |
 
 main_splashed_flan:
-  JSL $03AF23                               ; $01AA9E |
+  JSL CODE_03AF23                           ; $01AA9E |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $01AAA2 |
   BNE CODE_01AAA9                           ; $01AAA4 |
   INC !s_spr_wildcard_5_lo_dp,x             ; $01AAA6 |
@@ -5113,10 +5113,10 @@ main_hedgehog:
   LDA !s_spr_oam_1,x                        ; $01AAEC |
   LSR A                                     ; $01AAEF |
   BCC CODE_01AAF6                           ; $01AAF0 |
-  JSL $03AA52                               ; $01AAF2 |
+  JSL CODE_03AA52                           ; $01AAF2 |
 
 CODE_01AAF6:
-  JSL $03AF23                               ; $01AAF6 |
+  JSL CODE_03AF23                           ; $01AAF6 |
   TXY                                       ; $01AAFA |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $01AAFB |
   ASL A                                     ; $01AAFD |
@@ -5395,7 +5395,7 @@ main_gusty:
   STZ !s_spr_y_accel_ceiling,x              ; $01AD2D |
 
 CODE_01AD30:
-  JSL $03AF23                               ; $01AD30 |
+  JSL CODE_03AF23                           ; $01AD30 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $01AD34 |
   BEQ CODE_01AD3B                           ; $01AD36 |
   JMP CODE_01ADC2                           ; $01AD38 |
@@ -5510,6 +5510,7 @@ CODE_01ADF3:
 CODE_01AE17:
   RTL                                       ; $01AE17 |
 
+init_watermelon_seed:
   RTL                                       ; $01AE18 |
 
 main_seed:
@@ -5550,7 +5551,7 @@ CODE_01AE54:
   STA $03BC                                 ; $01AE6E |
 
 CODE_01AE71:
-  JSL $03AF23                               ; $01AE71 |
+  JSL CODE_03AF23                           ; $01AE71 |
   RTL                                       ; $01AE75 |
 
 init_pulley_guy:
@@ -5569,7 +5570,7 @@ init_pulley_guy:
   dw $AF10, $AF49                           ; $01AE91 |
 
 main_pulley_guy:
-  JSL $03AF23                               ; $01AE95 |
+  JSL CODE_03AF23                           ; $01AE95 |
   TXY                                       ; $01AE99 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $01AE9A |
   ASL A                                     ; $01AE9C |
@@ -5712,7 +5713,7 @@ levelmode_index:
 
 ; Main loading game mode
 ; $038C controls load type (Map stage or just new sublevel)
-gamemode0C:
+gm0c_level_fadein_and_name:
   JSL init_oam_and_bg3_tilemap              ; $01AF90 | Disable screen, clear OAM and init BG3 tilemap
   JSL prepare_in_level_states               ; $01AF94 | Clear out memory states
   JSL clear_all_sprites                     ; $01AF98 |
@@ -6025,7 +6026,7 @@ CODE_01B22F:
 
 CODE_01B243:
   JSL $01B25E                               ; $01B243 |
-  JML $1083E2                               ; $01B247 |
+  JML increment_gamemode                    ; $01B247 |
 
 ; table of music values to use for each level music setting
   db $01, $01, $01, $01                     ; $01B24B |
@@ -6344,11 +6345,11 @@ load_3d_sprite_graphic:
   RTS                                       ; $01B4E0 |
 
 
-gamemode0D:
+gm0d_level_fadein_post_pipe_or_door:
   LDA #$01                                  ; $01B4E1 |
   STA !s_player_disable_flag                ; $01B4E3 |
   STA !s_sprite_disable_flag                ; $01B4E6 |
-  JSL $01C0CE                               ; $01B4E9 |
+  JSL CODE_01C0CE                           ; $01B4E9 |
   REP #$20                                  ; $01B4ED |
   LDA $0B4A                                 ; $01B4EF |
   STA !gsu_r1                               ; $01B4F2 |
@@ -6381,10 +6382,10 @@ gamemode0D:
   STZ !s_player_disable_flag                ; $01B53B |
   STZ !s_sprite_disable_flag                ; $01B53E |
   INC !r_game_mode                          ; $01B541 |
-  JML $1083E2                               ; $01B544 |
+  JML increment_gamemode                    ; $01B544 |
 
 CODE_01B548:
-  JSL $00BE39                               ; $01B548 |
+  JSL CODE_00BE39                           ; $01B548 |
 
 ; DMA args
   dl $7E56D0, $703A02                       ; $01B54C |
@@ -6409,11 +6410,11 @@ CODE_01B548:
   PLB                                       ; $01B57E |
   RTL                                       ; $01B57F |
 
-gamemode10:
+gm10_victory_cutscene:
   LDX $0B57                                 ; $01B580 |
   CPX #$0D                                  ; $01B583 |
   BCS CODE_01B58E                           ; $01B585 |
-  JSL $01C0CE                               ; $01B587 |
+  JSL CODE_01C0CE                           ; $01B587 |
   LDX $0B57                                 ; $01B58B |
 
 CODE_01B58E:
@@ -6465,6 +6466,7 @@ CODE_01B5D1:
   TSB !r_reg_hdmaen_mirror                  ; $01B5E0 |
   RTS                                       ; $01B5E3 |
 
+CODE_01B5E4:
   REP #$20                                  ; $01B5E4 |
   PHB                                       ; $01B5E6 |
   LDX #$7E                                  ; $01B5E7 |
@@ -6528,6 +6530,7 @@ CODE_01B606:
   dw $4145, $0146, $8145, $0146             ; $01B6A9 |
   dw $0145, $8146, $0145, $0146             ; $01B6B1 |
 
+CODE_01B6B9:
   LDA #$18                                  ; $01B6B9 |
   STA $0127                                 ; $01B6BB |
   JMP CODE_01B5D1                           ; $01B6BE |
@@ -6538,13 +6541,14 @@ CODE_01B606:
 ; End marker
   dw $FFFF
 
+CODE_01B6C9:
   REP #$30                                  ; $01B6C9 |
   LDX #$000A                                ; $01B6CB |
   LDY #$0000                                ; $01B6CE |
   STZ $00                                   ; $01B6D1 |
 
 CODE_01B6D3:
-  LDA $B7D7,y                               ; $01B6D3 |
+  LDA DATA_01B7D7,y                         ; $01B6D3 |
   JSR CODE_01B785                           ; $01B6D6 |
   CPY #$0016                                ; $01B6D9 |
   BCC CODE_01B6D3                           ; $01B6DC |
@@ -6601,19 +6605,19 @@ CODE_01B728:
   LDY #$2800                                ; $01B74F |
   LDX #$D000                                ; $01B752 |
   LDA #$0800                                ; $01B755 |
-  JSL $00BEA6                               ; $01B758 |
+  JSL CODE_00BEA6                           ; $01B758 |
   LDA #$0052                                ; $01B75C |
   STA $01                                   ; $01B75F |
   LDY #$1000                                ; $01B761 |
   LDX #$1E00                                ; $01B764 |
   LDA #$0100                                ; $01B767 |
-  JSL $00BEA6                               ; $01B76A |
+  JSL CODE_00BEA6                           ; $01B76A |
   LDA #$0052                                ; $01B76E |
   STA $01                                   ; $01B771 |
   LDY #$1100                                ; $01B773 |
   LDX #$1EC0                                ; $01B776 |
   LDA #$0100                                ; $01B779 |
-  JSL $00BEA6                               ; $01B77C |
+  JSL CODE_00BEA6                           ; $01B77C |
   SEP #$30                                  ; $01B780 |
   JMP CODE_01B5D1                           ; $01B782 |
 
@@ -6666,6 +6670,7 @@ CODE_01B7CB:
   BCC CODE_01B7CB                           ; $01B7D4 |
   RTS                                       ; $01B7D6 |
 
+DATA_01B7D7:
   db $3A, $3C, $4E, $0E, $10, $0C, $0E, $4E ; $01B7D7 |
   db $24, $04, $1C, $22, $08, $36, $36, $36 ; $01B7DF |
   db $36, $54, $5C, $4E, $3A, $3C           ; $01B7E7 |
@@ -6726,6 +6731,7 @@ CODE_01B7CB:
   dw $01D4, $013D, $01D7, $011E             ; $01B94D |
   dw $011E, $017E, $0158                    ; $01B955 |
 
+CODE_01B95B:
   REP #$20                                  ; $01B95B |
   STZ $0392                                 ; $01B95D |
   STZ $0B5F                                 ; $01B960 |
@@ -6750,13 +6756,14 @@ CODE_01B7CB:
 ; End Marker
   dw $FFFF                                  ; $01B9B8 |
 
+CODE_01B9BA:
   REP #$30                                  ; $01B9BA |
   LDA #$007E                                ; $01B9BC |
   STA $01                                   ; $01B9BF |
   LDY #$34A0                                ; $01B9C1 |
   LDX #$5DA6                                ; $01B9C4 |
   LDA #$0480                                ; $01B9C7 |
-  JSL $00BEA6                               ; $01B9CA |
+  JSL CODE_00BEA6                           ; $01B9CA |
   LDX #$001C                                ; $01B9CE |
 
 CODE_01B9D1:
@@ -7123,7 +7130,7 @@ CODE_01BC89:
   LDY #$34A0                                ; $01BC9C |
   LDX #$5DA6                                ; $01BC9F |
   LDA #$0480                                ; $01BCA2 |
-  JSL $00BEA6                               ; $01BCA5 |
+  JSL CODE_00BEA6                           ; $01BCA5 |
   RTS                                       ; $01BCA9 |
 
 CODE_01BCAA:
@@ -7399,7 +7406,7 @@ CODE_01BEE4:
   LDA $BF23,x                               ; $01BF06 |
   TAX                                       ; $01BF09 |
   LDA #$0800                                ; $01BF0A |
-  JSL $00BEA6                               ; $01BF0D |
+  JSL CODE_00BEA6                           ; $01BF0D |
   SEP #$30                                  ; $01BF11 |
   LDA $0B5B                                 ; $01BF13 |
   INC A                                     ; $01BF16 |
@@ -7556,6 +7563,7 @@ large_shake_offsets:
 
   dw $01FF, $02FE, $2800                    ; $01C0C8 |
 
+CODE_01C0CE:
   PHB                                       ; $01C0CE |
   PHK                                       ; $01C0CF |
   PLB                                       ; $01C0D0 |
@@ -7564,7 +7572,7 @@ large_shake_offsets:
   STZ $38                                   ; $01C0D5 |
   STZ $37                                   ; $01C0D7 |
 
-gamemode0F:
+gm0f_run_level:
   LDA #$10                                  ; $01C0D9 |
   STA $0B83                                 ; $01C0DB |
   STZ $0B84                                 ; $01C0DE |
@@ -8085,7 +8093,7 @@ animation_palette_ptr:
   AND #$000E                                ; $01C4A2 |
   STA $0B73                                 ; $01C4A5 |
   BNE CODE_01C4BA                           ; $01C4A8 |
-  JSL $128875                               ; $01C4AA |
+  JSL CODE_128875                           ; $01C4AA |
   AND #$0003                                ; $01C4AE |
   TAX                                       ; $01C4B1 |
   LDA $C48F,x                               ; $01C4B2 |
@@ -8634,7 +8642,7 @@ CODE_01C8CB:
 CODE_01C8EA:
   DEC $0B77                                 ; $01C8EA |
   BPL CODE_01C900                           ; $01C8ED |
-  JSL $128875                               ; $01C8EF |
+  JSL CODE_128875                           ; $01C8EF |
   ADC !r_frame_counter_global_dp            ; $01C8F3 |
   AND #$0003                                ; $01C8F5 |
   ASL A                                     ; $01C8F8 |
@@ -9031,7 +9039,7 @@ CODE_01CC1F:
   STA $01                                   ; $01CC1F |
   LDY #$5400                                ; $01CC21 |
   LDA #$0400                                ; $01CC24 |
-  JSL $00BEA6                               ; $01CC27 |
+  JSL CODE_00BEA6                           ; $01CC27 |
 
 CODE_01CC2B:
   JSR CODE_01CE5D                           ; $01CC2B |
@@ -9045,7 +9053,7 @@ CODE_01CC2B:
   STX $01                                   ; $01CC3C |
   LDX #$6800                                ; $01CC3E |
   LDY #$2C00                                ; $01CC41 |
-  JSL $00BEA6                               ; $01CC44 |
+  JSL CODE_00BEA6                           ; $01CC44 |
 
 CODE_01CC48:
   JSR CODE_01CE5D                           ; $01CC48 |
@@ -9374,7 +9382,7 @@ CODE_01CE80:
   LDY #$2800                                ; $01CEF8 |
   LDX #$D000                                ; $01CEFB |
   LDA #$0800                                ; $01CEFE |
-  JSL $00BEA6                               ; $01CF01 |
+  JSL CODE_00BEA6                           ; $01CF01 |
   PLY                                       ; $01CF05 |
   RTS                                       ; $01CF06 |
 
@@ -9506,7 +9514,7 @@ CODE_01CFE6:
   LDY #$3400                                ; $01D00C |
   LDX #$AFDF                                ; $01D00F |
   LDA #$0700                                ; $01D012 |
-  JSL $00BEA6                               ; $01D015 |
+  JSL CODE_00BEA6                           ; $01D015 |
   SEP #$10                                  ; $01D019 |
   PLB                                       ; $01D01B |
   LDX #$09                                  ; $01D01C |
@@ -10429,7 +10437,7 @@ CODE_01D6E5:
   LDA !gsu_r1                               ; $01D6F6 |
   SEC                                       ; $01D6F9 |
   SBC #$385E                                ; $01D6FA |
-  JSL $00BE71                               ; $01D6FD |
+  JSL CODE_00BE71                           ; $01D6FD |
 
   dw $552C, $5E7E, $7038                    ; $01D701 |
 
@@ -10520,7 +10528,7 @@ CODE_01D795:
   LDA #$DC26                                ; $01D7B1 |
   JSL r_gsu_init_1                          ; $01D7B4 | GSU init
   LDA #$01A4                                ; $01D7B8 |
-  JSL $00BE71                               ; $01D7BB |
+  JSL CODE_00BE71                           ; $01D7BB |
 
   dw $5040, $727E, $7033                    ; $01D7BF |
 
@@ -10551,7 +10559,7 @@ CODE_01D7CD:
   LDA #$DD23                                ; $01D801 |
   JSL r_gsu_init_1                          ; $01D804 | GSU init
   LDA #$01A4                                ; $01D808 |
-  JSL $00BE71                               ; $01D80B |
+  JSL CODE_00BE71                           ; $01D80B |
 
   dw $51E4, $BA7E, $7036                    ; $01D80F |
 
@@ -10582,7 +10590,7 @@ CODE_01D81D:
   LDA #$DC4D                                ; $01D851 |
   JSL r_gsu_init_1                          ; $01D854 | GSU init
   LDA #$01A4                                ; $01D858 |
-  JSL $00BE71                               ; $01D85B |
+  JSL CODE_00BE71                           ; $01D85B |
 
   dw $5040, $727E, $7033                    ; $01D85F |
 
@@ -10613,7 +10621,7 @@ CODE_01D86D:
   LDA #$DC4D                                ; $01D8A1 |
   JSL r_gsu_init_1                          ; $01D8A4 | GSU init
   LDA #$01A4                                ; $01D8A8 |
-  JSL $00BE71                               ; $01D8AB |
+  JSL CODE_00BE71                           ; $01D8AB |
 
   dw $51E4, $BA7E, $7036                    ; $01D8AF |
 
@@ -10647,7 +10655,7 @@ CODE_01D8C6:
   LDA #$DD23                                ; $01D8FA |
   JSL r_gsu_init_1                          ; $01D8FD | GSU init
   LDA #$01A4                                ; $01D901 |
-  JSL $00BE71                               ; $01D904 |
+  JSL CODE_00BE71                           ; $01D904 |
 
   dw $5040, $727E, $7033                    ; $01D908 |
 
@@ -11260,7 +11268,7 @@ CODE_01DD8B:
   LDY #$36E0                                ; $01DDA0 |
   LDX #$B59F                                ; $01DDA3 |
   LDA #$0100                                ; $01DDA6 |
-  JSL $00BEA6                               ; $01DDA9 |
+  JSL CODE_00BEA6                           ; $01DDA9 |
   SEP #$30                                  ; $01DDAD |
   RTS                                       ; $01DDAF |
 
@@ -11668,7 +11676,7 @@ CODE_01E08D:
   SEP #$20                                  ; $01E093 |
   LDA $10                                   ; $01E095 |
   BNE CODE_01E0BE                           ; $01E097 |
-  JSL $00BE39                               ; $01E099 |
+  JSL CODE_00BE39                           ; $01E099 |
 
 ; DMA args
   dl $7E56D0, $703A02                       ; $01E09D |
@@ -11930,9 +11938,9 @@ CODE_01E258:
   PLB                                       ; $01E26B |
   RTS                                       ; $01E26C |
 
-gamemode31:
+gm31_fade_to_score_from_boss:
   LDX $0B57                                 ; $01E26D |
-  JSR ($E291,x)                             ; $01E270 |
+  JSR (DATA_01E291,x)                       ; $01E270 |
   LDA $0B57                                 ; $01E273 |
   CMP #$16                                  ; $01E276 |
   BCC CODE_01E284                           ; $01E278 |
@@ -11945,24 +11953,26 @@ CODE_01E284:
   LDA $0B57                                 ; $01E284 |
   CMP #$08                                  ; $01E287 |
   BCS CODE_01E28F                           ; $01E289 |
-  JSL $01C0CE                               ; $01E28B |
+  JSL CODE_01C0CE                           ; $01E28B |
 
 CODE_01E28F:
   PLB                                       ; $01E28F |
   RTL                                       ; $01E290 |
 
-  dw $E2A7                                  ; $01E291 |
-  dw $E2F0                                  ; $01E293 |
-  dw $E378                                  ; $01E295 |
-  dw $E442                                  ; $01E297 |
-  dw $B5E4                                  ; $01E299 |
-  dw $B6B9                                  ; $01E29B |
-  dw $B6C9                                  ; $01E29D |
-  dw $B95B                                  ; $01E29F |
-  dw $B9BA                                  ; $01E2A1 |
-  dw $E2F0                                  ; $01E2A3 |
-  dw $E4A0                                  ; $01E2A5 |
+DATA_01E291:
+  dw CODE_01E2A7                            ; $01E291 |
+  dw CODE_01E2F0                            ; $01E293 |
+  dw CODE_01E378                            ; $01E295 |
+  dw CODE_01E442                            ; $01E297 |
+  dw CODE_01B5E4                            ; $01E299 |
+  dw CODE_01B6B9                            ; $01E29B |
+  dw CODE_01B6C9                            ; $01E29D |
+  dw CODE_01B95B                            ; $01E29F |
+  dw CODE_01B9BA                            ; $01E2A1 |
+  dw CODE_01E2F0                            ; $01E2A3 |
+  dw CODE_01E4A0                            ; $01E2A5 |
 
+CODE_01E2A7:
   REP #$30                                  ; $01E2A7 |
   LDA !r_header_level_mode                  ; $01E2A9 |
   CMP #$0009                                ; $01E2AC |
@@ -12028,7 +12038,7 @@ CODE_01E2F0:
 CODE_01E338:
   DEC A                                     ; $01E338 |
   BNE CODE_01E348                           ; $01E339 |
-  JSL $00BE39                               ; $01E33B |
+  JSL CODE_00BE39                           ; $01E33B |
 
   dw $56D0, $027E, $703A, $00D2             ; $01E33F |
 
@@ -12037,7 +12047,7 @@ CODE_01E338:
 CODE_01E348:
   DEC A                                     ; $01E348 |
   BNE CODE_01E358                           ; $01E349 |
-  JSL $00BE39                               ; $01E34B |
+  JSL CODE_00BE39                           ; $01E34B |
 
   dw $57A2, $D47E, $703A, $00D2             ; $01E34F |
 
@@ -12046,7 +12056,7 @@ CODE_01E348:
 CODE_01E358:
   DEC A                                     ; $01E358 |
   BNE CODE_01E368                           ; $01E359 |
-  JSL $00BE39                               ; $01E35B |
+  JSL CODE_00BE39                           ; $01E35B |
 
   dw $5874, $A67E, $703B, $00D2             ; $01E35F |
 
@@ -12055,13 +12065,14 @@ CODE_01E358:
 CODE_01E368:
   DEC A                                     ; $01E368 |
   BNE CODE_01E377                           ; $01E369 |
-  JSL $00BE39                               ; $01E36B |
+  JSL CODE_00BE39                           ; $01E36B |
 
   dw $5946, $787E, $703C, $00D2             ; $01E36F |
 
 CODE_01E377:
   RTS                                       ; $01E377 |
 
+CODE_01E378:
   JSR CODE_01E3AF                           ; $01E378 |
   REP #$20                                  ; $01E37B |
   LDA $0D25                                 ; $01E37D |
@@ -12074,7 +12085,7 @@ CODE_01E377:
   INC $0B57                                 ; $01E38F |
   INC $0B57                                 ; $01E392 |
   JSL clear_all_sprites                     ; $01E395 |
-  JSL $008259                               ; $01E399 |
+  JSL init_oam_buffer                       ; $01E399 |
   SEP #$20                                  ; $01E39D |
   LDA #$20                                  ; $01E39F |
   STA !r_reg_hdmaen_mirror                  ; $01E3A1 |
@@ -12162,7 +12173,7 @@ CODE_01E403:
   SEC                                       ; $01E426 |
   SBC $E3AB,y                               ; $01E427 |
   STA $0D22                                 ; $01E42A |
-  JSL $00BE39                               ; $01E42D |
+  JSL CODE_00BE39                           ; $01E42D |
 
   dw $56D0, $027E, $703A, $0348             ; $01E431 |
 
@@ -12171,6 +12182,7 @@ CODE_01E403:
   STA !r_reg_hdmaen_mirror                  ; $01E43E |
   RTS                                       ; $01E441 |
 
+CODE_01E442:
   REP #$30                                  ; $01E442 |
   LDX #$0000                                ; $01E444 |
   LDA #$00FF                                ; $01E447 |
@@ -12184,7 +12196,7 @@ CODE_01E44A:
   CPX #$0348                                ; $01E452 |
   BCC CODE_01E44A                           ; $01E455 |
   SEP #$30                                  ; $01E457 |
-  JSL $00BE39                               ; $01E459 |
+  JSL CODE_00BE39                           ; $01E459 |
 
   dw $56D0, $027E, $703A, $0348             ; $01E45D |
 
@@ -12213,6 +12225,7 @@ CODE_01E44A:
   INC $0B57                                 ; $01E49C |
   RTS                                       ; $01E49F |
 
+CODE_01E4A0:
   JSR CODE_01E3AF                           ; $01E4A0 |
   REP #$20                                  ; $01E4A3 |
   LDA $0D23                                 ; $01E4A5 |
@@ -12270,13 +12283,13 @@ CODE_01E4D1:
   AND $02                                   ; $01E52A |
   RTL                                       ; $01E52C |
 
-gamemode33:
+gm33_fade_to_midring_restart_screen:
   JSL init_oam_and_bg3_tilemap              ; $01E52D |
   JSL clear_basic_states                    ; $01E531 |
   LDA #$2E                                  ; $01E535 |
   STA $704070                               ; $01E537 |
   JSR CODE_01E59A                           ; $01E53B |
-  JML $1083E2                               ; $01E53E |
+  JML increment_gamemode                    ; $01E53E |
 
 ; Retry screen tilemap queue entries
 ; init entry
@@ -12316,7 +12329,7 @@ gamemode33:
 
 CODE_01E59A:
   JSL clear_all_sprites                     ; $01E59A |
-  JSL $008259                               ; $01E59E | init OAM buffer
+  JSL init_oam_buffer                       ; $01E59E | init OAM buffer
   LDX levelmode_index                       ; $01E5A2 |
   JSL init_scene_regs                       ; $01E5A5 |
   LDX #$70                                  ; $01E5A9 |
@@ -12351,7 +12364,7 @@ CODE_01E5B1:
   STA !reg_nmitimen                         ; $01E5E5 |
   RTS                                       ; $01E5E8 |
 
-gamemode35:
+gm35_load_restart_from_midring:
   LDA #$2E                                  ; $01E5E9 |
   STA $704070                               ; $01E5EB |
   JSR CODE_01E689                           ; $01E5EF |
@@ -12444,18 +12457,18 @@ CODE_01E689:
   SEP #$30                                  ; $01E69F |
   RTS                                       ; $01E6A1 |
 
-gamemode3B:
+gm3b_load_retry_screen:
   JSL init_oam_and_bg3_tilemap              ; $01E6A2 |
   JSL clear_basic_states                    ; $01E6A6 |
   LDA #$21                                  ; $01E6AA |
   STA $704070                               ; $01E6AC |
   JSR CODE_01E59A                           ; $01E6B0 |
-  JML $1083E2                               ; $01E6B3 |
+  JML increment_gamemode                    ; $01E6B3 |
 
 try_again_sounds:
   db $43, $2E                               ; $01E6B7 | Yes: Yoshi sound, No: Bucket sound
 
-gamemode3D:
+gm3d_retry_screen:
   LDA #$21                                  ; $01E6B9 |
   STA $704070                               ; $01E6BB |
   JSR CODE_01E689                           ; $01E6BF |
@@ -12486,7 +12499,9 @@ CODE_01E6EC:
 
   db $0B, $1F                               ; $01E6EE |
 
-gamemode36:
+; used for both 'restart from middle ring' and
+; 'retry level' selection screens
+gm_retry_level_cutscene_select:
   DEC $8F                                   ; $01E6F0 |
   BNE CODE_01E70F                           ; $01E6F2 |
   LDA $704094                               ; $01E6F4 |

--- a/disassembly/bank02.asm
+++ b/disassembly/bank02.asm
@@ -378,7 +378,7 @@ CODE_028368:
   AND #$00FF                                ; $02836B |
   ASL A                                     ; $02836E |
   TAX                                       ; $02836F |
-  LDA $00E9D4,x                             ; $028370 |
+  LDA raphael_mode7_matrix_b_c,x            ; $028370 |
   SEP #$20                                  ; $028374 |
   STA !reg_m7a                              ; $028376 |
   XBA                                       ; $028379 |
@@ -1705,7 +1705,7 @@ CODE_02925F:
   LDA !s_spr_wildcard_3_lo_dp,x             ; $029261 |
   ASL A                                     ; $029263 |
   TAX                                       ; $029264 |
-  LDA $00E954,x                             ; $029265 |
+  LDA raphael_mode7_matrix_a_d,x            ; $029265 |
   STA $02                                   ; $029269 |
   BPL CODE_029271                           ; $02926B |
   EOR #$FFFF                                ; $02926D |
@@ -1767,7 +1767,7 @@ CODE_029298:
   ASL A                                     ; $0292DE |
   REP #$10                                  ; $0292DF |
   TAX                                       ; $0292E1 |
-  LDA $00E9D4,x                             ; $0292E2 |
+  LDA raphael_mode7_matrix_b_c,x            ; $0292E2 |
   ASL A                                     ; $0292E6 |
   ASL A                                     ; $0292E7 |
   ASL A                                     ; $0292E8 |
@@ -8651,7 +8651,7 @@ CODE_02CE23:
   AND #$00FF                                ; $02CEB5 |
   ASL A                                     ; $02CEB8 |
   TAX                                       ; $02CEB9 |
-  LDA $00E9D4,x                             ; $02CEBA |
+  LDA raphael_mode7_matrix_b_c,x            ; $02CEBA |
   ASL A                                     ; $02CEBE |
   ASL A                                     ; $02CEBF |
   ASL A                                     ; $02CEC0 |
@@ -8666,7 +8666,7 @@ CODE_02CECA:
   SEC                                       ; $02CECE |
   ADC $00                                   ; $02CECF |
   STA $00                                   ; $02CED1 |
-  LDA $00E954,x                             ; $02CED3 |
+  LDA raphael_mode7_matrix_a_d,x            ; $02CED3 |
   ASL A                                     ; $02CED7 |
   ASL A                                     ; $02CED8 |
   ASL A                                     ; $02CED9 |
@@ -11270,7 +11270,7 @@ CODE_02E39F:
   LDY #$04                                  ; $02E39F |
   REP #$10                                  ; $02E3A1 |
   TAX                                       ; $02E3A3 |
-  LDA $00E9D4,x                             ; $02E3A4 |
+  LDA raphael_mode7_matrix_b_c,x            ; $02E3A4 |
   ASL A                                     ; $02E3A8 |
   SEP #$10                                  ; $02E3A9 |
   LDX $12                                   ; $02E3AB |

--- a/disassembly/bank02.asm
+++ b/disassembly/bank02.asm
@@ -212,7 +212,7 @@ main_falling_wall:
 
 CODE_02822A:
   STA !r_reg_tm_mirror                      ; $02822A |
-  JSL $03AF23                               ; $02822D |
+  JSL CODE_03AF23                           ; $02822D |
   LDA !s_spr_timer_1,x                      ; $028231 |
   BNE CODE_02825F                           ; $028234 |
   LDY $0CB4                                 ; $028236 |
@@ -492,7 +492,7 @@ CODE_028417:
   LDX #$08                                  ; $028459 |
   LDA #$BE9F                                ; $02845B |
   JSL r_gsu_init_1                          ; $02845E | GSU init
-  JSL $00BE39                               ; $028462 |
+  JSL CODE_00BE39                           ; $028462 |
 
 ; args to $00BE39
   dw $5040, $727E, $7033, $01A4             ; $028466 |
@@ -568,7 +568,7 @@ CODE_0284E1:
   dw $FFA0                                  ; $0284F4 |
 
 main_roger:
-  JSL $03AF23                               ; $0284F6 |
+  JSL CODE_03AF23                           ; $0284F6 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $0284F9 |
   JSR CODE_0284E1                           ; $0284FC |
   LDA !s_spr_x_speed_lo,x                   ; $0284FF |
@@ -683,7 +683,7 @@ init_roger_2:
 
 main_roger_2:
   JSR CODE_02893E                           ; $0285EB |
-  JSL $03AF23                               ; $0285EE |
+  JSL CODE_03AF23                           ; $0285EE |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $0285F2 |
   ASL A                                     ; $0285F4 |
   TXY                                       ; $0285F5 |
@@ -1177,7 +1177,7 @@ CODE_028958:
   LDX #$08                                  ; $028996 |
   LDA #$E93B                                ; $028998 |
   JSL r_gsu_init_1                          ; $02899B | GSU init
-  JSL $00BE39                               ; $02899F |
+  JSL CODE_00BE39                           ; $02899F |
 
 ; args to $00BE39
   dw $5040, $727E                           ; $0289A3 |
@@ -1510,7 +1510,7 @@ init_roger_flame:
   dw $FF80, $0080, $FF00, $0100             ; $0290DE |
 
 main_roger_flame:
-  JSL $03AF23                               ; $0290E6 |
+  JSL CODE_03AF23                           ; $0290E6 |
   INC !s_spr_wildcard_3_lo_dp,x             ; $0290EA |
   LDA !s_spr_timer_1,x                      ; $0290EC |
   BNE CODE_02910A                           ; $0290EF |
@@ -1785,7 +1785,7 @@ CODE_029298:
   LDX $12                                   ; $029304 |
 
 CODE_029306:
-  JSL $03AF23                               ; $029306 |
+  JSL CODE_03AF23                           ; $029306 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $02930A |
   CLC                                       ; $02930C |
   ADC #$FFFF                                ; $02930D |
@@ -1820,11 +1820,11 @@ CODE_02934E:
   LDX #$08                                  ; $029351 |
   LDA #$C450                                ; $029353 |
   JSL r_gsu_init_1                          ; $029356 | GSU init
-  JSL $00BE39                               ; $02935A |
+  JSL CODE_00BE39                           ; $02935A |
 
   dw $51E4, $167E, $7035, $00A8             ; $02935E |
 
-  JSL $00BE39                               ; $029366 |
+  JSL CODE_00BE39                           ; $029366 |
 
   dw $5040, $727E, $7033, $01A4             ; $02936A |
 
@@ -1885,7 +1885,7 @@ CODE_0293CF:
   JMP CODE_029461                           ; $0293D3 |-- continue below
 
 CODE_0293D6:
-  JSL $03AF23                               ; $0293D6 |
+  JSL CODE_03AF23                           ; $0293D6 |
   LDA !s_spr_x_player_delta,x               ; $0293DA |
   CLC                                       ; $0293DD |
   ADC #$0020                                ; $0293DE |
@@ -2113,7 +2113,7 @@ init_invisible_slime_platform:
 
 ; golden egg calls it "dent of castella" (what)
 main_invisible_slime_platform:
-  JSL $03AF23                               ; $0295D3 |
+  JSL CODE_03AF23                           ; $0295D3 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0295D7 |
   STA !gsu_r6                               ; $0295D9 |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $0295DC |
@@ -2486,7 +2486,7 @@ init_super_star:
   STA !s_spr_x_speed_lo,x                   ; $02989B |
 
 CODE_02989E:
-  JSL $03AE60                               ; $02989E |
+  JSL CODE_03AE60                           ; $02989E |
   LDA #$0100                                ; $0298A2 |
   STA !gsu_r6                               ; $0298A5 |
   LDY !s_spr_dyntile_index,x                ; $0298A8 |
@@ -2531,7 +2531,7 @@ main_super_star:
 
   TYX                                       ; $029900 |
   JSL $03AA2E                               ; $029901 |
-  JSL $03AF23                               ; $029905 |
+  JSL CODE_03AF23                           ; $029905 |
   LDA !s_spr_y_accel,x                      ; $029909 |
   BNE CODE_02991D                           ; $02990C |
   LDA !s_player_form                        ; $02990E |
@@ -2788,7 +2788,7 @@ main_hookbill_background:
   LDX $12                                   ; $029B83 |
 
 CODE_029B85:
-  JSL $03AF23                               ; $029B85 |
+  JSL CODE_03AF23                           ; $029B85 |
   LDA $0B59                                 ; $029B89 |
   LSR A                                     ; $029B8C |
   BEQ CODE_029BC9                           ; $029B8D |
@@ -2878,7 +2878,7 @@ CODE_029C24:
   RTL                                       ; $029C46 |
 
 init_chomp_signboard:
-  JSL $03AE60                               ; $029C47 |
+  JSL CODE_03AE60                           ; $029C47 |
   LDA #$0100                                ; $029C4B |
   STA !gsu_r6                               ; $029C4E |
   LDY !s_spr_dyntile_index,x                ; $029C51 |
@@ -2902,7 +2902,7 @@ init_chomp_signboard:
   RTL                                       ; $029C86 |
 
 main_chomp_signboard:
-  JML $03AA52                               ; $029C87 |
+  JML CODE_03AA52                           ; $029C87 |
 
 init_falling_rock:
   LDA !s_spr_x_pixel_pos,x                  ; $029C8B |
@@ -2947,6 +2947,7 @@ CODE_029CAE:
   STA !s_spr_timer_1,x                      ; $029CE7 |
   RTL                                       ; $029CEA |
 
+main_falling_rock:
   JSR CODE_029DF6                           ; $029CEB |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $029CEE |
   BNE CODE_029D54                           ; $029CF0 |
@@ -2997,7 +2998,7 @@ CODE_029D51:
   STA !s_spr_gsu_morph_1_lo,x               ; $029D51 |
 
 CODE_029D54:
-  JSL $03AF23                               ; $029D54 |
+  JSL CODE_03AF23                           ; $029D54 |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $029D58 |
   BEQ CODE_029DC6                           ; $029D5A |
   LDA !s_cam_event_flag                     ; $029D5C |
@@ -3144,7 +3145,7 @@ main_falling_rock_common:
   JMP CODE_029F33                           ; $029E96 |
 
 CODE_029E99:
-  JSL $03AF23                               ; $029E99 |
+  JSL CODE_03AF23                           ; $029E99 |
   LDA $7CD7,x                               ; $029E9D |
   AND #$000F                                ; $029EA0 |
   STA $00                                   ; $029EA3 |
@@ -3324,7 +3325,7 @@ init_key:
   JML despawn_sprite_free_slot              ; $029FF2 |
 
 CODE_029FF6:
-  JSL $02A007                               ; $029FF6 |
+  JSL CODE_02A007                           ; $029FF6 |
   LDA !s_spr_x_pixel_pos,x                  ; $029FFA |
   STA !s_spr_wildcard_1_lo,x                ; $029FFD |
   LDA !s_spr_y_pixel_pos,x                  ; $02A000 |
@@ -3334,6 +3335,7 @@ CODE_02A006:
   RTL                                       ; $02A006 |
 
 ; long subroutine
+CODE_02A007:
   LDA !s_spr_x_pixel_pos,x                  ; $02A007 |
   AND #$FFF0                                ; $02A00A |
   ORA #$0008                                ; $02A00D |
@@ -3371,7 +3373,7 @@ main_key:
   STZ !s_spr_collision_state,x              ; $02A056 |
 
 CODE_02A059:
-  JSL $03B9DD                               ; $02A059 |
+  JSL CODE_03B9DD                           ; $02A059 |
   LDA !s_spr_wildcard_6_lo_dp,x             ; $02A05D |
   BEQ CODE_02A064                           ; $02A05F |
   JMP CODE_02A099                           ; $02A061 |
@@ -3475,15 +3477,15 @@ init_door:
   STA !s_spr_y_pixel_pos,x                  ; $02A131 |
 
 CODE_02A134:
-  JSL $03AE60                               ; $02A134 |
+  JSL CODE_03AE60                           ; $02A134 |
   JSL $02A153                               ; $02A138 |
   BRA CODE_02A142                           ; $02A13C |
 
 CODE_02A13E:
-  JSL $02A1FD                               ; $02A13E |
+  JSL CODE_02A1FD                           ; $02A13E |
 
 CODE_02A142:
-  JSL $02A007                               ; $02A142 |
+  JSL CODE_02A007                           ; $02A142 |
   LDA #$000C                                ; $02A146 |
   STA !s_spr_hitbox_width,x                 ; $02A149 |
   LDA #$0019                                ; $02A14C |
@@ -3563,6 +3565,7 @@ CODE_02A1C2:
   LDX $12                                   ; $02A1FA |
   RTL                                       ; $02A1FC |
 
+CODE_02A1FD:
   REP #$10                                  ; $02A1FD |
   LDY !s_spr_oam_pointer,x                  ; $02A1FF |
   LDA !s_spr_id,x                           ; $02A202 |
@@ -3673,13 +3676,13 @@ CODE_02A247:
 
 ; all doors
 main_door:
-  JSL $02A1FD                               ; $02A330 |
+  JSL CODE_02A1FD                           ; $02A330 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $02A334 |
   BEQ CODE_02A33B                           ; $02A336 |
   JMP CODE_02A3F0                           ; $02A338 |
 
 CODE_02A33B:
-  JSL $03AF23                               ; $02A33B |
+  JSL CODE_03AF23                           ; $02A33B |
   LDA !s_player_jump_state                  ; $02A33F |
   BNE CODE_02A34C                           ; $02A342 |
   LDA !s_spr_y_pixel_pos,x                  ; $02A344 |
@@ -3716,7 +3719,7 @@ CODE_02A34D:
 
 CODE_02A388:
   TYX                                       ; $02A388 |
-  JSL $03BF87                               ; $02A389 |
+  JSL CODE_03BF87                           ; $02A389 |
   JSL despawn_sprite_stage_ID               ; $02A38D |
   LDA #$0064                                ; $02A391 |\ play sound #$64
   JSL push_sound_queue                      ; $02A394 |/
@@ -3923,7 +3926,7 @@ init_teleport_sprite:
   RTL                                       ; $02A517 |
 
 main_teleport_sprite:
-  JSL $03AF23                               ; $02A518 |
+  JSL CODE_03AF23                           ; $02A518 |
   LDY !s_spr_collision_id,x                 ; $02A51C |
   BPL CODE_02A52B                           ; $02A51F |
   LDA !s_player_form                        ; $02A521 |
@@ -4162,7 +4165,7 @@ CODE_02A71C:
   LDX $12                                   ; $02A75F |
 
 CODE_02A761:
-  JSL $03AF23                               ; $02A761 |
+  JSL CODE_03AF23                           ; $02A761 |
   LDA $0B57                                 ; $02A765 |
   BNE CODE_02A786                           ; $02A768 |
   LDA !s_spr_cam_x_pos,x                    ; $02A76A |
@@ -4478,7 +4481,7 @@ CODE_02A9AE:
 
 CODE_02A9E7:
   PHA                                       ; $02A9E7 |
-  JSL $03BF87                               ; $02A9E8 |
+  JSL CODE_03BF87                           ; $02A9E8 |
   LDA #$0115                                ; $02A9EC |
   TXY                                       ; $02A9EF |
   JSL spawn_sprite                          ; $02A9F0 |
@@ -4509,7 +4512,7 @@ CODE_02AA21:
 
 ; $A9B7 table pointer
   TYX                                       ; $02AA2A |
-  JSL $03BF87                               ; $02AA2B |
+  JSL CODE_03BF87                           ; $02AA2B |
   LDA #$FB00                                ; $02AA2F |
   STA !s_spr_y_speed_lo,x                   ; $02AA32 |
   RTS                                       ; $02AA35 |
@@ -4791,8 +4794,8 @@ main_yoshi_at_goal:
   ASL A                                     ; $02AC89 |
   STA $6116                                 ; $02AC8A |
   JSL $04FB41                               ; $02AC8D |
-  JSL $03AA52                               ; $02AC91 |
-  JSL $03AF23                               ; $02AC95 |
+  JSL CODE_03AA52                           ; $02AC91 |
+  JSL CODE_03AF23                           ; $02AC95 |
   JSL $03A590                               ; $02AC99 |
 
 CODE_02AC9D:
@@ -4844,7 +4847,7 @@ init_star_item:
   db $88, $00                               ; $02AD08 |
 
 main_star_item:
-  JSL $03AF23                               ; $02AD0A |
+  JSL CODE_03AF23                           ; $02AD0A |
   JSL $03D127                               ; $02AD0E |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $02AD12 |
   BNE CODE_02AD57                           ; $02AD14 |
@@ -5148,7 +5151,7 @@ CODE_02AF68:
 
 CODE_02AF70:
   STA !s_spr_bitwise_settings_1,x           ; $02AF70 |
-  JSL $03AF23                               ; $02AF73 |
+  JSL CODE_03AF23                           ; $02AF73 |
   INC !s_spr_wildcard_3_lo_dp,x             ; $02AF77 |
   JSR CODE_02B276                           ; $02AF79 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $02AF7C |
@@ -7172,7 +7175,7 @@ init_nep_enut:
 
 main_nep_enut:
   JSR CODE_02C1F4                           ; $02BF91 |
-  JSL $03AF23                               ; $02BF94 |
+  JSL CODE_03AF23                           ; $02BF94 |
   LDY #$02                                  ; $02BF98 |
   LDA !s_spr_cam_x_pos,x                    ; $02BF9A |
   CLC                                       ; $02BF9D |
@@ -7513,7 +7516,7 @@ CODE_02C1F4:
   LDX #$08                                  ; $02C236 |
   LDA #$E93B                                ; $02C238 |
   JSL r_gsu_init_1                          ; $02C23B | GSU init
-  JSL $00BE39                               ; $02C23F |
+  JSL CODE_00BE39                           ; $02C23F |
 
   dw $5040, $727E, $7033, $0348             ; $02C243 |
 
@@ -7956,7 +7959,7 @@ CODE_02C943:
 
 main_prince_froggy:
   JSR CODE_02CDFA                           ; $02C950 |
-  JSL $03AF23                               ; $02C953 |
+  JSL CODE_03AF23                           ; $02C953 |
   LDA !r_y_cam_offset                       ; $02C957 |
   STA !r_bg3_cam_y                          ; $02C95A |
   STA !s_bg3_cam_y                          ; $02C95D |
@@ -8609,7 +8612,7 @@ CODE_02CE23:
   LDX #$0A                                  ; $02CE52 |
   LDA #$8F10                                ; $02CE54 |
   JSL r_gsu_init_1                          ; $02CE57 | GSU init
-  JSL $00BE39                               ; $02CE5B |
+  JSL CODE_00BE39                           ; $02CE5B |
 
 ; args to $00BE39
   dw $5040, $727E, $7033, $0690             ; $02CE5F |
@@ -8620,7 +8623,7 @@ CODE_02CE23:
   LDA #$0098                                ; $02CE70 |
   TSB !r_reg_hdmaen_mirror                  ; $02CE73 |
   LDX $12                                   ; $02CE76 |
-  JSL $03AA52                               ; $02CE78 |
+  JSL CODE_03AA52                           ; $02CE78 |
   REP #$10                                  ; $02CE7C |
   LDY !s_spr_oam_pointer,x                  ; $02CE7E |
   LDA $704582                               ; $02CE81 |
@@ -8782,7 +8785,7 @@ main_giant_shyguy:
   STA !s_spr_bitwise_settings_3,x           ; $02CFC6 |
 
 CODE_02CFC9:
-  JSL $03AF23                               ; $02CFC9 |
+  JSL CODE_03AF23                           ; $02CFC9 |
   LDA !s_spr_wildcard_2_lo,x                ; $02CFCD |
   BNE CODE_02CFED                           ; $02CFD0 |
   INC !s_spr_wildcard_5_lo_dp,x             ; $02CFD2 |
@@ -8849,7 +8852,7 @@ init_froggy_stomach_acid:
   RTL                                       ; $02D03F |
 
 main_froggy_stomach_acid:
-  JSL $03AF23                               ; $02D040 |
+  JSL CODE_03AF23                           ; $02D040 |
   LDA !s_spr_y_accel_ceiling,x              ; $02D044 |
   BEQ CODE_02D04C                           ; $02D047 |
   JMP CODE_02D09D                           ; $02D049 |
@@ -8999,7 +9002,7 @@ CODE_02D16A:
 
 main_sluggy_unshaven:
   JSR CODE_02D7D6                           ; $02D195 |
-  JSL $03AF23                               ; $02D198 |
+  JSL CODE_03AF23                           ; $02D198 |
   TXY                                       ; $02D19C |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $02D19D |\
   ASL A                                     ; $02D19F | | run state routine
@@ -9813,7 +9816,7 @@ CODE_02D7DD:
   LDX #$08                                  ; $02D7E9 |
   LDA #$E4BD                                ; $02D7EB |
   JSL r_gsu_init_1                          ; $02D7EE | GSU init
-  JSL $00BE39                               ; $02D7F2 |
+  JSL CODE_00BE39                           ; $02D7F2 |
 
 ; args to $00BE39
   dw $5040, $727E, $7033, $0348             ; $02D7F6 |
@@ -9930,7 +9933,7 @@ main_hidden_vertical_entrance:
   RTL                                       ; $02D8E6 |
 
 main_vertical_entrance:
-  JSL $03AF23                               ; $02D8E7 |
+  JSL CODE_03AF23                           ; $02D8E7 |
   JSR CODE_02D908                           ; $02D8EB |
   BCC CODE_02D907                           ; $02D8EE |
   LDA !r_joy1_hi_mirror                     ; $02D8F0 |
@@ -9994,7 +9997,7 @@ CODE_02D954:
 
 ; both left and right
 main_horizontal_entrance:
-  JSL $03AF23                               ; $02D95C |
+  JSL CODE_03AF23                           ; $02D95C |
   JSR CODE_02D908                           ; $02D960 |
   BCC CODE_02D984                           ; $02D963 |
   LDA !s_spr_x_player_dir,x                 ; $02D965 |
@@ -10078,7 +10081,7 @@ CODE_02D9C6:
   RTL                                       ; $02DA0D |
 
 main_boss_key:
-  JSL $03AA52                               ; $02DA0E |
+  JSL CODE_03AA52                           ; $02DA0E |
   TXY                                       ; $02DA12 |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $02DA13 |
   ASL A                                     ; $02DA15 |
@@ -10393,7 +10396,7 @@ CODE_02DC7D:
   LDX #$09                                  ; $02DC7D |
   LDA #$A82C                                ; $02DC7F |
   JSL r_gsu_init_1                          ; $02DC82 | GSU init
-  JSL $00BE39                               ; $02DC86 |
+  JSL CODE_00BE39                           ; $02DC86 |
 
   db $D0, $56, $7E, $02                     ; $02DC8A |
   db $3A, $70, $48, $03                     ; $02DC8E |
@@ -10598,7 +10601,7 @@ CODE_02DE32:
   LDX #$08                                  ; $02DE69 |
   LDA #$F05F                                ; $02DE6B |
   JSL r_gsu_init_1                          ; $02DE6E | GSU init
-  JSL $00BE39                               ; $02DE72 |
+  JSL CODE_00BE39                           ; $02DE72 |
 
   db $D0, $56, $7E, $02                     ; $02DE76 |
   db $3A, $70, $48, $03                     ; $02DE7A |
@@ -10772,7 +10775,7 @@ CODE_02DFC4:
   LDX #$08                                  ; $02DFD6 |
   LDA #$B2B6                                ; $02DFD8 |
   JSL r_gsu_init_1                          ; $02DFDB | GSU init
-  JSL $00BE39                               ; $02DFDF |
+  JSL CODE_00BE39                           ; $02DFDF |
 
   db $D0, $56, $7E, $02                     ; $02DFE3 |
   db $3A, $70, $48, $03                     ; $02DFE7 |
@@ -10818,7 +10821,7 @@ CODE_02E02A:
   TSB !r_reg_hdmaen_mirror                  ; $02E04B |
 
 CODE_02E04E:
-  JSL $03AF23                               ; $02E04E |
+  JSL CODE_03AF23                           ; $02E04E |
   LDA !s_spr_timer_1,x                      ; $02E052 |
   CMP #$0140                                ; $02E055 |
   BNE CODE_02E06C                           ; $02E058 |
@@ -10979,6 +10982,8 @@ CODE_02E190:
   LDA #$0200                                ; $02E19C |
   LDX #$00                                  ; $02E19F |
   BRA CODE_02E1A8                           ; $02E1A1 |
+
+CODE_02E1A3:
   LDA #$0200                                ; $02E1A3 |
   LDX #$01                                  ; $02E1A6 |
 
@@ -11013,8 +11018,8 @@ CODE_02E1DF:
   STA !s_player_disable_flag                ; $02E1E4 |
   JML $028922                               ; $02E1E7 |
 
-init_log:
-  JSL $03AE60                               ; $02E1EB |
+init_floating_log:
+  JSL CODE_03AE60                           ; $02E1EB |
   STZ !s_spr_facing_dir,x                   ; $02E1EF |
   SEP #$20                                  ; $02E1F2 |
   LDA #$FF                                  ; $02E1F4 |
@@ -11082,8 +11087,8 @@ init_log:
   dw $0008                                  ; $02E268 |
 
 main_log:
-  JSL $03AA52                               ; $02E26A |
-  JSL $03AF23                               ; $02E26E |
+  JSL CODE_03AA52                           ; $02E26A |
+  JSL CODE_03AF23                           ; $02E26E |
   REP #$10                                  ; $02E272 |
   LDA !s_spr_wildcard_2_lo,x                ; $02E274 |
   TAX                                       ; $02E277 |
@@ -11486,8 +11491,9 @@ CODE_02E526:
   dw $F273                                  ; $02E57B |
   dw $F310                                  ; $02E57D |
 
+main_naval_piranha:
   JSR CODE_02E5E4                           ; $02E57F |
-  JSL $03AF23                               ; $02E582 |
+  JSL CODE_03AF23                           ; $02E582 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $02E586 |
   BMI CODE_02E5AB                           ; $02E588 |
   TXY                                       ; $02E58A |
@@ -13298,7 +13304,7 @@ main_naval_bud:
   LDY $1072                                 ; $02F3A7 |
   LDA !s_spr_oam_yxppccct,y                 ; $02F3AA |
   STA !s_spr_oam_yxppccct,x                 ; $02F3AD |
-  JSL $03AF23                               ; $02F3B0 |
+  JSL CODE_03AF23                           ; $02F3B0 |
   TXY                                       ; $02F3B4 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $02F3B5 |
   ASL A                                     ; $02F3B7 |
@@ -14060,7 +14066,7 @@ main_naval_piranha_stalk:
   LDA !s_spr_oam_yxppccct,y                 ; $02F915 |
   STA !s_spr_oam_yxppccct,x                 ; $02F918 |
   JSR CODE_02F9CC                           ; $02F91B |
-  JSL $03AF23                               ; $02F91E |
+  JSL CODE_03AF23                           ; $02F91E |
   LDY $1072                                 ; $02F922 |
   LDA !s_spr_wildcard_5_lo,y                ; $02F925 |
   CMP #$001C                                ; $02F928 |

--- a/disassembly/bank03.asm
+++ b/disassembly/bank03.asm
@@ -6,1340 +6,1340 @@ org $038000
 
 ; sprite init routine table: $8000 - $852D
 sprite_inits:
-  dl $02E1EB                                ; $038000 | Log, floating on water / lava
-  dl $02A0E7                                ; $038003 | Closed door
-  dl $02F8FD                                ; $038006 | Naval Piranha's stalk
-  dl $0D8E60                                ; $038009 | Crate, key
-  dl $02ACFC                                ; $03800C | Item from Star Mario block
-  dl $048002                                ; $03800F | Icy watermelon
-  dl $048428                                ; $038012 | Chill
-  dl $048002                                ; $038015 | Watermelon
-  dl $0DFB93                                ; $038018 | Rubble
-  dl $048002                                ; $03801B | Fire watermelon
-  dl $03F2FE                                ; $03801E | Kaboomba
-  dl $0E8002                                ; $038021 | Cannonball of Kaboomba
-  dl $0FAD1F                                ; $038024 | Raphael the Raven
-  dl $02A52C                                ; $038027 | Goal
-  dl $0F8000                                ; $03802A | G O A L !
-  dl $0F8135                                ; $03802D | BONUS CHALLENGE
-  dl $06E02B                                ; $038030 | Caged Ghost, round mound
-  dl $11C8F0                                ; $038033 | Item Card
-  dl $02A125                                ; $038036 | Boss Door
-  dl $02DF55                                ; $038039 | Boss Explosion
-  dl $02D9B8                                ; $03803C | Key from defeated boss
-  dl $048140                                ; $03803F | Torpedo of Yoshi Submarine
-  dl $04B354                                ; $038042 | Bigger Boo
-  dl $0EDFDE                                ; $038045 | Frog Pirate
-  dl $04832C                                ; $038048 | Flame of Red Watermelon
-  dl $0484C0                                ; $03804B | Bubble
-  dl $04868A                                ; $03804E | Ski lift
-  dl $0488BC                                ; $038051 | Vertical log, floating on lava
-  dl $05CB0B                                ; $038054 | Dr. Freezegood, nothing / 6 stars / 1-up / Bumpty
-  dl $048655                                ; $038057 | Dr. Freezegood, with ski lift
-  dl $0489C0                                ; $03805A | Shy Guy, green / red / yellow / purple
-  dl $0F86EB                                ; $03805D | Rotating Doors
-  dl $0EC987                                ; $038060 | Bandit
-  dl $05C46B                                ; $038063 | ? bucket
-  dl $03B742                                ; $038066 | Flashing Egg
-  dl $03B746                                ; $038069 | Red Egg
-  dl $03B746                                ; $03806C | Yellow Egg
-  dl $03B759                                ; $03806F | Green Egg
-  dl $0DF8EA                                ; $038072 | Giant Egg, for battle with Bowser
-  dl $029FE4                                ; $038075 | Key
-  dl $0EA77F                                ; $038078 | Huffin' Puffin, running away
-  dl $03B759                                ; $03807B | Giant Egg, for battle with Prince Froggy?
-  dl $03B759                                ; $03807E | Red Giant Egg
-  dl $03B759                                ; $038081 | Green Giant Egg
-  dl $0496CC                                ; $038084 | Lunge Fish
-  dl $0681EF                                ; $038087 | Salvo the Slime
-  dl $0692E5                                ; $03808A | Salvo the Slime's eyes
-  dl $0CA07E                                ; $03808D | Little Mouser's Nest
-  dl $0CA21C                                ; $038090 | Little Mouser
-  dl $049BAA                                ; $038093 | Potted Spiked Fun Guy
-  dl $0CA087                                ; $038096 | Little Mouser, looking around, in nest / behind stuff
-  dl $0CA918                                ; $038099 | Little Mouser, from nest
-  dl $02848C                                ; $03809C | Rogger the Potted Ghost
-  dl $0285EA                                ; $03809F | Falling down Rogger the Potted Ghost?
-  dl $02812D                                ; $0380A2 | (BG3) Falling down wall
-  dl $049E15                                ; $0380A5 | Grim Leecher
-  dl $02908D                                ; $0380A8 | Flame spat by Rogger the Potted Ghost
-  dl $0291C3                                ; $0380AB | (BG3) Spinning wooden platform
-  dl $0DB8CA                                ; $0380AE | 3 Mini-Ravens
-  dl $0DB8CA                                ; $0380B1 | Mini-Raven
-  dl $0F9C0B                                ; $0380B4 | Tap-Tap the Red Nose
-  dl $04B11C                                ; $0380B7 | (BG3) Seesaw
-  dl $00878A                                ; $0380BA | Skinny platform
-  dl $068000                                ; $0380BD | Slime
-  dl $0F8D2F                                ; $0380C0 | Baby Luigi
-  dl $0F864B                                ; $0380C3 | Stork
-  dl $02D8C8                                ; $0380C6 | Vertical pipe entrance
-  dl $02CF72                                ; $0380C9 | Red Giant Shy Guy
-  dl $02CF72                                ; $0380CC | Green Giant Shy Guy
-  dl $02C7F4                                ; $0380CF | Prince Froggy, throat / before fight / throat with uvula / after fight
-  dl $069760                                ; $0380D2 | Burt the Bashful
-  dl $0CE5E9                                ; $0380D5 | Shy Guy for Rogger the Potted Ghost
-  dl $0CDB06                                ; $0380D8 | Kamek, for scenes before boss fights
-  dl $04CA61                                ; $0380DB | The head of fire of the Thunder Lakitu
-  dl $04CA61                                ; $0380DE | Fire of Thunder Lakitu
-  dl $04CA61                                ; $0380E1 | Hypocenter of the thunder.
-  dl $0EAAC5                                ; $0380E4 | Upside down Blow Hard
-  dl $029381                                ; $0380E7 | unknown
-  dl $02A0BC                                ; $0380EA | Locked door
-  dl $029383                                ; $0380ED | Middle ring
-  dl $04A197                                ; $0380F0 | (BG3) Board
-  dl $04A31F                                ; $0380F3 | (BG3) Large log
-  dl $05B421                                ; $0380F6 | Balloon
-  dl $0085DC                                ; $0380F9 | Kamek, says \OH MY!!!\""
-  dl $059F9F                                ; $0380FC | Upside down Wild Piranha
-  dl $04C2B8                                ; $0380FF | Green Pinwheel
-  dl $04C2B8                                ; $038102 | Pink Pinwheel
-  dl $06F08F                                ; $038105 | (BG3) Sewer ghost with Flatbed Ferry on its head
-  dl $0EDAFC                                ; $038108 | Green Solo Toady
-  dl $029880                                ; $03810B | Continuous Super Star
-  dl $0FABD7                                ; $03810E | Spark of Raphael the Raven.
-  dl $0ED847                                ; $038111 | Coin Bandit
-  dl $0EDAFC                                ; $038114 | Pink Toadie
-  dl $05FFC4                                ; $038117 | [CRASH]
-  dl $04A4B1                                ; $03811A | (BG3) Plank
-  dl $04A4B1                                ; $03811D | (BG3) Plank
-  dl $0E8002                                ; $038120 | Bomb
-  dl $06BCC8                                ; $038123 | Baby Mario
-  dl $0C8364                                ; $038126 | Goomba
-  dl $05E31D                                ; $038129 | Muddy Buddy
-  dl $04C2A7                                ; $03812C | Pink Pinwheel, (X: direction) (Y: size)
-  dl $0CEA06                                ; $03812F | Red coin
-  dl $059F9F                                ; $038132 | Wild Piranha
-  dl $0F8EAE                                ; $038135 | Hidden Winged Cloud, stars / seed / flower / 1-up
-  dl $0580C4                                ; $038138 | Flashing Egg Block
-  dl $0580C4                                ; $03813B | Red Egg Block
-  dl $0580C4                                ; $03813E | Yellow Egg Block
-  dl $05FE1F                                ; $038141 | Hit green Egg Block
-  dl $0582B5                                ; $038144 | Large Spring Ball
-  dl $0DB2EF                                ; $038147 | Hootie the Blue Fish, clockwise
-  dl $0DB2E9                                ; $03814A | Hootie the Blue Fish, anticlockwise
-  dl $0582F7                                ; $03814D | Spring Ball
-  dl $058627                                ; $038150 | Clawdaddy
-  dl $0CD4F5                                ; $038153 | Big Boo with 3 Boos / Big Boo / Big Boo with 3 Boos / Boo
-  dl $0CF18C                                ; $038156 | Train Bandit
-  dl $0CEFC4                                ; $038159 | (BG3) Balloon Pumper with red balloon
-  dl $04CCB1                                ; $03815C | Spike
-  dl $04CE5E                                ; $03815F | Spiked ball
-  dl $0DAF50                                ; $038162 | Piro Dangle, clockwise
-  dl $0DAF4C                                ; $038165 | Piro Dangle, anticlockwise
-  dl $05D1D7                                ; $038168 | Biting Bullet Bill Blaster
-  dl $05D1D7                                ; $03816B | Bouncing Bullet Bill Blaster
-  dl $05D1D7                                ; $03816E | Bullet Bill Blaster
-  dl $05D661                                ; $038171 | Biting Bullet Bill
-  dl $05D8DA                                ; $038174 | Bouncing Bullet Bill
-  dl $05D664                                ; $038177 | Bullet Bill
-  dl $0295BB                                ; $03817A | Dent of castella
-  dl $04ACB9                                ; $03817D | Log seesaw
-  dl $058CC6                                ; $038180 | Lava Bubble
-  dl $058E1B                                ; $038183 | Lava Bubble, jumps across
-  dl $05917D                                ; $038186 | Chain Chomp
-  dl $04DB19                                ; $038189 | Cloud
-  dl $02A517                                ; $03818C | Teleport sprite
-  dl $01AAE7                                ; $03818F | Harry Hedgehog
-  dl $05FFC4                                ; $038192 | [CRASH]
-  dl $0F90BF                                ; $038195 | Red Egg, gives 1-up
-  dl $029895                                ; $038198 | Super Star
-  dl $04A6AE                                ; $03819B | Red Flatbed Ferry, moving horizontally
-  dl $04A725                                ; $03819E | Pink Flatbed Ferry, moving vertically
-  dl $03E8D0                                ; $0381A1 | Mock Up, green / red
-  dl $02AC75                                ; $0381A4 | Yoshi, at the Goal
-  dl $03ECCB                                ; $0381A7 | Fly Guy, 5 stars / red coin / 1-up / 1-up
-  dl $0DEAD3                                ; $0381AA | Kamek, at Bowser's room
-  dl $05974C                                ; $0381AD | Swing of Grinders
-  dl $06D1A1                                ; $0381B0 | (BG3) Dangling Ghost
-  dl $04D5E9                                ; $0381B3 | 4 Toadies
-  dl $05F97A                                ; $0381B6 | Melon Bug
-  dl $02A125                                ; $0381B9 | Door
-  dl $059B30                                ; $0381BC | Expansion Block
-  dl $059D95                                ; $0381BF | Blue checkered block
-  dl $059D95                                ; $0381C2 | Red checkered block
-  dl $05F5AD                                ; $0381C5 | POW
-  dl $05B6DE                                ; $0381C8 | Yoshi Block
-  dl $0EB1B2                                ; $0381CB | Spiny Egg
-  dl $0E81C0                                ; $0381CE | Chained green Flatbed Ferry
-  dl $04D1C3                                ; $0381D1 | Mace Guy
-  dl $04D2A5                                ; $0381D4 | Mace
-  dl $0EB5DC                                ; $0381D7 | !-switch
-  dl $0EBE94                                ; $0381DA | Chomp Rock
-  dl $05A87C                                ; $0381DD | Wild Ptooie Piranha, spits 1 / 3 Needlenose
-  dl $0CC8E3                                ; $0381E0 | Tulip
-  dl $049CE0                                ; $0381E3 | Pot of Potted Spiked Fun Guy
-  dl $0EB1B2                                ; $0381E6 | Fireball of Thunder Lakitu
-  dl $0EC967                                ; $0381E9 | Bandit, getting under cover, left
-  dl $0EC967                                ; $0381EC | Bandit, getting under cover, right
-  dl $02BF00                                ; $0381EF | Nep-Enut / Gargantua Blargg
-  dl $0E8395                                ; $0381F2 | Incoming Chomp
-  dl $0E83A5                                ; $0381F5 | Flock of Incoming Chomps
-  dl $0E8436                                ; $0381F8 | Falling Incoming Chomp
-  dl $0E8DFE                                ; $0381FB | Shadow of falling Incoming Chomp
-  dl $0086E9                                ; $0381FE | Shy Guy in background
-  dl $029A57                                ; $038201 | Fill Eggs
-  dl $0DFBC1                                ; $038204 | Sign Arrow and Shadow
-  dl $05DA98                                ; $038207 | Hint Block
-  dl $018002                                ; $03820A | Hookbill the Koopa
-  dl $03C183                                ; $03820D | Morph Bubble, Car
-  dl $03C183                                ; $038210 | Morph Bubble, Mole Tank
-  dl $03C183                                ; $038213 | Morph Bubble, Helicopter
-  dl $03C183                                ; $038216 | Morph Bubble, Train
-  dl $039A6B                                ; $038219 | Wind of Fuzzy
-  dl $03C183                                ; $03821C | Morph Bubble, Submarine
-  dl $03C07F                                ; $03821F | Hidden Winged Cloud, 1-up / 5 stars / !-switch / 5 stars
-  dl $03C179                                ; $038222 | Winged Cloud, 8 coins
-  dl $03C179                                ; $038225 | Winged Cloud, bubbled 1-up
-  dl $03C179                                ; $038228 | Winged Cloud, flower
-  dl $03C1C0                                ; $03822B | Winged Cloud, POW
-  dl $03C1C0                                ; $03822E | Winged Cloud, stairs, right / left
-  dl $03C1C0                                ; $038231 | Winged Cloud, platform, right / left
-  dl $03C1C0                                ; $038234 | Winged Cloud, Bandit
-  dl $03C179                                ; $038237 | Winged Cloud, coin (object)
-  dl $03C1A2                                ; $03823A | Winged Cloud, 1-up
-  dl $03C179                                ; $03823D | Winged Cloud, key
-  dl $03C179                                ; $038240 | Winged Cloud, 3 stars
-  dl $03C179                                ; $038243 | Winged Cloud, 5 stars
-  dl $03C1C0                                ; $038246 | Winged Cloud, door
-  dl $03C1C0                                ; $038249 | Winged Cloud, ground eater
-  dl $03C1C0                                ; $03824C | Winged Cloud, watermelon
-  dl $03C1C0                                ; $03824F | Winged Cloud, fire watermelon
-  dl $03C1C0                                ; $038252 | Winged Cloud, icy watermelon
-  dl $03C1C0                                ; $038255 | Winged Cloud, seed of sunflower with 3 leaves
-  dl $03C1C0                                ; $038258 | Winged Cloud, seed of sunflower with 6 leaves
-  dl $03C1C0                                ; $03825B | Winged Cloud, [CRASH]
-  dl $02A09E                                ; $03825E | Boss Door of Bowser's room
-  dl $03C1C4                                ; $038261 | Winged Cloud, random item.
-  dl $03C179                                ; $038264 | Winged Cloud, !-switch / !-switch
-  dl $07F1CB                                ; $038267 | Baron Von Zeppelin, Giant Egg
-  dl $0DFAC2                                ; $03826A | Bowser's flame
-  dl $0DF637                                ; $03826D | Bowser's quake
-  dl $02D926                                ; $038270 | Horizontal entrance, towards right
-  dl $02D8C8                                ; $038273 | Hidden entrance, revealed by an ! switch
-  dl $06AA29                                ; $038276 | Marching Milde
-  dl $0F9328                                ; $038279 | Giant Milde
-  dl $0F98BC                                ; $03827C | Large Milde
-  dl $029B3C                                ; $03827F | Mountain backgrounds at fight with Hookbill the Koopa
-  dl $06E517                                ; $038282 | (BG3) Ghost with Flatbed Ferry on its head
-  dl $02D149                                ; $038285 | Sluggy the Unshaven
-  dl $029C47                                ; $038288 | Chomp signboard.
-  dl $0EF83C                                ; $03828B | Fishin' Lakitu
-  dl $0DBB52                                ; $03828E | Flower pot, key / 6 stars / 6 coins / nothing
-  dl $06E944                                ; $038291 | (BG3) Soft thing
-  dl $0EC8D7                                ; $038294 | Snowball
-  dl $01A248                                ; $038297 | Closer, in Naval Piranha's room
-  dl $029C8B                                ; $03829A | Falling Rock
-  dl $0CCE4D                                ; $03829D | Piscatory Pete, Blue / Gold
-  dl $0CD064                                ; $0382A0 | Preying Mantas
-  dl $0CD122                                ; $0382A3 | Loch Nestor
-  dl $0E8E91                                ; $0382A6 | Boo Blah, normal / upside down
-  dl $0E8E91                                ; $0382A9 | Boo Blah with Piro Dangle, normal / upside down
-  dl $05E0F8                                ; $0382AC | Heading cactus
-  dl $0EB1B2                                ; $0382AF | Green Needlenose
-  dl $01AC8E                                ; $0382B2 | Gusty, left / right / infinite right / infinite left
-  dl $05ABB2                                ; $0382B5 | Burt, two / one
-  dl $0E93E2                                ; $0382B8 | Goonie, right / towards Yoshi / generator right / generator left
-  dl $0E936E                                ; $0382BB | 3 Flightless Goonies
-  dl $06B9DA                                ; $0382BE | Cloud Drop, moving vertically
-  dl $06BB7A                                ; $0382C1 | Cloud Drop, moving horizontally
-  dl $05BE69                                ; $0382C4 | Flamer Guy, jumping around
-  dl $05BE69                                ; $0382C7 | Flamer Guy, walking around
-  dl $05B99F                                ; $0382CA | Eggo-Dil
-  dl $05B9EE                                ; $0382CD | Eggo-Dil's face
-  dl $05BE02                                ; $0382D0 | Petal of Eggo-Dil
-  dl $078000                                ; $0382D3 | Bubble-Plant
-  dl $078540                                ; $0382D6 | Stilt Guy, green / red / yellow / purple
-  dl $0CFB8F                                ; $0382D9 | Woozy Guy, green / red / yellow / purple
-  dl $0780C3                                ; $0382DC | Egg-Plant / Needlenose-Plant
-  dl $0788A7                                ; $0382DF | Slugger
-  dl $0EA472                                ; $0382E2 | Parent and children of Huffin' Puffins
-  dl $0EA131                                ; $0382E5 | Barney Bubble
-  dl $0EAAC5                                ; $0382E8 | Blow Hard
-  dl $0EB1B2                                ; $0382EB | Yellow Needlenose
-  dl $0EB36A                                ; $0382EE | Flower
-  dl $079025                                ; $0382F1 | Spear Guy, long spear
-  dl $07902F                                ; $0382F4 | Spear Guy, short spear
-  dl $07CE9D                                ; $0382F7 | Zeus Guy
-  dl $07D8D4                                ; $0382FA | Energy of Zeus Guy
-  dl $079628                                ; $0382FD | Poochy
-  dl $04C89A                                ; $038300 | Bubbled 1-up
-  dl $0D8002                                ; $038303 | Spiky mace
-  dl $0D8002                                ; $038306 | Spiky mace, double-ended
-  dl $04DAE9                                ; $038309 | Boo Guys spinning spiky mace
-  dl $0CB636                                ; $03830C | Jean de Fillet, right / left
-  dl $0D834D                                ; $03830F | Boo Guys, carrying bombs towards left.
-  dl $0D8352                                ; $038312 | Boo Guys, carrying bombs towards right
-  dl $01AE18                                ; $038315 | Seed of watermelon
-  dl $04CFDD                                ; $038318 | Milde
-  dl $0DC171                                ; $03831B | Tap-Tap
-  dl $0DC171                                ; $03831E | Tap-Tap, stays on ledges
-  dl $0DC171                                ; $038321 | Hopping Tap-Tap
-  dl $0D89FF                                ; $038324 | Chained spike ball, controlled by Boo Guy
-  dl $01AE76                                ; $038327 | Boo Guy, rotating a pulley, right / left
-  dl $0D8E60                                ; $03832A | Crate, 6 stars
-  dl $05DC74                                ; $03832D | Boo Man Bluff
-  dl $0EB54E                                ; $038330 | Flower
-  dl $01A5C9                                ; $038333 | Georgette Jelly
-  dl $01AA9D                                ; $038336 | Splashed Georgette Jelly
-  dl $0793FA                                ; $038339 | Snifit
-  dl $079591                                ; $03833C | Bullet, shot by Snifit
-  dl $04C968                                ; $03833F | Coin, gravity affected
-  dl $04AF9E                                ; $038342 | Floating round platform on water
-  dl $04CB46                                ; $038345 | Donut Lift
-  dl $04CB46                                ; $038348 | Giant Donut Lift
-  dl $05EA0A                                ; $03834B | Spooky
-  dl $079FD0                                ; $03834E | Green Glove
-  dl $07A67A                                ; $038351 | Lakitu, one / two
-  dl $0DBD3B                                ; $038354 | Lakitu's cloud
-  dl $0EB1B2                                ; $038357 | Spiny Egg
-  dl $05F07F                                ; $03835A | Brown Arrow Wheel
-  dl $05F07F                                ; $03835D | Blue Arrow Wheel
-  dl $05F3F0                                ; $038360 | Double-ended arrow lift
-  dl $04CC24                                ; $038363 | Explosion of Number Platform
-  dl $05C46B                                ; $038366 | ? bucket, Bandit
-  dl $05C46B                                ; $038369 | ? bucket, 5 coins
-  dl $0490F1                                ; $03836C | Stretch, green / red / yellow / purple
-  dl $03E3B7                                ; $03836F | Kamek, for the ending scene / flying and chases
-  dl $0D9439                                ; $038372 | Spiked log held by chain and pulley
-  dl $0D9770                                ; $038375 | ? Pulley
-  dl $0DF037                                ; $038378 | Ground shake
-  dl $03F59E                                ; $03837B | Fuzzy
-  dl $0489B3                                ; $03837E | Shy Guy, with Bandit hidden
-  dl $07ADD7                                ; $038381 | Fat Guy, red / green
-  dl $0CF38B                                ; $038384 | Fly Guy carrying red coin / Whirly Fly Guy
-  dl $0CFA4B                                ; $038387 | Yoshi, in the intro scene
-  dl $06B933                                ; $03838A | unknown
-  dl $07AB51                                ; $03838D | Lava Drop, moving horizontally
-  dl $07AC5F                                ; $038390 | Lava Drop, moving vertically
-  dl $02A0D4                                ; $038393 | Locked door
-  dl $0693E6                                ; $038396 | Lemon Drop
-  dl $0489C0                                ; $038399 | Lantern Ghost
-  dl $0DC50C                                ; $03839C | Baby Bowser
-  dl $0D983D                                ; $03839F | Raven, always circling, anticlockwise / clockwise
-  dl $0D983D                                ; $0383A2 | Raven, anticlockwise / clockwise initially
-  dl $029E55                                ; $0383A5 | 3x6 Falling Rock
-  dl $029E55                                ; $0383A8 | 3x3 Falling Rock
-  dl $029E55                                ; $0383AB | 3x9 Falling Rock
-  dl $029E55                                ; $0383AE | 6x3 Falling Rock
-  dl $02D03F                                ; $0383B1 | Stomach Acid
-  dl $0D9A1A                                ; $0383B4 | Flipper, downwards
-  dl $07B052                                ; $0383B7 | Fang, dangling
-  dl $07B1B6                                ; $0383BA | Fang, flying wavily
-  dl $07B28E                                ; $0383BD | Flopsy Fish, swimming around
-  dl $07B28E                                ; $0383C0 | Flopsy Fish, swimming and occasionally jumps vertically
-  dl $05F6DE                                ; $0383C3 | Flopsy Fish, swimming and jumps in an arc
-  dl $05F6DE                                ; $0383C6 | Flopsy Fish, jumps 3 times in an arc, right / left
-  dl $07BE90                                ; $0383C9 | Spray Fish
-  dl $0D9D2E                                ; $0383CC | Flipper, rightwards / leftwards
-  dl $07B6A3                                ; $0383CF | Blue Sluggy, falling down / crawing ceiling
-  dl $07B6AC                                ; $0383D2 | Pink Sluggy, falling down / crawing ceiling but doesn't move
-  dl $02D922                                ; $0383D5 | Horizontal entrance, towards left
-  dl $0582B5                                ; $0383D8 | Large Spring Ball
-  dl $07B9A4                                ; $0383DB | Arrow cloud, up
-  dl $07B9A9                                ; $0383DE | Arrow cloud, up right
-  dl $07B9AE                                ; $0383E1 | Arrow cloud, right
-  dl $07B9B3                                ; $0383E4 | Arrow cloud, down right
-  dl $07B9B8                                ; $0383E7 | Arrow cloud, down
-  dl $07B9BD                                ; $0383EA | Arrow cloud, down left
-  dl $07B9C2                                ; $0383ED | Arrow cloud, left
-  dl $07B9C7                                ; $0383F0 | Arrow cloud, up left
-  dl $07B9EE                                ; $0383F3 | Arrow cloud, rotating
-  dl $07BB20                                ; $0383F6 | Flutter
-  dl $0E942D                                ; $0383F9 | Goonie with Shy Guy
-  dl $0DA097                                ; $0383FC | Shark Chomp
-  dl $0E9A9B                                ; $0383FF | Very Fat Goonie
-  dl $0EB839                                ; $038402 | Cactus Jack, one / three
-  dl $07C2D6                                ; $038405 | Wall Lakitu
-  dl $0E9AA1                                ; $038408 | Bowling Goonie
-  dl $07C6A6                                ; $03840B | Grunt, walking
-  dl $07C6CB                                ; $03840E | Grunt, running
-  dl $07C968                                ; $038411 | Dancing Spear Guy
-  dl $0DA513                                ; $038414 | Green switch for green spiked platform
-  dl $0DA513                                ; $038417 | Red switch for red spiked platform
-  dl $04C244                                ; $03841A | Pink Pinwheel with Shy Guys, clockwise / anticlockwise
-  dl $0DA560                                ; $03841D | Green spiked platform
-  dl $0DA560                                ; $038420 | Red spiked platform
-  dl $0F927C                                ; $038423 | Bonus Item, red coin / key / flower / door
-  dl $0DA8C7                                ; $038426 | Two spiked platforms with one switch in the center
-  dl $0F9111                                ; $038429 | Bouncing green Needlenose
-  dl $0F8B5B                                ; $03842C | Nipper Plant
-  dl $0F8B36                                ; $03842F | Nipper Spore
-  dl $07EB4C                                ; $038432 | Thunder Lakitu, one / two
-  dl $07D956                                ; $038435 | Green Koopa shell
-  dl $07D956                                ; $038438 | Red Koopa shell
-  dl $07DD52                                ; $03843B | Green Beach Koopa
-  dl $07DD52                                ; $03843E | Red Beach Koopa
-  dl $07DD78                                ; $038441 | Green Koopa
-  dl $07DD78                                ; $038444 | Red Koopa
-  dl $07E487                                ; $038447 | Green Para Koopa, jumping forth.
-  dl $07E4D1                                ; $03844A | Red Para Koopa, flying horizontally
-  dl $07E520                                ; $03844D | Red Para Koopa, flying vertically
-  dl $07E7B5                                ; $038450 | Aqua Lakitu
-  dl $02E494                                ; $038453 | Naval Piranha
-  dl $02F37F                                ; $038456 | Naval Bud
-  dl $07F19B                                ; $038459 | Baron Von Zeppelin, red Suy Guy
-  dl $07F196                                ; $03845C | Baron Von Zeppelin, Needlenose
-  dl $07F191                                ; $03845F | Baron Von Zeppelin, bomb
-  dl $07F18C                                ; $038462 | Baron Von Zeppelin, Bandit
-  dl $07F139                                ; $038465 | Baron Von Zeppelin, large Spring Ball
-  dl $07F125                                ; $038468 | Baron Von Zeppelin, 1-up
-  dl $07F11D                                ; $03846B | Baron Von Zeppelin, key
-  dl $07F118                                ; $03846E | Baron Von Zeppelin, 5 coins
-  dl $07F187                                ; $038471 | Baron Von Zeppelin, watermelon
-  dl $07F182                                ; $038474 | Baron Von Zeppelin, fire watermelon
-  dl $07F17D                                ; $038477 | Baron Von Zeppelin, icy watermelon
-  dl $07F1FB                                ; $03847A | Baron Von Zeppelin, crate, 6 stars.
-  dl $07FB24                                ; $03847D | Baron Von Zeppelin
-  dl $0DBA11                                ; $038480 | Spinning Log
-  dl $0F8370                                ; $038483 | Crazee Dayzee
-  dl $0F89F9                                ; $038486 | Dragonfly
-  dl $0F8A93                                ; $038489 | Butterfly
-  dl $0C9306                                ; $03848C | Bumpty
-  dl $04A872                                ; $03848F | Active line guided green Flatbed Ferry, left
-  dl $04A872                                ; $038492 | Active line guided green Flatbed Ferry, right
-  dl $04A872                                ; $038495 | Active line guided yellow Flatbed Ferry, left
-  dl $04A872                                ; $038498 | Active line guided yellow Flatbed Ferry, right
-  dl $04A88A                                ; $03849B | Line guided green Flatbed Ferry, left
-  dl $04A88A                                ; $03849E | Line guided green Flatbed Ferry, right
-  dl $04A88A                                ; $0384A1 | Line guided yellow Flatbed Ferry, left
-  dl $04A88A                                ; $0384A4 | Line guided yellow Flatbed Ferry, right
-  dl $04A88A                                ; $0384A7 | Line guided red Flatbed Ferry, left
-  dl $04A88A                                ; $0384AA | Line guided red Flatbed Ferry, right
-  dl $04AA24                                ; $0384AD | Whirling lift
-  dl $0C800C                                ; $0384B0 | Falling icicle
-  dl $0F8F53                                ; $0384B3 | Sparrow
-  dl $049481                                ; $0384B6 | Muti Guy, green / red / yellow / purple
-  dl $06D9C0                                ; $0384B9 | Caged Ghost, squeezing in sewer
-  dl $0C905A                                ; $0384BC | Blargg
-  dl $0C863E                                ; $0384BF | unknown
-  dl $0C8671                                ; $0384C2 | Unbalanced snowy platform
-  dl $0F899D                                ; $0384C5 | Arrow sign, up / right / left / down
-  dl $0F8972                                ; $0384C8 | Diagonal arrow sign, up left / up right / down left / down right
-  dl $0C88E6                                ; $0384CB | Dizzy Dandy
-  dl $0C8B61                                ; $0384CE | Boo Guy
-  dl $0C970A                                ; $0384D1 | Bumpty, tackles at Yoshi
-  dl $0C99B5                                ; $0384D4 | Flying Bumpty, flying aronnd / flying straightly
-  dl $0C9B6C                                ; $0384D7 | Skeleton Goonie
-  dl $0C9CF3                                ; $0384DA | Flightless Skeleton Goonie
-  dl $0C9D6C                                ; $0384DD | Skeleton Goonie with a bomb
-  dl $0CA00F                                ; $0384E0 | Firebar, double-ended, clockwise / anticlockwise
-  dl $0CA00F                                ; $0384E3 | Firebar, clockwise / anticlockwise
-  dl $0CB530                                ; $0384E6 | Star
-  dl $0CB304                                ; $0384E9 | Little Skull Mouser
-  dl $07FDBF                                ; $0384EC | Cork, seals 3D pipe
-  dl $02AD90                                ; $0384EF | Grinder, runs away
-  dl $02ADF7                                ; $0384F2 | Grinder, spits seeds of watermelon
-  dl $02AE2B                                ; $0384F5 | Short Fuse / Seedy Sally, right / left
-  dl $02AE70                                ; $0384F8 | Grinder, grasps Baby Mario
-  dl $02AE07                                ; $0384FB | Grinder, climbing, spits seeds of watermelon
-  dl $0CB914                                ; $0384FE | Hot Lips
-  dl $0CBE98                                ; $038501 | Boo Balloon, coin / !-switch
-  dl $0F917C                                ; $038504 | Frog
-  dl $0CC369                                ; $038507 | Kamek, shoots magic at Yoshi.
-  dl $0CC796                                ; $03850A | Kamek's magic
-  dl $0CE961                                ; $03850D | Coin
-  dl $0CEB10                                ; $038510 | (BG3) Balloon
-  dl $11B088                                ; $038513 | Coin Cannon for Mini Battle
-  dl $11B23B                                ; $038516 | Coin for Mini Battle
-  dl $11B317                                ; $038519 | Bandit for Mini Battle
-  dl $11A08D                                ; $03851C | Checkered Platform for Mini Battle
-  dl $11A77A                                ; $03851F | Bandit for Mini Battle
-  dl $11A0E6                                ; $038522 | Red Balloon for Mini Battle
-  dl $11BA69                                ; $038525 | Bandit for Mini Battle
-  dl $11C44B                                ; $038528 | Watermelon Pot for Mini Battle
-  dl $11C640                                ; $03852B | possibly Bandit for Mini Battle
+  dl init_floating_log                      ; $038000 | Log, floating on water / lava
+  dl init_closed_door                       ; $038003 | Closed door
+  dl init_naval_piranha_stalk               ; $038006 | Naval Piranha's stalk
+  dl init_crate                             ; $038009 | Crate, key
+  dl init_star_item                         ; $03800C | Item from Star Mario block
+  dl init_melon                             ; $03800F | Icy watermelon
+  dl init_chill                             ; $038012 | Chill
+  dl init_melon                             ; $038015 | Watermelon
+  dl init_rubble                            ; $038018 | Rubble
+  dl init_melon                             ; $03801B | Fire watermelon
+  dl init_kaboomba                          ; $03801E | Kaboomba
+  dl init_cannonball                        ; $038021 | Cannonball of Kaboomba
+  dl init_raphael                           ; $038024 | Raphael the Raven
+  dl init_goal                              ; $038027 | Goal
+  dl init_GOAL_text                         ; $03802A | G O A L !
+  dl init_BONUS                             ; $03802D | BONUS CHALLENGE
+  dl init_caged_ghost_round                 ; $038030 | Caged Ghost, round mound
+  dl init_item_card                         ; $038033 | Item Card
+  dl init_door                              ; $038036 | Boss Door
+  dl init_boss_explosion                    ; $038039 | Boss Explosion
+  dl init_boss_key                          ; $03803C | Key from defeated boss
+  dl init_torpedo                           ; $03803F | Torpedo of Yoshi Submarine
+  dl init_bigger_boo                        ; $038042 | Bigger Boo
+  dl init_frog_pirate                       ; $038045 | Frog Pirate
+  dl init_melon_flame                       ; $038048 | Flame of Red Watermelon
+  dl init_bubble                            ; $03804B | Bubble
+  dl init_ski_lift                          ; $03804E | Ski lift
+  dl init_lava_log                          ; $038051 | Vertical log, floating on lava
+  dl init_freezegood                        ; $038054 | Dr. Freezegood, nothing / 6 stars / 1-up / Bumpty
+  dl init_freezegood_ski_lift               ; $038057 | Dr. Freezegood, with ski lift
+  dl init_shy_guy                           ; $03805A | Shy Guy, green / red / yellow / purple
+  dl init_rotating_doors                    ; $03805D | Rotating Doors
+  dl init_bandit                            ; $038060 | Bandit
+  dl init_bucket                            ; $038063 | ? bucket
+  dl init_flashing_egg                      ; $038066 | Flashing Egg
+  dl init_egg                               ; $038069 | Red Egg
+  dl init_egg                               ; $03806C | Yellow Egg
+  dl init_egg_return                        ; $03806F | Green Egg
+  dl init_baby_bowser_egg                   ; $038072 | Giant Egg, for battle with Bowser
+  dl init_key                               ; $038075 | Key
+  dl init_huffin_puffin_running             ; $038078 | Huffin' Puffin, running away
+  dl init_egg_return                        ; $03807B | Giant Egg, for battle with Prince Froggy?
+  dl init_egg_return                        ; $03807E | Red Giant Egg
+  dl init_egg_return                        ; $038081 | Green Giant Egg
+  dl init_lunge_fish                        ; $038084 | Lunge Fish
+  dl init_salvo                             ; $038087 | Salvo the Slime
+  dl init_salvo_eyes                        ; $03808A | Salvo the Slime's eyes
+  dl init_little_mouser_nest                ; $03808D | Little Mouser's Nest
+  dl init_little_mouser                     ; $038090 | Little Mouser
+  dl init_potted_spiked_guy                 ; $038093 | Potted Spiked Fun Guy
+  dl init_little_mouser_in_nest             ; $038096 | Little Mouser, looking around, in nest / behind stuff
+  dl init_little_mouser_from_nest           ; $038099 | Little Mouser, from nest
+  dl init_roger                             ; $03809C | Rogger the Potted Ghost
+  dl init_roger_2                           ; $03809F | Falling down Rogger the Potted Ghost?
+  dl init_falling_wall                      ; $0380A2 | (BG3) Falling down wall
+  dl init_grim_leecher                      ; $0380A5 | Grim Leecher
+  dl init_roger_flame                       ; $0380A8 | Flame spat by Rogger the Potted Ghost
+  dl init_spinning_wooden_platform          ; $0380AB | (BG3) Spinning wooden platform
+  dl init_mini_raven                        ; $0380AE | 3 Mini-Ravens
+  dl init_mini_raven                        ; $0380B1 | Mini-Raven
+  dl init_tap_tap_the_red_nose              ; $0380B4 | Tap-Tap the Red Nose
+  dl init_seesaw                            ; $0380B7 | (BG3) Seesaw
+  dl init_skinny_platform                   ; $0380BA | Skinny platform
+  dl init_slime                             ; $0380BD | Slime
+  dl init_baby_luigi                        ; $0380C0 | Baby Luigi
+  dl init_stork                             ; $0380C3 | Stork
+  dl init_vertical_entrance                 ; $0380C6 | Vertical pipe entrance
+  dl init_giant_shyguy                      ; $0380C9 | Red Giant Shy Guy
+  dl init_giant_shyguy                      ; $0380CC | Green Giant Shy Guy
+  dl init_prince_froggy                     ; $0380CF | Prince Froggy, throat / before fight / throat with uvula / after fight
+  dl init_burt                              ; $0380D2 | Burt the Bashful
+  dl init_roger_shy_guy                     ; $0380D5 | Shy Guy for Rogger the Potted Ghost
+  dl init_boss_kamek                        ; $0380D8 | Kamek, for scenes before boss fights
+  dl init_thunder_lakitu_fire_stuff         ; $0380DB | The head of fire of the Thunder Lakitu
+  dl init_thunder_lakitu_fire_stuff         ; $0380DE | Fire of Thunder Lakitu
+  dl init_thunder_lakitu_fire_stuff         ; $0380E1 | Hypocenter of the thunder.
+  dl init_blow_hard                         ; $0380E4 | Upside down Blow Hard
+  dl init_unused_4D                         ; $0380E7 | unknown
+  dl init_locked_door                       ; $0380EA | Locked door
+  dl init_middle_ring                       ; $0380ED | Middle ring
+  dl init_board_bg3                         ; $0380F0 | (BG3) Board
+  dl init_large_log_bg3                     ; $0380F3 | (BG3) Large log
+  dl init_balloon                           ; $0380F6 | Balloon
+  dl init_kamek_OH_MY                       ; $0380F9 | Kamek, says \OH MY!!!\""
+  dl init_wild_piranha                      ; $0380FC | Upside down Wild Piranha
+  dl init_pinwheel                          ; $0380FF | Green Pinwheel
+  dl init_pinwheel                          ; $038102 | Pink Pinwheel
+  dl init_platform_ghost_sewer              ; $038105 | (BG3) Sewer ghost with Flatbed Ferry on its head
+  dl init_toadie                            ; $038108 | Green Solo Toady
+  dl init_super_star_continuous             ; $03810B | Continuous Super Star
+  dl init_raph_spark                        ; $03810E | Spark of Raphael the Raven.
+  dl init_coin_bandit                       ; $038111 | Coin Bandit
+  dl init_toadie                            ; $038114 | Pink Toadie
+  dl junk_sprite_pointer                    ; $038117 | [CRASH]
+  dl init_plank_bg3                         ; $03811A | (BG3) Plank
+  dl init_plank_bg3                         ; $03811D | (BG3) Plank
+  dl init_cannonball                        ; $038120 | Bomb
+  dl init_baby_mario                        ; $038123 | Baby Mario
+  dl init_goomba                            ; $038126 | Goomba
+  dl init_muddy_buddy                       ; $038129 | Muddy Buddy
+  dl init_pink_pinwheel                     ; $03812C | Pink Pinwheel, (X: direction) (Y: size)
+  dl init_red_coin                          ; $03812F | Red coin
+  dl init_wild_piranha                      ; $038132 | Wild Piranha
+  dl init_hidden_winged_cloud_A             ; $038135 | Hidden Winged Cloud, stars / seed / flower / 1-up
+  dl init_egg_block                         ; $038138 | Flashing Egg Block
+  dl init_egg_block                         ; $03813B | Red Egg Block
+  dl init_egg_block                         ; $03813E | Yellow Egg Block
+  dl init_hit_green_egg_block               ; $038141 | Hit green Egg Block
+  dl init_large_spring_ball                 ; $038144 | Large Spring Ball
+  dl init_hootie_clockwise                  ; $038147 | Hootie the Blue Fish, clockwise
+  dl init_hootie_anticlockwise              ; $03814A | Hootie the Blue Fish, anticlockwise
+  dl init_spring_ball                       ; $03814D | Spring Ball
+  dl init_clawdaddy                         ; $038150 | Clawdaddy
+  dl init_boo                               ; $038153 | Big Boo with 3 Boos / Big Boo / Big Boo with 3 Boos / Boo
+  dl init_train_bandit                      ; $038156 | Train Bandit
+  dl init_balloon_pumper_red_bg3            ; $038159 | (BG3) Balloon Pumper with red balloon
+  dl init_spike                             ; $03815C | Spike
+  dl init_spiked_ball                       ; $03815F | Spiked ball
+  dl init_piro_dangle_clockwise             ; $038162 | Piro Dangle, clockwise
+  dl init_piro_dangle_anticlockwise         ; $038165 | Piro Dangle, anticlockwise
+  dl init_bullet_bill_blaster               ; $038168 | Biting Bullet Bill Blaster
+  dl init_bullet_bill_blaster               ; $03816B | Bouncing Bullet Bill Blaster
+  dl init_bullet_bill_blaster               ; $03816E | Bullet Bill Blaster
+  dl init_biting_bullet_bill                ; $038171 | Biting Bullet Bill
+  dl init_bouncing_bullet_bill              ; $038174 | Bouncing Bullet Bill
+  dl init_bullet_bill                       ; $038177 | Bullet Bill
+  dl init_invisible_slime_platform          ; $03817A | Dent of castella
+  dl init_log_seesaw                        ; $03817D | Log seesaw
+  dl init_lava_bubble                       ; $038180 | Lava Bubble
+  dl init_lava_bubble_arcing                ; $038183 | Lava Bubble, jumps across
+  dl init_chain_chomp                       ; $038186 | Chain Chomp
+  dl init_cloud                             ; $038189 | Cloud
+  dl init_teleport_sprite                   ; $03818C | Teleport sprite
+  dl init_hedgehog                          ; $03818F | Harry Hedgehog
+  dl junk_sprite_pointer                    ; $038192 | [CRASH]
+  dl init_red_1up_egg                       ; $038195 | Red Egg, gives 1-up
+  dl init_super_star                        ; $038198 | Super Star
+  dl init_red_platform                      ; $03819B | Red Flatbed Ferry, moving horizontally
+  dl init_pink_platform                     ; $03819E | Pink Flatbed Ferry, moving vertically
+  dl init_inflating_balloon                 ; $0381A1 | Mock Up, green / red
+  dl init_yoshi_at_goal                     ; $0381A4 | Yoshi, at the Goal
+  dl init_flyguy                            ; $0381A7 | Fly Guy, 5 stars / red coin / 1-up / 1-up
+  dl init_bowser_room_kamek                 ; $0381AA | Kamek, at Bowser's room
+  dl init_swing_of_grinders                 ; $0381AD | Swing of Grinders
+  dl init_dangling_ghost                    ; $0381B0 | (BG3) Dangling Ghost
+  dl init_4_toadies                         ; $0381B3 | 4 Toadies
+  dl init_melon_bug                         ; $0381B6 | Melon Bug
+  dl init_door                              ; $0381B9 | Door
+  dl init_expansion_block                   ; $0381BC | Expansion Block
+  dl init_checkered_block                   ; $0381BF | Blue checkered block
+  dl init_checkered_block                   ; $0381C2 | Red checkered block
+  dl init_POW                               ; $0381C5 | POW
+  dl init_yoshi_block                       ; $0381C8 | Yoshi Block
+  dl init_green_needlenose                  ; $0381CB | Spiny Egg
+  dl init_flatbed_ferry_green               ; $0381CE | Chained green Flatbed Ferry
+  dl init_mace_guy                          ; $0381D1 | Mace Guy
+  dl init_mace                              ; $0381D4 | Mace
+  dl init_red_pow_switch                    ; $0381D7 | !-switch
+  dl init_chomp_rock                        ; $0381DA | Chomp Rock
+  dl init_wild_ptooie_piranha               ; $0381DD | Wild Ptooie Piranha, spits 1 / 3 Needlenose
+  dl init_tulip                             ; $0381E0 | Tulip
+  dl init_pot_of_potted_spiked_guy          ; $0381E3 | Pot of Potted Spiked Fun Guy
+  dl init_green_needlenose                  ; $0381E6 | Fireball of Thunder Lakitu
+  dl init_bandit_under_cover                ; $0381E9 | Bandit, getting under cover, left
+  dl init_bandit_under_cover                ; $0381EC | Bandit, getting under cover, right
+  dl init_nep_enut                          ; $0381EF | Nep-Enut / Gargantua Blargg
+  dl init_incoming_chomp                    ; $0381F2 | Incoming Chomp
+  dl init_incoming_chomp_flock              ; $0381F5 | Flock of Incoming Chomps
+  dl init_incoming_chomp_falling            ; $0381F8 | Falling Incoming Chomp
+  dl init_incoming_chomp_falling_shadow     ; $0381FB | Shadow of falling Incoming Chomp
+  dl init_background_shyguy                 ; $0381FE | Shy Guy in background
+  dl init_full_eggs                         ; $038201 | Fill Eggs
+  dl Return_0DFBC1                          ; $038204 | Sign Arrow and Shadow
+  dl init_hint_block                        ; $038207 | Hint Block
+  dl init_hookbill                          ; $03820A | Hookbill the Koopa
+  dl init_transform_bubble                  ; $03820D | Morph Bubble, Car
+  dl init_transform_bubble                  ; $038210 | Morph Bubble, Mole Tank
+  dl init_transform_bubble                  ; $038213 | Morph Bubble, Helicopter
+  dl init_transform_bubble                  ; $038216 | Morph Bubble, Train
+  dl Return_039A6B                          ; $038219 | Wind of Fuzzy
+  dl init_transform_bubble                  ; $03821C | Morph Bubble, Submarine
+  dl init_special_winged_cloud              ; $03821F | Hidden Winged Cloud, 1-up / 5 stars / !-switch / 5 stars
+  dl init_winged_cloud_A                    ; $038222 | Winged Cloud, 8 coins
+  dl init_winged_cloud_A                    ; $038225 | Winged Cloud, bubbled 1-up
+  dl init_winged_cloud_A                    ; $038228 | Winged Cloud, flower
+  dl init_winged_cloud_B                    ; $03822B | Winged Cloud, POW
+  dl init_winged_cloud_B                    ; $03822E | Winged Cloud, stairs, right / left
+  dl init_winged_cloud_B                    ; $038231 | Winged Cloud, platform, right / left
+  dl init_winged_cloud_B                    ; $038234 | Winged Cloud, Bandit
+  dl init_winged_cloud_A                    ; $038237 | Winged Cloud, coin (object)
+  dl init_winged_cloud_1up                  ; $03823A | Winged Cloud, 1-up
+  dl init_winged_cloud_A                    ; $03823D | Winged Cloud, key
+  dl init_winged_cloud_A                    ; $038240 | Winged Cloud, 3 stars
+  dl init_winged_cloud_A                    ; $038243 | Winged Cloud, 5 stars
+  dl init_winged_cloud_B                    ; $038246 | Winged Cloud, door
+  dl init_winged_cloud_B                    ; $038249 | Winged Cloud, ground eater
+  dl init_winged_cloud_B                    ; $03824C | Winged Cloud, watermelon
+  dl init_winged_cloud_B                    ; $03824F | Winged Cloud, fire watermelon
+  dl init_winged_cloud_B                    ; $038252 | Winged Cloud, icy watermelon
+  dl init_winged_cloud_B                    ; $038255 | Winged Cloud, seed of sunflower with 3 leaves
+  dl init_winged_cloud_B                    ; $038258 | Winged Cloud, seed of sunflower with 6 leaves
+  dl init_winged_cloud_B                    ; $03825B | Winged Cloud, [CRASH]
+  dl init_boss_door_bowser                  ; $03825E | Boss Door of Bowser's room
+  dl init_winged_cloud_item                 ; $038261 | Winged Cloud, random item.
+  dl init_winged_cloud_A                    ; $038264 | Winged Cloud, !-switch / !-switch
+  dl init_bvz_giant_egg                     ; $038267 | Baron Von Zeppelin, Giant Egg
+  dl init_bowser_flame                      ; $03826A | Bowser's flame
+  dl init_bowser_quake                      ; $03826D | Bowser's quake
+  dl init_horizontal_entrance_right         ; $038270 | Horizontal entrance, towards right
+  dl init_vertical_entrance                 ; $038273 | Hidden entrance, revealed by an ! switch
+  dl init_marching_milde                    ; $038276 | Marching Milde
+  dl init_giant_milde                       ; $038279 | Giant Milde
+  dl init_large_milde                       ; $03827C | Large Milde
+  dl init_hookbill_background               ; $03827F | Mountain backgrounds at fight with Hookbill the Koopa
+  dl init_platform_ghost                    ; $038282 | (BG3) Ghost with Flatbed Ferry on its head
+  dl init_sluggy_unshaven                   ; $038285 | Sluggy the Unshaven
+  dl init_chomp_signboard                   ; $038288 | Chomp signboard.
+  dl init_fishin_lakitu                     ; $03828B | Fishin' Lakitu
+  dl init_flower_pot                        ; $03828E | Flower pot, key / 6 stars / 6 coins / nothing
+  dl init_soft_thing                        ; $038291 | (BG3) Soft thing
+  dl init_snowball                          ; $038294 | Snowball
+  dl init_boss_closer                       ; $038297 | Closer, in Naval Piranha's room
+  dl init_falling_rock                      ; $03829A | Falling Rock
+  dl init_piscatory_pete                    ; $03829D | Piscatory Pete, Blue / Gold
+  dl init_preying_mantas                    ; $0382A0 | Preying Mantas
+  dl init_loch_nestor                       ; $0382A3 | Loch Nestor
+  dl init_boo_blah                          ; $0382A6 | Boo Blah, normal / upside down
+  dl init_boo_blah                          ; $0382A9 | Boo Blah with Piro Dangle, normal / upside down
+  dl init_heading_cactus                    ; $0382AC | Heading cactus
+  dl init_green_needlenose                  ; $0382AF | Green Needlenose
+  dl init_gusty                             ; $0382B2 | Gusty, left / right / infinite right / infinite left
+  dl init_small_burt                        ; $0382B5 | Burt, two / one
+  dl init_goonie                            ; $0382B8 | Goonie, right / towards Yoshi / generator right / generator left
+  dl init_flightless_goonie                 ; $0382BB | 3 Flightless Goonies
+  dl init_cloud_drop_vertical               ; $0382BE | Cloud Drop, moving vertically
+  dl init_cloud_drop_horizontal             ; $0382C1 | Cloud Drop, moving horizontally
+  dl init_flamer_guy                        ; $0382C4 | Flamer Guy, jumping around
+  dl init_flamer_guy                        ; $0382C7 | Flamer Guy, walking around
+  dl init_eggo_dil                          ; $0382CA | Eggo-Dil
+  dl init_eggo_dil_face                     ; $0382CD | Eggo-Dil's face
+  dl init_eggo_dil_petal                    ; $0382D0 | Petal of Eggo-Dil
+  dl init_bubble_plant                      ; $0382D3 | Bubble-Plant
+  dl init_stilt_guy                         ; $0382D6 | Stilt Guy, green / red / yellow / purple
+  dl init_woozy_guy                         ; $0382D9 | Woozy Guy, green / red / yellow / purple
+  dl init_egg_plant                         ; $0382DC | Egg-Plant / Needlenose-Plant
+  dl init_slugger                           ; $0382DF | Slugger
+  dl init_parent_huffin_puffin              ; $0382E2 | Parent and children of Huffin' Puffins
+  dl init_barney_bubble                     ; $0382E5 | Barney Bubble
+  dl init_blow_hard                         ; $0382E8 | Blow Hard
+  dl init_green_needlenose                  ; $0382EB | Yellow Needlenose
+  dl init_flower                            ; $0382EE | Flower
+  dl init_spear_guy_long                    ; $0382F1 | Spear Guy, long spear
+  dl init_spear_guy_short                   ; $0382F4 | Spear Guy, short spear
+  dl init_zeus_guy                          ; $0382F7 | Zeus Guy
+  dl init_zeus_guy_energy                   ; $0382FA | Energy of Zeus Guy
+  dl init_poochy                            ; $0382FD | Poochy
+  dl init_bubbled_1_up                      ; $038300 | Bubbled 1-up
+  dl init_spiky_mace                        ; $038303 | Spiky mace
+  dl init_spiky_mace                        ; $038306 | Spiky mace, double-ended
+  dl init_spiky_mace_boo_guys               ; $038309 | Boo Guys spinning spiky mace
+  dl init_jean_de_fillet                    ; $03830C | Jean de Fillet, right / left
+  dl init_boo_guys_carrying_bombs_left      ; $03830F | Boo Guys, carrying bombs towards left.
+  dl init_boo_guys_carrying_bombs_right     ; $038312 | Boo Guys, carrying bombs towards right
+  dl init_watermelon_seed                   ; $038315 | Seed of watermelon
+  dl init_milde                             ; $038318 | Milde
+  dl init_tap_tap                           ; $03831B | Tap-Tap
+  dl init_tap_tap                           ; $03831E | Tap-Tap, stays on ledges
+  dl init_tap_tap                           ; $038321 | Hopping Tap-Tap
+  dl init_chained_spike_ball                ; $038324 | Chained spike ball, controlled by Boo Guy
+  dl init_pulley_guy                        ; $038327 | Boo Guy, rotating a pulley, right / left
+  dl init_crate                             ; $03832A | Crate, 6 stars
+  dl init_boo_man_bluff                     ; $03832D | Boo Man Bluff
+  dl init_flower_2                          ; $038330 | Flower
+  dl init_flan                              ; $038333 | Georgette Jelly
+  dl init_splashed_flan                     ; $038336 | Splashed Georgette Jelly
+  dl init_snifit                            ; $038339 | Snifit
+  dl init_snifit_bullet                     ; $03833C | Bullet, shot by Snifit
+  dl init_coin_with_gravity                 ; $03833F | Coin, gravity affected
+  dl init_water_platform                    ; $038342 | Floating round platform on water
+  dl init_donut_lift                        ; $038345 | Donut Lift
+  dl init_donut_lift                        ; $038348 | Giant Donut Lift
+  dl init_spooky                            ; $03834B | Spooky
+  dl init_green_glove                       ; $03834E | Green Glove
+  dl init_lakitu                            ; $038351 | Lakitu, one / two
+  dl init_lakitu_cloud                      ; $038354 | Lakitu's cloud
+  dl init_green_needlenose                  ; $038357 | Spiny Egg
+  dl init_arrow_wheel                       ; $03835A | Brown Arrow Wheel
+  dl init_arrow_wheel                       ; $03835D | Blue Arrow Wheel
+  dl init_double_ended_arrow_lift           ; $038360 | Double-ended arrow lift
+  dl init_number_platform_explosion         ; $038363 | Explosion of Number Platform
+  dl init_bucket                            ; $038366 | ? bucket, Bandit
+  dl init_bucket                            ; $038369 | ? bucket, 5 coins
+  dl init_stretch                           ; $03836C | Stretch, green / red / yellow / purple
+  dl init_kamek                             ; $03836F | Kamek, for the ending scene / flying and chases
+  dl init_spiked_log                        ; $038372 | Spiked log held by chain and pulley
+  dl init_pulley                            ; $038375 | ? Pulley
+  dl Return_0DF037                          ; $038378 | Ground shake
+  dl init_fuzzy                             ; $03837B | Fuzzy
+  dl main_shy_guy_bandit                    ; $03837E | Shy Guy, with Bandit hidden
+  dl init_fat_guy                           ; $038381 | Fat Guy, red / green
+  dl init_fly_guy                           ; $038384 | Fly Guy carrying red coin / Whirly Fly Guy
+  dl init_yoshi_in_intro_cutscene           ; $038387 | Yoshi, in the intro scene
+  dl init_12E                               ; $03838A | unknown
+  dl init_lava_drop_horizontal              ; $03838D | Lava Drop, moving horizontally
+  dl init_lava_drop_vertical                ; $038390 | Lava Drop, moving vertically
+  dl init_locked_door_2                     ; $038393 | Locked door
+  dl init_lemon_drop                        ; $038396 | Lemon Drop
+  dl init_shy_guy                           ; $038399 | Lantern Ghost
+  dl init_baby_bowser                       ; $03839C | Baby Bowser
+  dl init_small_raven                       ; $03839F | Raven, always circling, anticlockwise / clockwise
+  dl init_small_raven                       ; $0383A2 | Raven, anticlockwise / clockwise initially
+  dl init_falling_rock_common               ; $0383A5 | 3x6 Falling Rock
+  dl init_falling_rock_common               ; $0383A8 | 3x3 Falling Rock
+  dl init_falling_rock_common               ; $0383AB | 3x9 Falling Rock
+  dl init_falling_rock_common               ; $0383AE | 6x3 Falling Rock
+  dl init_froggy_stomach_acid               ; $0383B1 | Stomach Acid
+  dl init_flipper_downwards                 ; $0383B4 | Flipper, downwards
+  dl init_fang_dangling                     ; $0383B7 | Fang, dangling
+  dl init_fang_flying                       ; $0383BA | Fang, flying wavily
+  dl init_flopsy_fish                       ; $0383BD | Flopsy Fish, swimming around
+  dl init_flopsy_fish                       ; $0383C0 | Flopsy Fish, swimming and occasionally jumps vertically
+  dl init_flopsy_fish_jumps                 ; $0383C3 | Flopsy Fish, swimming and jumps in an arc
+  dl init_flopsy_fish_jumps                 ; $0383C6 | Flopsy Fish, jumps 3 times in an arc, right / left
+  dl init_spray_fish                        ; $0383C9 | Spray Fish
+  dl init_flipper_left_and_right            ; $0383CC | Flipper, rightwards / leftwards
+  dl init_blue_sluggy                       ; $0383CF | Blue Sluggy, falling down / crawing ceiling
+  dl init_pink_sluggy                       ; $0383D2 | Pink Sluggy, falling down / crawing ceiling but doesn't move
+  dl init_horizontal_entrance_left          ; $0383D5 | Horizontal entrance, towards left
+  dl init_large_spring_ball                 ; $0383D8 | Large Spring Ball
+  dl init_arrow_cloud_up                    ; $0383DB | Arrow cloud, up
+  dl init_arrow_cloud_up_right              ; $0383DE | Arrow cloud, up right
+  dl init_arrow_cloud_right                 ; $0383E1 | Arrow cloud, right
+  dl init_arrow_cloud_down_right            ; $0383E4 | Arrow cloud, down right
+  dl init_arrow_cloud_down                  ; $0383E7 | Arrow cloud, down
+  dl init_arrow_cloud_down_left             ; $0383EA | Arrow cloud, down left
+  dl init_arrow_cloud_left                  ; $0383ED | Arrow cloud, left
+  dl init_arrow_cloud_up_left               ; $0383F0 | Arrow cloud, up left
+  dl init_arrow_cloud_rotating              ; $0383F3 | Arrow cloud, rotating
+  dl init_flutter                           ; $0383F6 | Flutter
+  dl CODE_0E942D                            ; $0383F9 | Goonie with Shy Guy
+  dl init_shark_chomp                       ; $0383FC | Shark Chomp
+  dl init_fat_goonie                        ; $0383FF | Very Fat Goonie
+  dl init_cactus_jack                       ; $038402 | Cactus Jack, one / three
+  dl init_wall_lakitu                       ; $038405 | Wall Lakitu
+  dl init_bowling_goonie                    ; $038408 | Bowling Goonie
+  dl init_grunt_walking                     ; $03840B | Grunt, walking
+  dl init_grunt_running                     ; $03840E | Grunt, running
+  dl init_spear_guy_dancing                 ; $038411 | Dancing Spear Guy
+  dl init_spiked_platform_switch            ; $038414 | Green switch for green spiked platform
+  dl init_spiked_platform_switch            ; $038417 | Red switch for red spiked platform
+  dl init_pink_pinwheel_with_shyguys        ; $03841A | Pink Pinwheel with Shy Guys, clockwise / anticlockwise
+  dl init_spiked_platform                   ; $03841D | Green spiked platform
+  dl init_spiked_platform                   ; $038420 | Red spiked platform
+  dl init_bonus_sprite                      ; $038423 | Bonus Item, red coin / key / flower / door
+  dl init_two_spiked_platforms_with_switch  ; $038426 | Two spiked platforms with one switch in the center
+  dl init_bouncing_green_needlenose         ; $038429 | Bouncing green Needlenose
+  dl init_nipper_plant                      ; $03842C | Nipper Plant
+  dl init_nipper_spore                      ; $03842F | Nipper Spore
+  dl init_thunder_lakitu                    ; $038432 | Thunder Lakitu, one / two
+  dl init_koopa_shell                       ; $038435 | Green Koopa shell
+  dl init_koopa_shell                       ; $038438 | Red Koopa shell
+  dl init_beach_koopa                       ; $03843B | Green Beach Koopa
+  dl init_beach_koopa                       ; $03843E | Red Beach Koopa
+  dl init_koopa                             ; $038441 | Green Koopa
+  dl init_koopa                             ; $038444 | Red Koopa
+  dl init_green_parakoopa                   ; $038447 | Green Para Koopa, jumping forth.
+  dl init_red_parakoopa_horizontal          ; $03844A | Red Para Koopa, flying horizontally
+  dl init_red_parakoopa_vertical            ; $03844D | Red Para Koopa, flying vertically
+  dl init_aqua_lakitu                       ; $038450 | Aqua Lakitu
+  dl init_naval_piranha                     ; $038453 | Naval Piranha
+  dl init_naval_bud                         ; $038456 | Naval Bud
+  dl init_bvz_red_shy_guy                   ; $038459 | Baron Von Zeppelin, red Suy Guy
+  dl init_bvz_needlenose                    ; $03845C | Baron Von Zeppelin, Needlenose
+  dl init_bvz_bomb                          ; $03845F | Baron Von Zeppelin, bomb
+  dl init_bvz_bandit                        ; $038462 | Baron Von Zeppelin, Bandit
+  dl init_bvz_large_spring_ball             ; $038465 | Baron Von Zeppelin, large Spring Ball
+  dl init_bvz_1_up                          ; $038468 | Baron Von Zeppelin, 1-up
+  dl init_bvz_key                           ; $03846B | Baron Von Zeppelin, key
+  dl init_bvz_5_coins                       ; $03846E | Baron Von Zeppelin, 5 coins
+  dl init_bvz_watermelon                    ; $038471 | Baron Von Zeppelin, watermelon
+  dl init_bvz_fire_watermelon               ; $038474 | Baron Von Zeppelin, fire watermelon
+  dl init_bvz_icy_watermelon                ; $038477 | Baron Von Zeppelin, icy watermelon
+  dl init_bvz_crate_with_6_stars            ; $03847A | Baron Von Zeppelin, crate, 6 stars.
+  dl init_bvz                               ; $03847D | Baron Von Zeppelin
+  dl init_spinning_log                      ; $038480 | Spinning Log
+  dl init_crazee_dayzee                     ; $038483 | Crazee Dayzee
+  dl init_dragonfly                         ; $038486 | Dragonfly
+  dl init_butterfly                         ; $038489 | Butterfly
+  dl init_bumpty                            ; $03848C | Bumpty
+  dl init_line_guided_platform              ; $03848F | Active line guided green Flatbed Ferry, left
+  dl init_line_guided_platform              ; $038492 | Active line guided green Flatbed Ferry, right
+  dl init_line_guided_platform              ; $038495 | Active line guided yellow Flatbed Ferry, left
+  dl init_line_guided_platform              ; $038498 | Active line guided yellow Flatbed Ferry, right
+  dl init_line_guide_platform_inactive      ; $03849B | Line guided green Flatbed Ferry, left
+  dl init_line_guide_platform_inactive      ; $03849E | Line guided green Flatbed Ferry, right
+  dl init_line_guide_platform_inactive      ; $0384A1 | Line guided yellow Flatbed Ferry, left
+  dl init_line_guide_platform_inactive      ; $0384A4 | Line guided yellow Flatbed Ferry, right
+  dl init_line_guide_platform_inactive      ; $0384A7 | Line guided red Flatbed Ferry, left
+  dl init_line_guide_platform_inactive      ; $0384AA | Line guided red Flatbed Ferry, right
+  dl init_whirling_lift                     ; $0384AD | Whirling lift
+  dl init_falling_icicle                    ; $0384B0 | Falling icicle
+  dl init_sparrow                           ; $0384B3 | Sparrow
+  dl init_mufti_guy                         ; $0384B6 | Muti Guy, green / red / yellow / purple
+  dl init_caged_ghost_sewer                 ; $0384B9 | Caged Ghost, squeezing in sewer
+  dl init_blargg                            ; $0384BC | Blargg
+  dl init_unknown                           ; $0384BF | unknown
+  dl init_unbalanced_snowy_platform         ; $0384C2 | Unbalanced snowy platform
+  dl init_arrow_sign                        ; $0384C5 | Arrow sign, up / right / left / down
+  dl init_diagonal_arrow_sign               ; $0384C8 | Diagonal arrow sign, up left / up right / down left / down right
+  dl init_dizzy_dandy                       ; $0384CB | Dizzy Dandy
+  dl init_boo_guy                           ; $0384CE | Boo Guy
+  dl init_bumpty_tackling                   ; $0384D1 | Bumpty, tackles at Yoshi
+  dl init_bumpty_flying                     ; $0384D4 | Flying Bumpty, flying aronnd / flying straightly
+  dl init_skeleton_goonie                   ; $0384D7 | Skeleton Goonie
+  dl init_skeleton_goonie_flightless        ; $0384DA | Flightless Skeleton Goonie
+  dl init_skeleton_goonie_with_bomb         ; $0384DD | Skeleton Goonie with a bomb
+  dl init_firebar                           ; $0384E0 | Firebar, double-ended, clockwise / anticlockwise
+  dl init_firebar                           ; $0384E3 | Firebar, clockwise / anticlockwise
+  dl init_star                              ; $0384E6 | Star
+  dl init_little_skill_mouser               ; $0384E9 | Little Skull Mouser
+  dl init_cork                              ; $0384EC | Cork, seals 3D pipe
+  dl init_grinder_runs_away                 ; $0384EF | Grinder, runs away
+  dl init_grinder_spits_seeds               ; $0384F2 | Grinder, spits seeds of watermelon
+  dl init_seedy_sally                       ; $0384F5 | Short Fuse / Seedy Sally, right / left
+  dl init_grinder_grabs_baby_mario          ; $0384F8 | Grinder, grasps Baby Mario
+  dl init_grinder_spits_seeds_climbing      ; $0384FB | Grinder, climbing, spits seeds of watermelon
+  dl init_hot_lips                          ; $0384FE | Hot Lips
+  dl init_boo_balloon                       ; $038501 | Boo Balloon, coin / !-switch
+  dl init_frog                              ; $038504 | Frog
+  dl init_kamek_shoots_magic                ; $038507 | Kamek, shoots magic at Yoshi.
+  dl init_kamek_magic                       ; $03850A | Kamek's magic
+  dl init_coin                              ; $03850D | Coin
+  dl init_balloon_bg3                       ; $038510 | (BG3) Balloon
+  dl init_coin_cannon                       ; $038513 | Coin Cannon for Mini Battle
+  dl init_mini_battle_coin                  ; $038516 | Coin for Mini Battle
+  dl init_mini_battle_bandit                ; $038519 | Bandit for Mini Battle
+  dl init_mini_battle_checkered_platform    ; $03851C | Checkered Platform for Mini Battle
+  dl init_mini_battle_bandit_2              ; $03851F | Bandit for Mini Battle
+  dl init_mini_battle_red_balloon           ; $038522 | Red Balloon for Mini Battle
+  dl init_mini_battle_bandit_3              ; $038525 | Bandit for Mini Battle
+  dl init_mini_battle_watermelon_pot        ; $038528 | Watermelon Pot for Mini Battle
+  dl init_mini_battle_bandit_4              ; $03852B | possibly Bandit for Mini Battle
 ; end init routine table
 
 ; sprite main routine table: $852E - 8A5B
 sprite_mains:
-  dl $02E26A                                ; $03852E | Log, floating on water / lava
-  dl $02A330                                ; $038531 | Closed door
-  dl $02F912                                ; $038534 | Naval Piranha's stalk
-  dl $0D8EBE                                ; $038537 | Crate, key
-  dl $02AD0A                                ; $03853A | Item from Star Mario block
-  dl $048031                                ; $03853D | Icy watermelon
-  dl $048429                                ; $038540 | Chill
-  dl $048031                                ; $038543 | Watermelon
-  dl $0DFB94                                ; $038546 | Rubble
-  dl $048031                                ; $038549 | Fire watermelon
-  dl $03F331                                ; $03854C | Kaboomba
-  dl $0E8019                                ; $03854F | Cannonball of Kaboomba
-  dl $0FAD27                                ; $038552 | Raphael the Raven
-  dl $02A617                                ; $038555 | Goal
-  dl $0F8019                                ; $038558 | G O A L !
-  dl $0F8174                                ; $03855B | BONUS CHALLENGE
-  dl $06E047                                ; $03855E | Caged Ghost, round mound
-  dl $11C9A0                                ; $038561 | Item Card
-  dl $02A330                                ; $038564 | Boss Door
-  dl $02DF7A                                ; $038567 | Boss Explosion
-  dl $02DA0E                                ; $03856A | Key from defeated boss
-  dl $04816B                                ; $03856D | Torpedo of Yoshi Submarine
-  dl $04B4EA                                ; $038570 | Bigger Boo
-  dl $0EE023                                ; $038573 | Frog Pirate
-  dl $04833D                                ; $038576 | Flame of Red Watermelon
-  dl $04850D                                ; $038579 | Bubble
-  dl $048707                                ; $03857C | Ski lift
-  dl $0488DC                                ; $03857F | Vertical log, floating on lava
-  dl $05CB64                                ; $038582 | Dr. Freezegood, nothing / 6 stars / 1-up / Bumpty
-  dl $048707                                ; $038585 | Dr. Freezegood, with ski lift
-  dl $048A58                                ; $038588 | Shy Guy, green / red / yellow / purple
-  dl $0F8797                                ; $03858B | Rotating Doors
-  dl $0EC9AD                                ; $03858E | Bandit
-  dl $05C8B6                                ; $038591 | ? bucket
-  dl $03B86E                                ; $038594 | Flashing Egg
-  dl $03B872                                ; $038597 | Red Egg
-  dl $03B872                                ; $03859A | Yellow Egg
-  dl $03B872                                ; $03859D | Green Egg
-  dl $0DF8FB                                ; $0385A0 | Giant Egg, for battle with Bowser
-  dl $02A04A                                ; $0385A3 | Key
-  dl $0EA792                                ; $0385A6 | Huffin' Puffin, running away
-  dl $03B7B4                                ; $0385A9 | Giant Egg, for battle with Prince Froggy?
-  dl $03B872                                ; $0385AC | Red Giant Egg
-  dl $03B872                                ; $0385AF | Green Giant Egg
-  dl $0496FA                                ; $0385B2 | Lunge Fish
-  dl $0683CA                                ; $0385B5 | Salvo the Slime
-  dl $0692E6                                ; $0385B8 | Salvo the Slime's eyes
-  dl $0CA082                                ; $0385BB | Little Mouser's Nest
-  dl $0CA2C7                                ; $0385BE | Little Mouser
-  dl $049C0A                                ; $0385C1 | Potted Spiked Fun Guy
-  dl $0CA0B4                                ; $0385C4 | Little Mouser, looking around, in nest / behind stuff
-  dl $0CA98E                                ; $0385C7 | Little Mouser, from nest
-  dl $0284F6                                ; $0385CA | Rogger the Potted Ghost
-  dl $0285EB                                ; $0385CD | Falling down Rogger the Potted Ghost?
-  dl $028209                                ; $0385D0 | (BG3) Falling down wall
-  dl $049E30                                ; $0385D3 | Grim Leecher
-  dl $0290E6                                ; $0385D6 | Flame spat by Rogger the Potted Ghost
-  dl $029235                                ; $0385D9 | (BG3) Spinning wooden platform
-  dl $0DB918                                ; $0385DC | 3 Mini-Ravens
-  dl $0DB918                                ; $0385DF | Mini-Raven
-  dl $0F9C58                                ; $0385E2 | Tap-Tap the Red Nose
-  dl $04B15B                                ; $0385E5 | (BG3) Seesaw
-  dl $00878E                                ; $0385E8 | Skinny platform
-  dl $0683CA                                ; $0385EB | Slime
-  dl $0F8DB1                                ; $0385EE | Baby Luigi
-  dl $0F865F                                ; $0385F1 | Stork
-  dl $02D8E7                                ; $0385F4 | Vertical pipe entrance
-  dl $02CFA6                                ; $0385F7 | Red Giant Shy Guy
-  dl $02CFA6                                ; $0385FA | Green Giant Shy Guy
-  dl $02C950                                ; $0385FD | Prince Froggy, throat / before fight / throat with uvula / after fight
-  dl $0699DC                                ; $038600 | Burt the Bushful
-  dl $0CE658                                ; $038603 | Shy Guy for Rogger the Potted Ghost
-  dl $0CDB6C                                ; $038606 | Kamek, for scenes before boss fights
-  dl $04CA62                                ; $038609 | The head of fire of the Thunder Lakitu
-  dl $04CAFE                                ; $03860C | Fire of Thunder Lakitu
-  dl $04CAFE                                ; $03860F | Hypocenter of the thunder.
-  dl $0EAAF0                                ; $038612 | Upside down Blow Hard
-  dl $029382                                ; $038615 | unknown
-  dl $02A330                                ; $038618 | Locked door
-  dl $02938E                                ; $03861B | Middle ring
-  dl $04A1B4                                ; $03861E | (BG3) Board
-  dl $04A342                                ; $038621 | (BG3) Large log
-  dl $05B4CC                                ; $038624 | Balloon
-  dl $0085E5                                ; $038627 | Kamek, says \OH MY!!!\""
-  dl $059FE6                                ; $03862A | Upside down Wild Piranha
-  dl $04C2F6                                ; $03862D | Green Pinwheel
-  dl $04C2F6                                ; $038630 | Pink Pinwheel
-  dl $06F0C2                                ; $038633 | (BG3) Sewer ghost with Flatbed Ferry on its head
-  dl $0EDB40                                ; $038636 | Green Solo Toady
-  dl $0298F4                                ; $038639 | Continuous Super Star
-  dl $0FABE5                                ; $03863C | Spark of Raphael the Raven.
-  dl $0ED8B9                                ; $03863F | Coin Bandit
-  dl $0EDB40                                ; $038642 | Pink Toadie
-  dl $05FFC4                                ; $038645 | [CRASH]
-  dl $04A4D5                                ; $038648 | (BG3) Plank
-  dl $04A4D5                                ; $03864B | (BG3) Plank
-  dl $0E8023                                ; $03864E | Bomb
-  dl $06BCEC                                ; $038651 | Baby Mario
-  dl $0C8369                                ; $038654 | Goomba
-  dl $05E346                                ; $038657 | Muddy Buddy
-  dl $04C2F6                                ; $03865A | Pink Pinwheel, (X: direction) (Y: size)
-  dl $0CEA40                                ; $03865D | Red coin
-  dl $059FE6                                ; $038660 | Wild Piranha
-  dl $0F8EEB                                ; $038663 | Hidden Winged Cloud, stars / seed / flower / 1-up
-  dl $0580DD                                ; $038666 | Flashing Egg Block
-  dl $0580E1                                ; $038669 | Red Egg Block
-  dl $0580E1                                ; $03866C | Yellow Egg Block
-  dl $05FE6E                                ; $03866F | Hit green Egg Block
-  dl $058325                                ; $038672 | Large Spring Ball
-  dl $0DB316                                ; $038675 | Hootie the Blue Fish, clockwise
-  dl $0DB316                                ; $038678 | Hootie the Blue Fish, anticlockwise
-  dl $058320                                ; $03867B | Spring Ball
-  dl $058648                                ; $03867E | Clawdaddy
-  dl $0CD545                                ; $038681 | Big Boo with 3 Boos / Big Boo / Big Boo with 3 Boos / Boo
-  dl $0CF1D5                                ; $038684 | Train Bandit
-  dl $0CF005                                ; $038687 | (BG3) Balloon Pumper with red balloon
-  dl $04CCD3                                ; $03868A | Spike
-  dl $04CE70                                ; $03868D | Spiked ball
-  dl $0DAF7E                                ; $038690 | Piro Dangle, clockwise
-  dl $0DAF7E                                ; $038693 | Piro Dangle, anticlockwise
-  dl $05D246                                ; $038696 | Biting Bullet Bill Blaster
-  dl $05D246                                ; $038699 | Bouncing Bullet Bill Blaster
-  dl $05D246                                ; $03869C | Bullet Bill Blaster
-  dl $05D665                                ; $03869F | Biting Bullet Bill
-  dl $05D8E6                                ; $0386A2 | Bouncing Bullet Bill
-  dl $05D6ED                                ; $0386A5 | Bullet Bill
-  dl $0295D3                                ; $0386A8 | Dent of castella
-  dl $04ACD3                                ; $0386AB | Log seesaw
-  dl $058CDA                                ; $0386AE | Lava Bubble
-  dl $058CDA                                ; $0386B1 | Lava Bubble, jumps across
-  dl $0591DA                                ; $0386B4 | Chain Chomp
-  dl $04DB2B                                ; $0386B7 | Cloud
-  dl $02A518                                ; $0386BA | Teleport sprite
-  dl $01AAEC                                ; $0386BD | Harry Hedgehog
-  dl $05FFC4                                ; $0386C0 | [CRASH]
-  dl $0F90C0                                ; $0386C3 | Red Egg, gives 1-up
-  dl $0298F4                                ; $0386C6 | Super Star
-  dl $04A6F8                                ; $0386C9 | Red Flatbed Ferry, moving horizontally
-  dl $04A752                                ; $0386CC | Pink Flatbed Ferry, moving vertically
-  dl $03E925                                ; $0386CF | Mock Up, green / red
-  dl $02AC86                                ; $0386D2 | Yoshi, at the Goal
-  dl $03ED20                                ; $0386D5 | Fly Guy, 5 stars / red coin / 1-up / 1-up
-  dl $0DEB70                                ; $0386D8 | Kamek, at Bowser's room
-  dl $059775                                ; $0386DB | Swing of Grinders
-  dl $06D1C7                                ; $0386DE | (BG3) Dangling Ghost
-  dl $04D5FC                                ; $0386E1 | 4 Toadies
-  dl $05F981                                ; $0386E4 | Melon Bug
-  dl $02A330                                ; $0386E7 | Door
-  dl $059B4E                                ; $0386EA | Expansion Block
-  dl $059DBC                                ; $0386ED | Blue checkered block
-  dl $059DBC                                ; $0386F0 | Red checkered block
-  dl $05F5D2                                ; $0386F3 | POW
-  dl $05B75A                                ; $0386F6 | Yoshi Block
-  dl $0EB1B3                                ; $0386F9 | Spiny Egg
-  dl $0E81D1                                ; $0386FC | Chained green Flatbed Ferry
-  dl $04D20C                                ; $0386FF | Mace Guy
-  dl $04D2B1                                ; $038702 | Mace
-  dl $0EB601                                ; $038705 | !-switch
-  dl $0EBED5                                ; $038708 | Chomp Rock
-  dl $05A8B3                                ; $03870B | Wild Ptooie Piranha, spits 1 / 3 Needlenose
-  dl $0CC91D                                ; $03870E | Tulip
-  dl $049CE5                                ; $038711 | Pot of Potted Spiked Fun Guy
-  dl $0EB1BE                                ; $038714 | Fireball of Thunder Lakitu
-  dl $0EC9AD                                ; $038717 | Bandit, getting under cover, left
-  dl $0EC9AD                                ; $03871A | Bandit, getting under cover, right
-  dl $02BF91                                ; $03871D | Nep-Enut / Gargantua Blargg
-  dl $0E8456                                ; $038720 | Incoming Chomp
-  dl $0E8BE4                                ; $038723 | Flcok of Incoming Chomps
-  dl $0E8456                                ; $038726 | Falling Incoming Chomp
-  dl $0E8E08                                ; $038729 | Shadow of falling Incoming Chomp
-  dl $00872A                                ; $03872C | Shy Guy in background
-  dl $029A58                                ; $03872F | Fill Eggs
-  dl $0DFBC2                                ; $038732 | Sign Arrow and Shadow
-  dl $05DAC3                                ; $038735 | Hint Block
-  dl $018A14                                ; $038738 | Hookbill the Koopa
-  dl $03C2BF                                ; $03873B | Morph Bubble, Car
-  dl $03C2BF                                ; $03873E | Morph Bubble, Mole Tank
-  dl $03C2BF                                ; $038741 | Morph Bubble, Helicopter
-  dl $03C2BF                                ; $038744 | Morph Bubble, Train
-  dl $039F4E                                ; $038747 | Wind of Fuzzy
-  dl $03C2BF                                ; $03874A | Morph Bubble, Submarine
-  dl $03C08C                                ; $03874D | Hidden Winged Cloud, 1-up / 5 stars / !-switch / 5 stars
-  dl $03C2BF                                ; $038750 | Winged Cloud, 8 coins
-  dl $03C2BF                                ; $038753 | Winged Cloud, bubbled 1-up
-  dl $03C2BF                                ; $038756 | Winged Cloud, flower
-  dl $03C2BF                                ; $038759 | Winged Cloud, POW
-  dl $03C2BF                                ; $03875C | Winged Cloud, stairs, right / left
-  dl $03C2BF                                ; $03875F | Winged Cloud, platform, right / left
-  dl $03C2BF                                ; $038762 | Winged Cloud, Bandit
-  dl $03C2BF                                ; $038765 | Winged Cloud, coin (object)
-  dl $03C2BF                                ; $038768 | Winged Cloud, 1-up
-  dl $03C2BF                                ; $03876B | Winged Cloud, key
-  dl $03C2BF                                ; $03876E | Winged Cloud, 3 stars
-  dl $03C2BF                                ; $038771 | Winged Cloud, 5 stars
-  dl $03C2BF                                ; $038774 | Winged Cloud, door
-  dl $03C2BF                                ; $038777 | Winged Cloud, ground eater
-  dl $03C2BF                                ; $03877A | Winged Cloud, watermelon
-  dl $03C2BF                                ; $03877D | Winged Cloud, fire watermelon
-  dl $03C2BF                                ; $038780 | Winged Cloud, icy watermelon
-  dl $03C2BF                                ; $038783 | Winged Cloud, seed of sunflower with 3 leaves
-  dl $03C2BF                                ; $038786 | Winged Cloud, seed of sunflower with 6 leaves
-  dl $03C2BF                                ; $038789 | Winged Cloud, [CRASH]
-  dl $02A330                                ; $03878C | Boss Door of Bowser's room
-  dl $03C2BF                                ; $03878F | Winged Cloud, random item.
-  dl $03C2BF                                ; $038792 | Winged Cloud, !-switch / !-switch
-  dl $07F2F1                                ; $038795 | Baron Von Zeppelin, Giant Egg
-  dl $0DFB1D                                ; $038798 | Bowser's flame
-  dl $0DF6FE                                ; $03879B | Bowser's quake
-  dl $02D95C                                ; $03879E | Horizontal entrance, towards right
-  dl $02D8DE                                ; $0387A1 | Hidden entrance, revealed by an ! switch
-  dl $06AA8B                                ; $0387A4 | Marching Milde
-  dl $0F933F                                ; $0387A7 | Giant Milde
-  dl $0F98BD                                ; $0387AA | Large Milde
-  dl $029B45                                ; $0387AD | Mountain backgrounds at fight with Hookbill the Koopa
-  dl $06E530                                ; $0387B0 | (BG3) Ghost with Flatbed Ferry on its head
-  dl $02D195                                ; $0387B3 | Sluggy the Unshaven
-  dl $029C87                                ; $0387B6 | Chomp signboard.
-  dl $0EF86F                                ; $0387B9 | Fishin' Lakitu
-  dl $0DBB80                                ; $0387BC | Flower pot, key / 6 stars / 6 coins / nothing
-  dl $06E961                                ; $0387BF | (BG3) Soft thing
-  dl $0EC8F2                                ; $0387C2 | Snowball
-  dl $01A2D5                                ; $0387C5 | Closer, in Naval Piranha's room
-  dl $029CEB                                ; $0387C8 | Falling Rock
-  dl $0CCE83                                ; $0387CB | Piscatory Pete, Blue / Gold
-  dl $0CD093                                ; $0387CE | Preying Mantas
-  dl $0CD154                                ; $0387D1 | Loch Nestor
-  dl $0E8F79                                ; $0387D4 | Boo Blah, normal / upside down
-  dl $0E8F79                                ; $0387D7 | Boo Blah with Piro Dangle, normal / upside down
-  dl $05E13D                                ; $0387DA | Heading cactus
-  dl $0EB1B3                                ; $0387DD | Green Needlenose
-  dl $01AD17                                ; $0387E0 | Gusty, left / right / infinite right / infinite left
-  dl $05ACAE                                ; $0387E3 | Burt, two / one
-  dl $0E951E                                ; $0387E6 | Goonie, right / towards Yoshi / generator right / generator left
-  dl $0E951E                                ; $0387E9 | 3 Flightless Goonies
-  dl $06BA33                                ; $0387EC | Cloud Drop, moving vertically
-  dl $06BBD3                                ; $0387EF | Cloud Drop, moving horizontally
-  dl $05BEB2                                ; $0387F2 | Flamer Guy, jumping around
-  dl $05BEB2                                ; $0387F5 | Flamer Guy, walking around
-  dl $05B9C8                                ; $0387F8 | Eggo-Dil
-  dl $05B9FC                                ; $0387FB | Eggo-Dil's face
-  dl $05BE03                                ; $0387FE | Petal of Eggo-Dil
-  dl $078020                                ; $038801 | Bubble-Plant
-  dl $07858F                                ; $038804 | Stilt Guy, green / red / yellow / purple
-  dl $0CFC37                                ; $038807 | Woozy Guy, green / red / yellow / purple
-  dl $0780F3                                ; $03880A | Egg-Plant / Needlenose-Plant
-  dl $0788D3                                ; $03880D | Slugger
-  dl $0EA4F5                                ; $038810 | Parent and children of Huffin' Puffins
-  dl $0EA140                                ; $038813 | Barney Bubble
-  dl $0EAAF0                                ; $038816 | Blow Hard
-  dl $0EB1B3                                ; $038819 | Yellow Needlenose
-  dl $0EB3AC                                ; $03881C | Flower
-  dl $079090                                ; $03881F | Spear Guy, long spear
-  dl $079090                                ; $038822 | Spear Guy, short spear
-  dl $07CEB0                                ; $038825 | Zeus Guy
-  dl $07D8F3                                ; $038828 | Energy of Zeus Guy
-  dl $079635                                ; $03882B | Poochy
-  dl $04C89B                                ; $03882E | Bubbled 1-up
-  dl $0D8031                                ; $038831 | Spiky mace
-  dl $0D8031                                ; $038834 | Spiky mace, double-ended
-  dl $04DAF6                                ; $038837 | Boo Guys spinning spiky mace
-  dl $0CB6AC                                ; $03883A | Jean de Fillet, right / left
-  dl $0D84AB                                ; $03883D | Boo Guys, carrying bombs towards left.
-  dl $0D84AB                                ; $038840 | Boo Guys, carrying bombs towards right
-  dl $01AE19                                ; $038843 | Seed of watermelon
-  dl $04CFF9                                ; $038846 | Milde
-  dl $0DC1A5                                ; $038849 | Tap-Tap
-  dl $0DC1A5                                ; $03884C | Tap-Tap, stays on ledges
-  dl $0DC1A5                                ; $03884F | Hopping Tap-Tap
-  dl $0D8AF1                                ; $038852 | Chained spike ball, controlled by Boo Guy
-  dl $01AE95                                ; $038855 | Boo Guy, rotating a pulley, right / left
-  dl $0D8EBE                                ; $038858 | Crate, 6 stars
-  dl $05DCBE                                ; $03885B | Boo Man Bluff
-  dl $0EB55F                                ; $03885E | Flower
-  dl $01A5EC                                ; $038861 | Georgette Jelly
-  dl $01AA9E                                ; $038864 | Splashed Georgette Jelly
-  dl $079410                                ; $038867 | Snifit
-  dl $07959B                                ; $03886A | Bullet, shot by Snifit
-  dl $04C97B                                ; $03886D | Coin, gravity affected
-  dl $04AFC0                                ; $038870 | Floating round platform on water
-  dl $04CB7C                                ; $038873 | Donut Lift
-  dl $04CB7C                                ; $038876 | Giant Donut Lift
-  dl $05EA2B                                ; $038879 | Spooky
-  dl $079FDC                                ; $03887C | Green Glove
-  dl $07A702                                ; $03887F | Lakitu, one / two
-  dl $0DBD50                                ; $038882 | Lakitu's cloud
-  dl $0EB1B3                                ; $038885 | Spiny Egg
-  dl $05F09F                                ; $038888 | Brown Arrow Wheel
-  dl $05F09F                                ; $03888B | Blue Arrow Wheel
-  dl $05F436                                ; $03888E | Double-ended arrow lift
-  dl $04CC45                                ; $038891 | Explosion of Number Platform
-  dl $05C4AD                                ; $038894 | ? bucket, Bandit
-  dl $05C4AD                                ; $038897 | ? bucket, 5 coins
-  dl $049147                                ; $03889A | Stretch, green / red / yellow / purple
-  dl $03E409                                ; $03889D | Kamek, for the ending scene / flying and chases
-  dl $0D94F5                                ; $0388A0 | Spiked log held by chain and pulley
-  dl $0D9771                                ; $0388A3 | ? Pulley
-  dl $0DF038                                ; $0388A6 | Ground shake
-  dl $03F5B7                                ; $0388A9 | Fuzzy
-  dl $048A58                                ; $0388AC | Shy Guy, with Bandit hidden
-  dl $07AE68                                ; $0388AF | Fat Guy, red / green
-  dl $0CF42B                                ; $0388B2 | Fly Guy carrying red coin / Whirly Fly Guy
-  dl $0CFA6E                                ; $0388B5 | Yoshi, in the intro scene
-  dl $06B950                                ; $0388B8 | unknown
-  dl $07AB9C                                ; $0388BB | Lava Drop, moving horizontally
-  dl $07ACD2                                ; $0388BE | Lava Drop, moving vertically
-  dl $02A330                                ; $0388C1 | Locked door
-  dl $069401                                ; $0388C4 | Lemon Drop
-  dl $048A58                                ; $0388C7 | Lantern Ghost
-  dl $0DC55B                                ; $0388CA | Baby Bowser
-  dl $0D9879                                ; $0388CD | Raven, always circling, anticlockwise / clockwise
-  dl $0D9879                                ; $0388D0 | Raven, anticlockwise / clockwise initially
-  dl $029E8F                                ; $0388D3 | 3x6 Falling Rock
-  dl $029E8F                                ; $0388D6 | 3x3 Falling Rock
-  dl $029E8F                                ; $0388D9 | 3x9 Falling Rock
-  dl $029E8F                                ; $0388DC | 6x3 Falling Rock
-  dl $02D040                                ; $0388DF | Stomach Acid
-  dl $0D9A25                                ; $0388E2 | Flipper, downwards
-  dl $07B059                                ; $0388E5 | Fang, dangling
-  dl $07B1FC                                ; $0388E8 | Fang, flying wavily
-  dl $07B2F3                                ; $0388EB | Flopsy Fish, swimming around
-  dl $07B310                                ; $0388EE | Flopsy Fish, swimming and occasionally jumps vertically
-  dl $05F74E                                ; $0388F1 | Flopsy Fish, swimming and jumps in an arc
-  dl $05F74E                                ; $0388F4 | Flopsy Fish, jumps 3 times in an arc, right / left
-  dl $07BEFC                                ; $0388F7 | Spray Fish
-  dl $0D9D49                                ; $0388FA | Flipper, rightwards / leftwards
-  dl $07B6DC                                ; $0388FD | Blue Sluggy, falling down / crawing ceiling
-  dl $07B6DC                                ; $038900 | Pink Sluggy, falling down / crawing ceiling but doesn't move
-  dl $02D95C                                ; $038903 | Horizontal entrance, towards left
-  dl $058325                                ; $038906 | Large Spring Ball
-  dl $07BA31                                ; $038909 | Arrow cloud, up
-  dl $07BA31                                ; $03890C | Arrow cloud, up right
-  dl $07BA31                                ; $03890F | Arrow cloud, right
-  dl $07BA31                                ; $038912 | Arrow cloud, down right
-  dl $07BA31                                ; $038915 | Arrow cloud, down
-  dl $07BA31                                ; $038918 | Arrow cloud, down left
-  dl $07BA31                                ; $03891B | Arrow cloud, left
-  dl $07BA31                                ; $03891E | Arrow cloud, up left
-  dl $07BA3D                                ; $038921 | Arrow cloud, rotating
-  dl $07BB61                                ; $038924 | Flutter
-  dl $0E951E                                ; $038927 | Goonie with Shy Guy
-  dl $0DA0FE                                ; $03892A | Shark Chomp
-  dl $0E9B38                                ; $03892D | Very Fat Goonie
-  dl $0EB92E                                ; $038930 | Cactus Jack, one / three
-  dl $07C344                                ; $038933 | Wall Lakitu
-  dl $0E9B38                                ; $038936 | Bowling Goonie
-  dl $07C6EC                                ; $038939 | Grunt, walking
-  dl $07C700                                ; $03893C | Grunt, running
-  dl $07C9C8                                ; $03893F | Dancing Spear Guy
-  dl $0DA527                                ; $038942 | Green switch for green spiked platform
-  dl $0DA527                                ; $038945 | Red switch for red spiked platform
-  dl $04C2F6                                ; $038948 | Pink Pinwheel with Shy Guys, clockwise / anticlockwise
-  dl $0DA5BA                                ; $03894B | Green spiked platform
-  dl $0DA5BA                                ; $03894E | Red spiked platform
-  dl $0F92A1                                ; $038951 | Bonus Item, red coin / key / flower / door
-  dl $0DA8F1                                ; $038954 | Two spiked platforms with one switch in the center
-  dl $0F9116                                ; $038957 | Bouncing green Needlenose
-  dl $0F8BA9                                ; $03895A | Nipper Plant
-  dl $0F8B8D                                ; $03895D | Nipper Spore
-  dl $07EBAE                                ; $038960 | Thunder Lakitu, one / two
-  dl $07D964                                ; $038963 | Green Koopa shell
-  dl $07D964                                ; $038966 | Red Koopa shell
-  dl $07DDA1                                ; $038969 | Green Beach Koopa
-  dl $07DDA1                                ; $03896C | Red Beach Koopa
-  dl $07DDD9                                ; $03896F | Green Koopa
-  dl $07DDD9                                ; $038972 | Red Koopa
-  dl $07E55A                                ; $038975 | Green Para Koopa, jumping forth.
-  dl $07E5D9                                ; $038978 | Red Para Koopa, flying horizontally
-  dl $07E64F                                ; $03897B | Red Para Koopa, flying vertically
-  dl $07E7D6                                ; $03897E | Aqua Lakitu
-  dl $02E57F                                ; $038981 | Naval Piranha
-  dl $02F3A4                                ; $038984 | Naval Bud
-  dl $07F2B2                                ; $038987 | Baron Von Zeppelin, red Suy Guy
-  dl $07F2B2                                ; $03898A | Baron Von Zeppelin, Needlenose
-  dl $07F2B2                                ; $03898D | Baron Von Zeppelin, bomb
-  dl $07F2B2                                ; $038990 | Baron Von Zeppelin, Bandit
-  dl $07F2D1                                ; $038993 | Baron Von Zeppelin, large Spring Ball
-  dl $07F333                                ; $038996 | Baron Von Zeppelin, 1-up
-  dl $07F333                                ; $038999 | Baron Von Zeppelin, key
-  dl $07F333                                ; $03899C | Baron Von Zeppelin, 5 coins
-  dl $07F2F1                                ; $03899F | Baron Von Zeppelin, watermelon
-  dl $07F2F1                                ; $0389A2 | Baron Von Zeppelin, fire watermelon
-  dl $07F310                                ; $0389A5 | Baron Von Zeppelin, icy watermelon
-  dl $07F391                                ; $0389A8 | Baron Von Zeppelin, crate, 6 stars.
-  dl $07FB3D                                ; $0389AB | Baron Von Zeppelin
-  dl $0DBA26                                ; $0389AE | Spinning Log
-  dl $0F839E                                ; $0389B1 | Crazee Dayzee
-  dl $0F8A17                                ; $0389B4 | Dragonfly
-  dl $0F8AE9                                ; $0389B7 | Butterfly
-  dl $0C930E                                ; $0389BA | Bumpty
-  dl $04A8B8                                ; $0389BD | Active line guided green Flatbed Ferry, left
-  dl $04A8B8                                ; $0389C0 | Active line guided green Flatbed Ferry, right
-  dl $04A8B8                                ; $0389C3 | Active line guided yellow Flatbed Ferry, left
-  dl $04A8B8                                ; $0389C6 | Active line guided yellow Flatbed Ferry, right
-  dl $04A8B8                                ; $0389C9 | Line guided green Flatbed Ferry, left
-  dl $04A8B8                                ; $0389CC | Line guided green Flatbed Ferry, right
-  dl $04A8B8                                ; $0389CF | Line guided yellow Flatbed Ferry, left
-  dl $04A8B8                                ; $0389D2 | Line guided yellow Flatbed Ferry, right
-  dl $04A8B8                                ; $0389D5 | Line guided red Flatbed Ferry, left
-  dl $04A8B8                                ; $0389D8 | Line guided red Flatbed Ferry, right
-  dl $04AA32                                ; $0389DB | Whirling lift
-  dl $0C8016                                ; $0389DE | Falling icicle
-  dl $0F8F64                                ; $0389E1 | Sparrow
-  dl $049490                                ; $0389E4 | Mufti Guy, green / red / yellow / purple
-  dl $06D9CD                                ; $0389E7 | Caged Ghost, squeezing in sewer
-  dl $0C9080                                ; $0389EA | Blargg
-  dl $0C86BD                                ; $0389ED | unknown
-  dl $0C87D1                                ; $0389F0 | Unbalanced snowy platform
-  dl $0F89E4                                ; $0389F3 | Arrow sign, up / right / left / down
-  dl $0F89E4                                ; $0389F6 | Diagonal arrow sign, up left / up right / down left / down right
-  dl $0C890B                                ; $0389F9 | Dizzy Dandy
-  dl $0C8BAF                                ; $0389FC | Boo Guy
-  dl $0C971D                                ; $0389FF | Bumpty, tackles at Yoshi
-  dl $0C9A13                                ; $038A02 | Flying Bumpty, flying aronnd / flying straightly
-  dl $0C9B8A                                ; $038A05 | Skeleton Goonie
-  dl $0C9CFD                                ; $038A08 | Flightless Skeleton Goonie
-  dl $0C9DF4                                ; $038A0B | Skeleton Goonie with a bomb
-  dl $0CA03C                                ; $038A0E | Firebar, double-ended, clockwise / anticlockwise
-  dl $0CA03C                                ; $038A11 | Firebar, clockwise / anticlockwise
-  dl $0CB537                                ; $038A14 | Star
-  dl $0CB36A                                ; $038A17 | Little Skull Mouser
-  dl $07FDE4                                ; $038A1A | Cork, seals 3D pipe
-  dl $02AF11                                ; $038A1D | Grinder, runs away
-  dl $02AF11                                ; $038A20 | Grinder, spits seeds of watermelon
-  dl $02AF11                                ; $038A23 | Short Fuse / Seedy Sally, right / left
-  dl $02AF11                                ; $038A26 | Grinder, grasps Baby Mario
-  dl $02AF11                                ; $038A29 | Grinder, climbing, spits seeds of watermelon
-  dl $0CBA2C                                ; $038A2C | Hot Lips
-  dl $0CBED6                                ; $038A2F | Boo Balloon, coin / !-switch
-  dl $0F918C                                ; $038A32 | Frog
-  dl $0CC39B                                ; $038A35 | Kamek, shoots magic at Yoshi.
-  dl $0CC797                                ; $038A38 | Kamek's magic
-  dl $0CE98B                                ; $038A3B | Coin
-  dl $0CEBBA                                ; $038A3E | (BG3) Balloon
-  dl $11B125                                ; $038A41 | Coin Cannon for Mini Battle
-  dl $11B24D                                ; $038A44 | Coin for Mini Battle
-  dl $11B32A                                ; $038A47 | Bandit for Mini Battle
-  dl $11A111                                ; $038A4A | Checkered Platform for Mini Battle
-  dl $11A790                                ; $038A4D | Bandit for Mini Battle
-  dl $11A175                                ; $038A50 | Red Balloon for Mini Battle
-  dl $11BB10                                ; $038A53 | Bandit for Mini Battle
-  dl $11C460                                ; $038A56 | Watermelon Pot for Mini Battle
-  dl $11C679                                ; $038A59 | possibly Bandit for Mini Battle
+  dl main_log                               ; $03852E | Log, floating on water / lava
+  dl main_door                              ; $038531 | Closed door
+  dl main_naval_piranha_stalk               ; $038534 | Naval Piranha's stalk
+  dl main_crate                             ; $038537 | Crate, key
+  dl main_star_item                         ; $03853A | Item from Star Mario block
+  dl main_melon                             ; $03853D | Icy watermelon
+  dl main_chill                             ; $038540 | Chill
+  dl main_melon                             ; $038543 | Watermelon
+  dl main_rubble                            ; $038546 | Rubble
+  dl main_melon                             ; $038549 | Fire watermelon
+  dl main_kaboomba                          ; $03854C | Kaboomba
+  dl main_cannonball                        ; $03854F | Cannonball of Kaboomba
+  dl main_raphael                           ; $038552 | Raphael the Raven
+  dl main_goal                              ; $038555 | Goal
+  dl main_GOAL_text                         ; $038558 | G O A L !
+  dl main_BONUS                             ; $03855B | BONUS CHALLENGE
+  dl main_caged_ghost_round                 ; $03855E | Caged Ghost, round mound
+  dl main_item_card                         ; $038561 | Item Card
+  dl main_door                              ; $038564 | Boss Door
+  dl main_boss_explosion                    ; $038567 | Boss Explosion
+  dl main_boss_key                          ; $03856A | Key from defeated boss
+  dl main_torpedo                           ; $03856D | Torpedo of Yoshi Submarine
+  dl main_bigger_boo                        ; $038570 | Bigger Boo
+  dl main_frog_pirate                       ; $038573 | Frog Pirate
+  dl main_melon_flame                       ; $038576 | Flame of Red Watermelon
+  dl main_bubble                            ; $038579 | Bubble
+  dl main_ski_lift                          ; $03857C | Ski lift
+  dl main_lava_log                          ; $03857F | Vertical log, floating on lava
+  dl main_freezegood                        ; $038582 | Dr. Freezegood, nothing / 6 stars / 1-up / Bumpty
+  dl main_ski_lift                          ; $038585 | Dr. Freezegood, with ski lift
+  dl main_shy_guy                           ; $038588 | Shy Guy, green / red / yellow / purple
+  dl main_rotating_doors                    ; $03858B | Rotating Doors
+  dl main_bandit                            ; $03858E | Bandit
+  dl main_bucket                            ; $038591 | ? bucket
+  dl main_flashing_egg                      ; $038594 | Flashing Egg
+  dl main_egg                               ; $038597 | Red Egg
+  dl main_egg                               ; $03859A | Yellow Egg
+  dl main_egg                               ; $03859D | Green Egg
+  dl main_baby_bowser_egg                   ; $0385A0 | Giant Egg, for battle with Bowser
+  dl main_key                               ; $0385A3 | Key
+  dl main_huffin_puffin_running             ; $0385A6 | Huffin' Puffin, running away
+  dl main_giant_egg_frog                    ; $0385A9 | Giant Egg, for battle with Prince Froggy?
+  dl main_egg                               ; $0385AC | Red Giant Egg
+  dl main_egg                               ; $0385AF | Green Giant Egg
+  dl main_lunge_fish                        ; $0385B2 | Lunge Fish
+  dl main_salvo                             ; $0385B5 | Salvo the Slime
+  dl main_salvo_eyes                        ; $0385B8 | Salvo the Slime's eyes
+  dl main_little_mouser_nest                ; $0385BB | Little Mouser's Nest
+  dl main_little_mouser                     ; $0385BE | Little Mouser
+  dl main_potted_spiked_guy                 ; $0385C1 | Potted Spiked Fun Guy
+  dl main_little_mouser_in_nest             ; $0385C4 | Little Mouser, looking around, in nest / behind stuff
+  dl main_little_mouser_from_nest           ; $0385C7 | Little Mouser, from nest
+  dl main_roger                             ; $0385CA | Rogger the Potted Ghost
+  dl main_roger_2                           ; $0385CD | Falling down Rogger the Potted Ghost?
+  dl main_falling_wall                      ; $0385D0 | (BG3) Falling down wall
+  dl main_grim_leecher                      ; $0385D3 | Grim Leecher
+  dl main_roger_flame                       ; $0385D6 | Flame spat by Rogger the Potted Ghost
+  dl main_spinning_wooden_platform          ; $0385D9 | (BG3) Spinning wooden platform
+  dl main_mini_raven                        ; $0385DC | 3 Mini-Ravens
+  dl main_mini_raven                        ; $0385DF | Mini-Raven
+  dl main_tap_tap_the_red_nose              ; $0385E2 | Tap-Tap the Red Nose
+  dl main_seesaw                            ; $0385E5 | (BG3) Seesaw
+  dl main_skinny_platform                   ; $0385E8 | Skinny platform
+  dl main_salvo                             ; $0385EB | Slime
+  dl main_baby_luigi                        ; $0385EE | Baby Luigi
+  dl main_stork                             ; $0385F1 | Stork
+  dl main_vertical_entrance                 ; $0385F4 | Vertical pipe entrance
+  dl main_giant_shyguy                      ; $0385F7 | Red Giant Shy Guy
+  dl main_giant_shyguy                      ; $0385FA | Green Giant Shy Guy
+  dl main_prince_froggy                     ; $0385FD | Prince Froggy, throat / before fight / throat with uvula / after fight
+  dl main_burt                              ; $038600 | Burt the Bushful
+  dl main_roger_shy_guy                     ; $038603 | Shy Guy for Rogger the Potted Ghost
+  dl main_boss_kamek                        ; $038606 | Kamek, for scenes before boss fights
+  dl main_head_of_fire                      ; $038609 | The head of fire of the Thunder Lakitu
+  dl main_thunder_lakitu_fire_stuff         ; $03860C | Fire of Thunder Lakitu
+  dl main_thunder_lakitu_fire_stuff         ; $03860F | Hypocenter of the thunder.
+  dl main_blow_hard                         ; $038612 | Upside down Blow Hard
+  dl main_unused_4D                         ; $038615 | unknown
+  dl main_door                              ; $038618 | Locked door
+  dl main_middle_ring                       ; $03861B | Middle ring
+  dl main_board_bg3                         ; $03861E | (BG3) Board
+  dl main_large_log_bg3                     ; $038621 | (BG3) Large log
+  dl main_balloon                           ; $038624 | Balloon
+  dl main_kamek_OH_MY                       ; $038627 | Kamek, says \OH MY!!!\""
+  dl main_wild_piranha                      ; $03862A | Upside down Wild Piranha
+  dl main_pinwheel                          ; $03862D | Green Pinwheel
+  dl main_pinwheel                          ; $038630 | Pink Pinwheel
+  dl main_platform_ghost_sewer              ; $038633 | (BG3) Sewer ghost with Flatbed Ferry on its head
+  dl main_toadies                           ; $038636 | Green Solo Toady
+  dl main_super_star                        ; $038639 | Continuous Super Star
+  dl main_raph_spark                        ; $03863C | Spark of Raphael the Raven.
+  dl main_coin_bandit                       ; $03863F | Coin Bandit
+  dl main_toadies                           ; $038642 | Pink Toadie
+  dl junk_sprite_pointer                    ; $038645 | [CRASH]
+  dl main_plank_bg3                         ; $038648 | (BG3) Plank
+  dl main_plank_bg3                         ; $03864B | (BG3) Plank
+  dl CODE_0E8023                            ; $03864E | Bomb
+  dl main_baby_mario                        ; $038651 | Baby Mario
+  dl main_goomba                            ; $038654 | Goomba
+  dl main_muddy_buddy                       ; $038657 | Muddy Buddy
+  dl main_pinwheel                          ; $03865A | Pink Pinwheel, (X: direction) (Y: size)
+  dl main_red_coin                          ; $03865D | Red coin
+  dl main_wild_piranha                      ; $038660 | Wild Piranha
+  dl main_hidden_winged_cloud_A             ; $038663 | Hidden Winged Cloud, stars / seed / flower / 1-up
+  dl main_flashing_egg_block                ; $038666 | Flashing Egg Block
+  dl main_egg_block                         ; $038669 | Red Egg Block
+  dl main_egg_block                         ; $03866C | Yellow Egg Block
+  dl main_hit_green_egg_block               ; $03866F | Hit green Egg Block
+  dl main_large_spring_ball                 ; $038672 | Large Spring Ball
+  dl main_hootie                            ; $038675 | Hootie the Blue Fish, clockwise
+  dl main_hootie                            ; $038678 | Hootie the Blue Fish, anticlockwise
+  dl main_spring_ball                       ; $03867B | Spring Ball
+  dl main_clawdaddy                         ; $03867E | Clawdaddy
+  dl main_boo                               ; $038681 | Big Boo with 3 Boos / Big Boo / Big Boo with 3 Boos / Boo
+  dl main_train_bandit                      ; $038684 | Train Bandit
+  dl main_balloon_pumper_red_bg3            ; $038687 | (BG3) Balloon Pumper with red balloon
+  dl main_spike                             ; $03868A | Spike
+  dl main_spiked_ball                       ; $03868D | Spiked ball
+  dl main_piro_dangle                       ; $038690 | Piro Dangle, clockwise
+  dl main_piro_dangle                       ; $038693 | Piro Dangle, anticlockwise
+  dl main_bullet_bill_blaster               ; $038696 | Biting Bullet Bill Blaster
+  dl main_bullet_bill_blaster               ; $038699 | Bouncing Bullet Bill Blaster
+  dl main_bullet_bill_blaster               ; $03869C | Bullet Bill Blaster
+  dl main_biting_bullet_bill                ; $03869F | Biting Bullet Bill
+  dl main_bouncing_bullet_bill              ; $0386A2 | Bouncing Bullet Bill
+  dl main_bullet_bill                       ; $0386A5 | Bullet Bill
+  dl main_invisible_slime_platform          ; $0386A8 | Dent of castella
+  dl main_log_seesaw                        ; $0386AB | Log seesaw
+  dl main_lava_bubble                       ; $0386AE | Lava Bubble
+  dl main_lava_bubble                       ; $0386B1 | Lava Bubble, jumps across
+  dl main_chain_chomp                       ; $0386B4 | Chain Chomp
+  dl main_cloud                             ; $0386B7 | Cloud
+  dl main_teleport_sprite                   ; $0386BA | Teleport sprite
+  dl main_hedgehog                          ; $0386BD | Harry Hedgehog
+  dl junk_sprite_pointer                    ; $0386C0 | [CRASH]
+  dl main_red_1up_egg                       ; $0386C3 | Red Egg, gives 1-up
+  dl main_super_star                        ; $0386C6 | Super Star
+  dl main_red_platform                      ; $0386C9 | Red Flatbed Ferry, moving horizontally
+  dl main_pink_platform                     ; $0386CC | Pink Flatbed Ferry, moving vertically
+  dl main_inflating_balloon                 ; $0386CF | Mock Up, green / red
+  dl main_yoshi_at_goal                     ; $0386D2 | Yoshi, at the Goal
+  dl main_flyguy                            ; $0386D5 | Fly Guy, 5 stars / red coin / 1-up / 1-up
+  dl main_bower_room_kamek                  ; $0386D8 | Kamek, at Bowser's room
+  dl main_swing_of_grinders                 ; $0386DB | Swing of Grinders
+  dl main_dangling_ghost                    ; $0386DE | (BG3) Dangling Ghost
+  dl main_4_toadies                         ; $0386E1 | 4 Toadies
+  dl main_melon_bug                         ; $0386E4 | Melon Bug
+  dl main_door                              ; $0386E7 | Door
+  dl main_expansion_block                   ; $0386EA | Expansion Block
+  dl main_checkered_block                   ; $0386ED | Blue checkered block
+  dl main_checkered_block                   ; $0386F0 | Red checkered block
+  dl main_pow_block                         ; $0386F3 | POW
+  dl main_yoshi_block                       ; $0386F6 | Yoshi Block
+  dl main_green_needlenose                  ; $0386F9 | Spiny Egg
+  dl main_flatbed_ferry_green               ; $0386FC | Chained green Flatbed Ferry
+  dl main_mace_guy                          ; $0386FF | Mace Guy
+  dl main_mace                              ; $038702 | Mace
+  dl main_red_pow_switch                    ; $038705 | !-switch
+  dl main_chomp_rock                        ; $038708 | Chomp Rock
+  dl main_wild_ptooie_piranha               ; $03870B | Wild Ptooie Piranha, spits 1 / 3 Needlenose
+  dl main_tulip                             ; $03870E | Tulip
+  dl main_pot_of_potted_spiked_guy          ; $038711 | Pot of Potted Spiked Fun Guy
+  dl CODE_0EB1BE                            ; $038714 | Fireball of Thunder Lakitu
+  dl main_bandit                            ; $038717 | Bandit, getting under cover, left
+  dl main_bandit                            ; $03871A | Bandit, getting under cover, right
+  dl main_nep_enut                          ; $03871D | Nep-Enut / Gargantua Blargg
+  dl main_incoming_chomp                    ; $038720 | Incoming Chomp
+  dl main_incoming_chomp_flock              ; $038723 | Flcok of Incoming Chomps
+  dl main_incoming_chomp                    ; $038726 | Falling Incoming Chomp
+  dl main_incoming_chomp_falling_shadow     ; $038729 | Shadow of falling Incoming Chomp
+  dl main_background_shyguy                 ; $03872C | Shy Guy in background
+  dl main_full_eggs                         ; $03872F | Fill Eggs
+  dl CODE_0DFBC2                            ; $038732 | Sign Arrow and Shadow
+  dl main_hint_block                        ; $038735 | Hint Block
+  dl main_hookbill                          ; $038738 | Hookbill the Koopa
+  dl main_winged_cloud                      ; $03873B | Morph Bubble, Car
+  dl main_winged_cloud                      ; $03873E | Morph Bubble, Mole Tank
+  dl main_winged_cloud                      ; $038741 | Morph Bubble, Helicopter
+  dl main_winged_cloud                      ; $038744 | Morph Bubble, Train
+  dl main_fuzzy_wind                        ; $038747 | Wind of Fuzzy
+  dl main_winged_cloud                      ; $03874A | Morph Bubble, Submarine
+  dl main_hidden_winged_cloud_B             ; $03874D | Hidden Winged Cloud, 1-up / 5 stars / !-switch / 5 stars
+  dl main_winged_cloud                      ; $038750 | Winged Cloud, 8 coins
+  dl main_winged_cloud                      ; $038753 | Winged Cloud, bubbled 1-up
+  dl main_winged_cloud                      ; $038756 | Winged Cloud, flower
+  dl main_winged_cloud                      ; $038759 | Winged Cloud, POW
+  dl main_winged_cloud                      ; $03875C | Winged Cloud, stairs, right / left
+  dl main_winged_cloud                      ; $03875F | Winged Cloud, platform, right / left
+  dl main_winged_cloud                      ; $038762 | Winged Cloud, Bandit
+  dl main_winged_cloud                      ; $038765 | Winged Cloud, coin (object)
+  dl main_winged_cloud                      ; $038768 | Winged Cloud, 1-up
+  dl main_winged_cloud                      ; $03876B | Winged Cloud, key
+  dl main_winged_cloud                      ; $03876E | Winged Cloud, 3 stars
+  dl main_winged_cloud                      ; $038771 | Winged Cloud, 5 stars
+  dl main_winged_cloud                      ; $038774 | Winged Cloud, door
+  dl main_winged_cloud                      ; $038777 | Winged Cloud, ground eater
+  dl main_winged_cloud                      ; $03877A | Winged Cloud, watermelon
+  dl main_winged_cloud                      ; $03877D | Winged Cloud, fire watermelon
+  dl main_winged_cloud                      ; $038780 | Winged Cloud, icy watermelon
+  dl main_winged_cloud                      ; $038783 | Winged Cloud, seed of sunflower with 3 leaves
+  dl main_winged_cloud                      ; $038786 | Winged Cloud, seed of sunflower with 6 leaves
+  dl main_winged_cloud                      ; $038789 | Winged Cloud, [CRASH]
+  dl main_door                              ; $03878C | Boss Door of Bowser's room
+  dl main_winged_cloud                      ; $03878F | Winged Cloud, random item.
+  dl main_winged_cloud                      ; $038792 | Winged Cloud, !-switch / !-switch
+  dl main_bvz_melon_and_giant_egg           ; $038795 | Baron Von Zeppelin, Giant Egg
+  dl main_bowser_flame                      ; $038798 | Bowser's flame
+  dl main_bowser_quake                      ; $03879B | Bowser's quake
+  dl main_horizontal_entrance               ; $03879E | Horizontal entrance, towards right
+  dl main_hidden_vertical_entrance          ; $0387A1 | Hidden entrance, revealed by an ! switch
+  dl main_marching_milde                    ; $0387A4 | Marching Milde
+  dl main_giant_milde                       ; $0387A7 | Giant Milde
+  dl main_large_milde                       ; $0387AA | Large Milde
+  dl main_hookbill_background               ; $0387AD | Mountain backgrounds at fight with Hookbill the Koopa
+  dl main_platform_ghost                    ; $0387B0 | (BG3) Ghost with Flatbed Ferry on its head
+  dl main_sluggy_unshaven                   ; $0387B3 | Sluggy the Unshaven
+  dl main_chomp_signboard                   ; $0387B6 | Chomp signboard.
+  dl main_fishin_lakitu                     ; $0387B9 | Fishin' Lakitu
+  dl main_flower_pot                        ; $0387BC | Flower pot, key / 6 stars / 6 coins / nothing
+  dl main_soft_thing                        ; $0387BF | (BG3) Soft thing
+  dl main_snowball                          ; $0387C2 | Snowball
+  dl main_boss_closer                       ; $0387C5 | Closer, in Naval Piranha's room
+  dl main_falling_rock                      ; $0387C8 | Falling Rock
+  dl main_piscatory_pete                    ; $0387CB | Piscatory Pete, Blue / Gold
+  dl main_preying_mantas                    ; $0387CE | Preying Mantas
+  dl main_loch_nestor                       ; $0387D1 | Loch Nestor
+  dl main_boo_blah                          ; $0387D4 | Boo Blah, normal / upside down
+  dl main_boo_blah                          ; $0387D7 | Boo Blah with Piro Dangle, normal / upside down
+  dl main_heading_cactus                    ; $0387DA | Heading cactus
+  dl main_green_needlenose                  ; $0387DD | Green Needlenose
+  dl main_gusty                             ; $0387E0 | Gusty, left / right / infinite right / infinite left
+  dl main_small_burt                        ; $0387E3 | Burt, two / one
+  dl main_goonie                            ; $0387E6 | Goonie, right / towards Yoshi / generator right / generator left
+  dl main_goonie                            ; $0387E9 | 3 Flightless Goonies
+  dl main_cloud_drop_vertical               ; $0387EC | Cloud Drop, moving vertically
+  dl main_cloud_drop_horizontal             ; $0387EF | Cloud Drop, moving horizontally
+  dl main_flamer_guy                        ; $0387F2 | Flamer Guy, jumping around
+  dl main_flamer_guy                        ; $0387F5 | Flamer Guy, walking around
+  dl main_eggo_dil                          ; $0387F8 | Eggo-Dil
+  dl main_eggo_dil_face                     ; $0387FB | Eggo-Dil's face
+  dl main_eggo_dil_petal                    ; $0387FE | Petal of Eggo-Dil
+  dl main_bubble_plant                      ; $038801 | Bubble-Plant
+  dl main_stilt_guy                         ; $038804 | Stilt Guy, green / red / yellow / purple
+  dl main_woozy_guy                         ; $038807 | Woozy Guy, green / red / yellow / purple
+  dl main_egg_plant                         ; $03880A | Egg-Plant / Needlenose-Plant
+  dl main_slugger                           ; $03880D | Slugger
+  dl main_parent_huffin_puffin              ; $038810 | Parent and children of Huffin' Puffins
+  dl main_barney_bubble                     ; $038813 | Barney Bubble
+  dl main_blow_hard                         ; $038816 | Blow Hard
+  dl main_green_needlenose                  ; $038819 | Yellow Needlenose
+  dl main_flower                            ; $03881C | Flower
+  dl main_spear_guy                         ; $03881F | Spear Guy, long spear
+  dl main_spear_guy                         ; $038822 | Spear Guy, short spear
+  dl main_zeus_guy                          ; $038825 | Zeus Guy
+  dl main_zeus_guy_energy                   ; $038828 | Energy of Zeus Guy
+  dl main_poochy                            ; $03882B | Poochy
+  dl main_bubbled_1_up                      ; $03882E | Bubbled 1-up
+  dl main_spiky_mace                        ; $038831 | Spiky mace
+  dl main_spiky_mace                        ; $038834 | Spiky mace, double-ended
+  dl main_spiky_mace_boo_guys               ; $038837 | Boo Guys spinning spiky mace
+  dl main_jean_de_fillet                    ; $03883A | Jean de Fillet, right / left
+  dl main_boo_guys_carrying_bombs           ; $03883D | Boo Guys, carrying bombs towards left.
+  dl main_boo_guys_carrying_bombs           ; $038840 | Boo Guys, carrying bombs towards right
+  dl main_seed                              ; $038843 | Seed of watermelon
+  dl main_milde                             ; $038846 | Milde
+  dl main_tap_tap                           ; $038849 | Tap-Tap
+  dl main_tap_tap                           ; $03884C | Tap-Tap, stays on ledges
+  dl main_tap_tap                           ; $03884F | Hopping Tap-Tap
+  dl main_chained_spike_ball                ; $038852 | Chained spike ball, controlled by Boo Guy
+  dl main_pulley_guy                        ; $038855 | Boo Guy, rotating a pulley, right / left
+  dl main_crate                             ; $038858 | Crate, 6 stars
+  dl main_boo_man_bluff                     ; $03885B | Boo Man Bluff
+  dl main_flower_2                          ; $03885E | Flower
+  dl main_flan                              ; $038861 | Georgette Jelly
+  dl main_splashed_flan                     ; $038864 | Splashed Georgette Jelly
+  dl main_snifit                            ; $038867 | Snifit
+  dl main_snifit_bullet                     ; $03886A | Bullet, shot by Snifit
+  dl main_coin_with_gravity                 ; $03886D | Coin, gravity affected
+  dl main_water_platform                    ; $038870 | Floating round platform on water
+  dl main_donut_lift                        ; $038873 | Donut Lift
+  dl main_donut_lift                        ; $038876 | Giant Donut Lift
+  dl main_spooky                            ; $038879 | Spooky
+  dl main_green_glove                       ; $03887C | Green Glove
+  dl main_lakitu                            ; $03887F | Lakitu, one / two
+  dl main_lakitu_cloud                      ; $038882 | Lakitu's cloud
+  dl main_green_needlenose                  ; $038885 | Spiny Egg
+  dl main_arrow_wheel                       ; $038888 | Brown Arrow Wheel
+  dl main_arrow_wheel                       ; $03888B | Blue Arrow Wheel
+  dl main_double_ended_arrow_lift           ; $03888E | Double-ended arrow lift
+  dl main_number_platform_explosion         ; $038891 | Explosion of Number Platform
+  dl main_bucket_obj                        ; $038894 | ? bucket, Bandit
+  dl main_bucket_obj                        ; $038897 | ? bucket, 5 coins
+  dl main_stretch                           ; $03889A | Stretch, green / red / yellow / purple
+  dl main_kamek                             ; $03889D | Kamek, for the ending scene / flying and chases
+  dl main_chained_pulley_log                ; $0388A0 | Spiked log held by chain and pulley
+  dl main_pulley                            ; $0388A3 | ? Pulley
+  dl main_ground_shake                      ; $0388A6 | Ground shake
+  dl main_fuzzy                             ; $0388A9 | Fuzzy
+  dl main_shy_guy                           ; $0388AC | Shy Guy, with Bandit hidden
+  dl main_fat_guy                           ; $0388AF | Fat Guy, red / green
+  dl main_fly_guy                           ; $0388B2 | Fly Guy carrying red coin / Whirly Fly Guy
+  dl main_yoshi_in_intro_cutscene           ; $0388B5 | Yoshi, in the intro scene
+  dl main_12E                               ; $0388B8 | unknown
+  dl main_lava_drop_horizontal              ; $0388BB | Lava Drop, moving horizontally
+  dl main_lava_drop_vertical                ; $0388BE | Lava Drop, moving vertically
+  dl main_door                              ; $0388C1 | Locked door
+  dl main_lemon_drop                        ; $0388C4 | Lemon Drop
+  dl main_shy_guy                           ; $0388C7 | Lantern Ghost
+  dl main_baby_bowser                       ; $0388CA | Baby Bowser
+  dl main_small_raven                       ; $0388CD | Raven, always circling, anticlockwise / clockwise
+  dl main_small_raven                       ; $0388D0 | Raven, anticlockwise / clockwise initially
+  dl main_falling_rock_common               ; $0388D3 | 3x6 Falling Rock
+  dl main_falling_rock_common               ; $0388D6 | 3x3 Falling Rock
+  dl main_falling_rock_common               ; $0388D9 | 3x9 Falling Rock
+  dl main_falling_rock_common               ; $0388DC | 6x3 Falling Rock
+  dl main_froggy_stomach_acid               ; $0388DF | Stomach Acid
+  dl main_flipper_downwards                 ; $0388E2 | Flipper, downwards
+  dl main_fang_dangling                     ; $0388E5 | Fang, dangling
+  dl main_fang_flying_wavily                ; $0388E8 | Fang, flying wavily
+  dl main_flopsy_fish                       ; $0388EB | Flopsy Fish, swimming around
+  dl main_flopsy_fish_jumping               ; $0388EE | Flopsy Fish, swimming and occasionally jumps vertically
+  dl main_flopsy_fish_jumps                 ; $0388F1 | Flopsy Fish, swimming and jumps in an arc
+  dl main_flopsy_fish_jumps                 ; $0388F4 | Flopsy Fish, jumps 3 times in an arc, right / left
+  dl main_spray_fish                        ; $0388F7 | Spray Fish
+  dl main_flipped_left_and_right            ; $0388FA | Flipper, rightwards / leftwards
+  dl main_sluggy                            ; $0388FD | Blue Sluggy, falling down / crawing ceiling
+  dl main_sluggy                            ; $038900 | Pink Sluggy, falling down / crawing ceiling but doesn't move
+  dl main_horizontal_entrance               ; $038903 | Horizontal entrance, towards left
+  dl main_large_spring_ball                 ; $038906 | Large Spring Ball
+  dl main_arrow_cloud                       ; $038909 | Arrow cloud, up
+  dl main_arrow_cloud                       ; $03890C | Arrow cloud, up right
+  dl main_arrow_cloud                       ; $03890F | Arrow cloud, right
+  dl main_arrow_cloud                       ; $038912 | Arrow cloud, down right
+  dl main_arrow_cloud                       ; $038915 | Arrow cloud, down
+  dl main_arrow_cloud                       ; $038918 | Arrow cloud, down left
+  dl main_arrow_cloud                       ; $03891B | Arrow cloud, left
+  dl main_arrow_cloud                       ; $03891E | Arrow cloud, up left
+  dl main_arrow_cloud_rotating              ; $038921 | Arrow cloud, rotating
+  dl main_flutter                           ; $038924 | Flutter
+  dl main_goonie                            ; $038927 | Goonie with Shy Guy
+  dl main_shark_chomp                       ; $03892A | Shark Chomp
+  dl main_fat_goonie                        ; $03892D | Very Fat Goonie
+  dl main_cactus_jack                       ; $038930 | Cactus Jack, one / three
+  dl main_wall_lakitu                       ; $038933 | Wall Lakitu
+  dl main_fat_goonie                        ; $038936 | Bowling Goonie
+  dl main_grunt_walking                     ; $038939 | Grunt, walking
+  dl main_grunt_running                     ; $03893C | Grunt, running
+  dl main_spear_guy_dancing                 ; $03893F | Dancing Spear Guy
+  dl main_spiked_platform_switch            ; $038942 | Green switch for green spiked platform
+  dl main_spiked_platform_switch            ; $038945 | Red switch for red spiked platform
+  dl main_pinwheel                          ; $038948 | Pink Pinwheel with Shy Guys, clockwise / anticlockwise
+  dl main_spiked_platform                   ; $03894B | Green spiked platform
+  dl main_spiked_platform                   ; $03894E | Red spiked platform
+  dl main_bonus_sprite                      ; $038951 | Bonus Item, red coin / key / flower / door
+  dl main_two_spiked_platforms_with_switch  ; $038954 | Two spiked platforms with one switch in the center
+  dl main_bouncing_green_needlenose         ; $038957 | Bouncing green Needlenose
+  dl main_nipper_plant                      ; $03895A | Nipper Plant
+  dl main_nipper_spore                      ; $03895D | Nipper Spore
+  dl main_thunder_lakitu                    ; $038960 | Thunder Lakitu, one / two
+  dl main_koopa_shell                       ; $038963 | Green Koopa shell
+  dl main_koopa_shell                       ; $038966 | Red Koopa shell
+  dl main_beach_koopa                       ; $038969 | Green Beach Koopa
+  dl main_beach_koopa                       ; $03896C | Red Beach Koopa
+  dl main_koopa                             ; $03896F | Green Koopa
+  dl main_koopa                             ; $038972 | Red Koopa
+  dl main_green_parakoopa                   ; $038975 | Green Para Koopa, jumping forth.
+  dl main_red_parakoopa_horizontal          ; $038978 | Red Para Koopa, flying horizontally
+  dl main_red_parakoopa_vertical            ; $03897B | Red Para Koopa, flying vertically
+  dl main_aqua_lakitu                       ; $03897E | Aqua Lakitu
+  dl main_naval_piranha                     ; $038981 | Naval Piranha
+  dl main_naval_bud                         ; $038984 | Naval Bud
+  dl main_bvz_enemies                       ; $038987 | Baron Von Zeppelin, red Suy Guy
+  dl main_bvz_enemies                       ; $03898A | Baron Von Zeppelin, Needlenose
+  dl main_bvz_enemies                       ; $03898D | Baron Von Zeppelin, bomb
+  dl main_bvz_enemies                       ; $038990 | Baron Von Zeppelin, Bandit
+  dl main_bvz_large_spring_ball             ; $038993 | Baron Von Zeppelin, large Spring Ball
+  dl main_bvz_consumables                   ; $038996 | Baron Von Zeppelin, 1-up
+  dl main_bvz_consumables                   ; $038999 | Baron Von Zeppelin, key
+  dl main_bvz_consumables                   ; $03899C | Baron Von Zeppelin, 5 coins
+  dl main_bvz_melon_and_giant_egg           ; $03899F | Baron Von Zeppelin, watermelon
+  dl main_bvz_melon_and_giant_egg           ; $0389A2 | Baron Von Zeppelin, fire watermelon
+  dl main_bvz_icy_watermelon                ; $0389A5 | Baron Von Zeppelin, icy watermelon
+  dl main_bvz_crate_with_6_stars            ; $0389A8 | Baron Von Zeppelin, crate, 6 stars.
+  dl main_bvz                               ; $0389AB | Baron Von Zeppelin
+  dl main_spinning_log                      ; $0389AE | Spinning Log
+  dl main_crazee_dayzee                     ; $0389B1 | Crazee Dayzee
+  dl main_dragonfly                         ; $0389B4 | Dragonfly
+  dl main_butterfly                         ; $0389B7 | Butterfly
+  dl main_bumpty                            ; $0389BA | Bumpty
+  dl main_line_guided_platform              ; $0389BD | Active line guided green Flatbed Ferry, left
+  dl main_line_guided_platform              ; $0389C0 | Active line guided green Flatbed Ferry, right
+  dl main_line_guided_platform              ; $0389C3 | Active line guided yellow Flatbed Ferry, left
+  dl main_line_guided_platform              ; $0389C6 | Active line guided yellow Flatbed Ferry, right
+  dl main_line_guided_platform              ; $0389C9 | Line guided green Flatbed Ferry, left
+  dl main_line_guided_platform              ; $0389CC | Line guided green Flatbed Ferry, right
+  dl main_line_guided_platform              ; $0389CF | Line guided yellow Flatbed Ferry, left
+  dl main_line_guided_platform              ; $0389D2 | Line guided yellow Flatbed Ferry, right
+  dl main_line_guided_platform              ; $0389D5 | Line guided red Flatbed Ferry, left
+  dl main_line_guided_platform              ; $0389D8 | Line guided red Flatbed Ferry, right
+  dl main_whirling_lift                     ; $0389DB | Whirling lift
+  dl main_falling_icicle                    ; $0389DE | Falling icicle
+  dl main_sparrow                           ; $0389E1 | Sparrow
+  dl main_mufti_guy                         ; $0389E4 | Mufti Guy, green / red / yellow / purple
+  dl main_caged_ghost_sewer                 ; $0389E7 | Caged Ghost, squeezing in sewer
+  dl main_blargg                            ; $0389EA | Blargg
+  dl main_unknown                           ; $0389ED | unknown
+  dl main_unbalanced_snowy_playform         ; $0389F0 | Unbalanced snowy platform
+  dl main_arrow_sign                        ; $0389F3 | Arrow sign, up / right / left / down
+  dl main_arrow_sign                        ; $0389F6 | Diagonal arrow sign, up left / up right / down left / down right
+  dl main_dizzy_dandy                       ; $0389F9 | Dizzy Dandy
+  dl main_boo_guy                           ; $0389FC | Boo Guy
+  dl main_bumpty_tackling                   ; $0389FF | Bumpty, tackles at Yoshi
+  dl main_bumpty_flying                     ; $038A02 | Flying Bumpty, flying aronnd / flying straightly
+  dl main_skeleton_goonie                   ; $038A05 | Skeleton Goonie
+  dl main_skeleton_goonie_flightless        ; $038A08 | Flightless Skeleton Goonie
+  dl main_skeleton_goonie_with_bomb         ; $038A0B | Skeleton Goonie with a bomb
+  dl main_firebar                           ; $038A0E | Firebar, double-ended, clockwise / anticlockwise
+  dl main_firebar                           ; $038A11 | Firebar, clockwise / anticlockwise
+  dl main_star                              ; $038A14 | Star
+  dl main_little_skull_mouser               ; $038A17 | Little Skull Mouser
+  dl main_cork                              ; $038A1A | Cork, seals 3D pipe
+  dl main_grinder_common                    ; $038A1D | Grinder, runs away
+  dl main_grinder_common                    ; $038A20 | Grinder, spits seeds of watermelon
+  dl main_grinder_common                    ; $038A23 | Short Fuse / Seedy Sally, right / left
+  dl main_grinder_common                    ; $038A26 | Grinder, grasps Baby Mario
+  dl main_grinder_common                    ; $038A29 | Grinder, climbing, spits seeds of watermelon
+  dl main_hot_lips                          ; $038A2C | Hot Lips
+  dl main_boo_balloon                       ; $038A2F | Boo Balloon, coin / !-switch
+  dl main_frog                              ; $038A32 | Frog
+  dl main_kamek_shoots_magic                ; $038A35 | Kamek, shoots magic at Yoshi.
+  dl main_kamek_magic                       ; $038A38 | Kamek's magic
+  dl main_coin                              ; $038A3B | Coin
+  dl main_balloon_bg3                       ; $038A3E | (BG3) Balloon
+  dl main_coin_cannon                       ; $038A41 | Coin Cannon for Mini Battle
+  dl main_mini_battle_coin                  ; $038A44 | Coin for Mini Battle
+  dl main_mini_battle_bandit                ; $038A47 | Bandit for Mini Battle
+  dl main_mini_battle_checkered_platform    ; $038A4A | Checkered Platform for Mini Battle
+  dl main_mini_battle_bandit_2              ; $038A4D | Bandit for Mini Battle
+  dl main_mini_battle_red_balloon           ; $038A50 | Red Balloon for Mini Battle
+  dl main_mini_battle_bandit_3              ; $038A53 | Bandit for Mini Battle
+  dl main_mini_battle_watermelon_pot        ; $038A56 | Watermelon Pot for Mini Battle
+  dl main_mini_battle_bandit_4              ; $038A59 | possibly Bandit for Mini Battle
 ; end main table
 
 ; sprite head_bops routine table: $8A5C - $8F89
 head_bops:
-  dl $039A6B                                ; $038A5C | Log, floating on water / lava
-  dl $039A6B                                ; $038A5F | Closed door
-  dl $039A6B                                ; $038A62 | Naval Piranha's stalk
-  dl $039A6B                                ; $038A65 | Crate, key
-  dl $039A6B                                ; $038A68 | Item from Star Mario block
-  dl $039F9F                                ; $038A6B | Icy watermelon
-  dl $039A6B                                ; $038A6E | Chill
-  dl $039F9F                                ; $038A71 | Watermelon
-  dl $039A6B                                ; $038A74 | Rubble
-  dl $039F9F                                ; $038A77 | Fire watermelon
-  dl $039A6B                                ; $038A7A | Kaboomba
-  dl $039A6B                                ; $038A7D | Cannonball of Kaboomba
-  dl $039A6B                                ; $038A80 | Raphael the Raven
-  dl $039A6B                                ; $038A83 | Goal
-  dl $039A6B                                ; $038A86 | G O A L !
-  dl $039A6B                                ; $038A89 | BONUS CHALLENGE
-  dl $039A6B                                ; $038A8C | Caged Ghost, round mound
-  dl $039A6B                                ; $038A8F | Item Card
-  dl $039A6B                                ; $038A92 | Boss Door
-  dl $039A6B                                ; $038A95 | Boss Explosion
-  dl $039A6B                                ; $038A98 | Key from defeated boss
-  dl $039A6B                                ; $038A9B | Torpedo of Yoshi Submarine
-  dl $039A6B                                ; $038A9E | Bigger Boo
-  dl $0EF7CE                                ; $038AA1 | Frog Pirate
-  dl $039A6B                                ; $038AA4 | Flame of Red Watermelon
-  dl $039A6B                                ; $038AA7 | Bubble
-  dl $039A6B                                ; $038AAA | Ski lift
-  dl $039A6B                                ; $038AAD | Vertical log, floating on lava
-  dl $039A6B                                ; $038AB0 | Dr. Freezegood, nothing / 6 stars / 1-up / Bumpty
-  dl $039A6B                                ; $038AB3 | Dr. Freezegood, with ski lift
-  dl $049087                                ; $038AB6 | Shy Guy, green / red / yellow / purple
-  dl $039A6B                                ; $038AB9 | Rotating Doors
-  dl $0ED83D                                ; $038ABC | Bandit
-  dl $039A6B                                ; $038ABF | ? bucket
-  dl $039F9B                                ; $038AC2 | Flashing Egg
-  dl $039F9F                                ; $038AC5 | Red Egg
-  dl $039F9F                                ; $038AC8 | Yellow Egg
-  dl $039F9F                                ; $038ACB | Green Egg
-  dl $039A6B                                ; $038ACE | Giant Egg, for battle with Bowser
-  dl $039F9F                                ; $038AD1 | Key
-  dl $039F9F                                ; $038AD4 | Huffin' Puffin, running away
-  dl $039F9F                                ; $038AD7 | Giant Egg, for battle with Prince Froggy?
-  dl $039F9F                                ; $038ADA | Red Giant Egg
-  dl $039F9F                                ; $038ADD | Green Giant Egg
-  dl $039A6B                                ; $038AE0 | Lunge Fish
-  dl $039A6B                                ; $038AE3 | Salvo the Slime
-  dl $039A6B                                ; $038AE6 | Salvo the Slime's eyes
-  dl $039A6B                                ; $038AE9 | Little Mouser's Nest
-  dl $039F9F                                ; $038AEC | Little Mouser
-  dl $039A6B                                ; $038AEF | Potted Spiked Fun Guy
-  dl $039A6B                                ; $038AF2 | Little Mouser, looking around, in nest / behind stuff
-  dl $039F9F                                ; $038AF5 | Little Mouser, from nest
-  dl $039A6B                                ; $038AF8 | Rogger the Potted Ghost
-  dl $039A6B                                ; $038AFB | Falling down Rogger the Potted Ghost?
-  dl $039A6B                                ; $038AFE | (BG3) Falling down wall
-  dl $039A6B                                ; $038B01 | Grim Leecher
-  dl $039A6B                                ; $038B04 | Flame spat by Rogger the Potted Ghost
-  dl $039A6B                                ; $038B07 | (BG3) Spinning wooden platform
-  dl $039A6B                                ; $038B0A | 3 Mini-Ravens
-  dl $039A6B                                ; $038B0D | Mini-Raven
-  dl $039A6B                                ; $038B10 | Tap-Tap the Red Nose
-  dl $039A6B                                ; $038B13 | (BG3) Seesaw
-  dl $039A6B                                ; $038B16 | Skinny platform
-  dl $039A6B                                ; $038B19 | Slime
-  dl $039A6B                                ; $038B1C | Baby Luigi
-  dl $039A6B                                ; $038B1F | Stork
-  dl $039A6B                                ; $038B22 | Vertical pipe entrance
-  dl $039F9F                                ; $038B25 | Red Giant Shy Guy
-  dl $039F9F                                ; $038B28 | Green Giant Shy Guy
-  dl $039A6B                                ; $038B2B | Prince Froggy, throat / before fight / throat with uvula / after fight
-  dl $039A6B                                ; $038B2E | Burt the Bushful
-  dl $039A6B                                ; $038B31 | Shy Guy for Rogger the Potted Ghost
-  dl $039A6B                                ; $038B34 | Kamek, for scenes before boss fights
-  dl $039A6B                                ; $038B37 | The head of fire of the Thunder Lakitu
-  dl $039A6B                                ; $038B3A | Fire of Thunder Lakitu
-  dl $039A6B                                ; $038B3D | Hypocenter of the thunder.
-  dl $039A6B                                ; $038B40 | Upside down Blow Hard
-  dl $039A6B                                ; $038B43 | unknown
-  dl $039A6B                                ; $038B46 | Locked door
-  dl $039A6B                                ; $038B49 | Middle ring
-  dl $039A6B                                ; $038B4C | (BG3) Board
-  dl $039A6B                                ; $038B4F | (BG3) Large log
-  dl $039A6B                                ; $038B52 | Balloon
-  dl $039A6B                                ; $038B55 | Kamek, says \OH MY!!!\""
-  dl $039A6B                                ; $038B58 | Upside down Wild Piranha
-  dl $039A6B                                ; $038B5B | Green Pinwheel
-  dl $039A6B                                ; $038B5E | Pink Pinwheel
-  dl $039A6B                                ; $038B61 | (BG3) Sewer ghost with Flatbed Ferry on its head
-  dl $039F9F                                ; $038B64 | Green Solo Toady
-  dl $039A6B                                ; $038B67 | Continuous Super Star
-  dl $039A6B                                ; $038B6A | Spark of Raphael the Raven.
-  dl $0ED83D                                ; $038B6D | Coin Bandit
-  dl $039F9F                                ; $038B70 | Pink Toadie
-  dl $039A6B                                ; $038B73 | [CRASH]
-  dl $039A6B                                ; $038B76 | (BG3) Plank
-  dl $039A6B                                ; $038B79 | (BG3) Plank
-  dl $039A6B                                ; $038B7C | Bomb
-  dl $039A6B                                ; $038B7F | Baby Mario
-  dl $0C858D                                ; $038B82 | Goomba
-  dl $039A6B                                ; $038B85 | Muddy Buddy
-  dl $039A6B                                ; $038B88 | Pink Pinwheel, (X: direction) (Y: size)
-  dl $039A6B                                ; $038B8B | Red coin
-  dl $039A6B                                ; $038B8E | Wild Piranha
-  dl $039A6B                                ; $038B91 | Hidden Winged Cloud, stars / seed / flower / 1-up
-  dl $039A6B                                ; $038B94 | Flashing Egg Block
-  dl $039A6B                                ; $038B97 | Red Egg Block
-  dl $039A6B                                ; $038B9A | Yellow Egg Block
-  dl $039A6B                                ; $038B9D | Hit green Egg Block
-  dl $039A6B                                ; $038BA0 | Large Spring Ball
-  dl $039A6B                                ; $038BA3 | Hootie the Blue Fish, clockwise
-  dl $039A6B                                ; $038BA6 | Hootie the Blue Fish, anticlockwise
-  dl $039A6B                                ; $038BA9 | Spring Ball
-  dl $039A6B                                ; $038BAC | Clawdaddy
-  dl $039A6B                                ; $038BAF | Big Boo with 3 Boos / Big Boo / Big Boo with 3 Boos / Boo
-  dl $039A6B                                ; $038BB2 | Train Bandit
-  dl $039A6B                                ; $038BB5 | (BG3) Balloon Pumper with red balloon
-  dl $039A6B                                ; $038BB8 | Spike
-  dl $039A6B                                ; $038BBB | Spiked ball
-  dl $039A6B                                ; $038BBE | Piro Dangle, clockwise
-  dl $039A6B                                ; $038BC1 | Piro Dangle, anticlockwise
-  dl $039A6B                                ; $038BC4 | Biting Bullet Bill Blaster
-  dl $039A6B                                ; $038BC7 | Bouncing Bullet Bill Blaster
-  dl $039A6B                                ; $038BCA | Bullet Bill Blaster
-  dl $05D8B6                                ; $038BCD | Biting Bullet Bill
-  dl $05D8B6                                ; $038BD0 | Bouncing Bullet Bill
-  dl $05D8D6                                ; $038BD3 | Bullet Bill
-  dl $039A6B                                ; $038BD6 | Dent of castella
-  dl $039A6B                                ; $038BD9 | Log seesaw
-  dl $039A6B                                ; $038BDC | Lava Bubble
-  dl $039A6B                                ; $038BDF | Lava Bubble, jumps across
-  dl $039A6B                                ; $038BE2 | Chain Chomp
-  dl $039A6B                                ; $038BE5 | Cloud
-  dl $039A6B                                ; $038BE8 | Teleport sprite
-  dl $039A6B                                ; $038BEB | Harry Hedgehog
-  dl $039A6B                                ; $038BEE | [CRASH]
-  dl $039A6B                                ; $038BF1 | Red Egg, gives 1-up
-  dl $039A6B                                ; $038BF4 | Super Star
-  dl $039A6B                                ; $038BF7 | Red Flatbed Ferry, moving horizontally
-  dl $039A6B                                ; $038BFA | Pink Flatbed Ferry, moving vertically
-  dl $039A6B                                ; $038BFD | Mock Up, green / red
-  dl $039A6B                                ; $038C00 | Yoshi, at the Goal
-  dl $039A6B                                ; $038C03 | Fly Guy, 5 stars / red coin / 1-up / 1-up
-  dl $039A6B                                ; $038C06 | Kamek, at Bowser's room
-  dl $039A6B                                ; $038C09 | Swing of Grinders
-  dl $039A6B                                ; $038C0C | (BG3) Dangling Ghost
-  dl $039FED                                ; $038C0F | 4 Toadies
-  dl $039A6B                                ; $038C12 | Melon Bug
-  dl $039A6B                                ; $038C15 | Door
-  dl $039A6B                                ; $038C18 | Expansion Block
-  dl $039A6B                                ; $038C1B | Blue checkered block
-  dl $039A6B                                ; $038C1E | Red checkered block
-  dl $039A6B                                ; $038C21 | POW
-  dl $039A6B                                ; $038C24 | Yoshi Block
-  dl $039A6B                                ; $038C27 | Spiny Egg
-  dl $039A6B                                ; $038C2A | Chained green Flatbed Ferry
-  dl $039A6B                                ; $038C2D | Mace Guy
-  dl $039A6B                                ; $038C30 | Mace
-  dl $039A6B                                ; $038C33 | !-switch
-  dl $039A6B                                ; $038C36 | Chomp Rock
-  dl $039A6B                                ; $038C39 | Wild Ptooie Piranha, spits 1 / 3 Needlenose
-  dl $039A6B                                ; $038C3C | Tulip
-  dl $039A6B                                ; $038C3F | Pot of Potted Spiked Fun Guy
-  dl $039A6B                                ; $038C42 | Fireball of Thunder Lakitu
-  dl $0ED83D                                ; $038C45 | Bandit, getting under cover, left
-  dl $0ED83D                                ; $038C48 | Bandit, getting under cover, right
-  dl $039A6B                                ; $038C4B | Nep-Enut / Gargantua Blargg
-  dl $039A6B                                ; $038C4E | Incoming Chomp
-  dl $039A6B                                ; $038C51 | Flcok of Incoming Chomps
-  dl $039A6B                                ; $038C54 | Falling Incoming Chomp
-  dl $039A6B                                ; $038C57 | Shadow of falling Incoming Chomp
-  dl $039A6B                                ; $038C5A | Shy Guy in background
-  dl $039A6B                                ; $038C5D | Fill Eggs
-  dl $039A6B                                ; $038C60 | Sign Arrow and Shadow
-  dl $039A6B                                ; $038C63 | Hint Block
-  dl $039A6B                                ; $038C66 | Hookbill the Koopa
-  dl $039A6B                                ; $038C69 | Morph Bubble, Car
-  dl $039A6B                                ; $038C6C | Morph Bubble, Mole Tank
-  dl $039A6B                                ; $038C6F | Morph Bubble, Helicopter
-  dl $039A6B                                ; $038C72 | Morph Bubble, Train
-  dl $039A6B                                ; $038C75 | Wind of Fuzzy
-  dl $039A6B                                ; $038C78 | Morph Bubble, Submarine
-  dl $039A6B                                ; $038C7B | Hidden Winged Cloud, 1-up / 5 stars / !-switch / 5 stars
-  dl $039A6B                                ; $038C7E | Winged Cloud, 8 coins
-  dl $039A6B                                ; $038C81 | Winged Cloud, bubbled 1-up
-  dl $039A6B                                ; $038C84 | Winged Cloud, flower
-  dl $039A6B                                ; $038C87 | Winged Cloud, POW
-  dl $039A6B                                ; $038C8A | Winged Cloud, stairs, right / left
-  dl $039A6B                                ; $038C8D | Winged Cloud, platform, right / left
-  dl $039A6B                                ; $038C90 | Winged Cloud, Bandit
-  dl $039A6B                                ; $038C93 | Winged Cloud, coin (object)
-  dl $039A6B                                ; $038C96 | Winged Cloud, 1-up
-  dl $039A6B                                ; $038C99 | Winged Cloud, key
-  dl $039A6B                                ; $038C9C | Winged Cloud, 3 stars
-  dl $039A6B                                ; $038C9F | Winged Cloud, 5 stars
-  dl $039A6B                                ; $038CA2 | Winged Cloud, door
-  dl $039A6B                                ; $038CA5 | Winged Cloud, ground eater
-  dl $039A6B                                ; $038CA8 | Winged Cloud, watermelon
-  dl $039A6B                                ; $038CAB | Winged Cloud, fire watermelon
-  dl $039A6B                                ; $038CAE | Winged Cloud, icy watermelon
-  dl $039A6B                                ; $038CB1 | Winged Cloud, seed of sunflower with 3 leaves
-  dl $039A6B                                ; $038CB4 | Winged Cloud, seed of sunflower with 6 leaves
-  dl $039A6B                                ; $038CB7 | Winged Cloud, [CRASH]
-  dl $039A6B                                ; $038CBA | Boss Door of Bowser's room
-  dl $039A6B                                ; $038CBD | Winged Cloud, random item.
-  dl $039A6B                                ; $038CC0 | Winged Cloud, !-switch / !-switch
-  dl $039A6B                                ; $038CC3 | Baron Von Zeppelin, Giant Egg
-  dl $039A6B                                ; $038CC6 | Bowser's flame
-  dl $039A6B                                ; $038CC9 | Bowser's quake
-  dl $039A6B                                ; $038CCC | Horizontal entrance, towards right
-  dl $039A6B                                ; $038CCF | Hidden entrance, revealed by an ! switch
-  dl $039A6B                                ; $038CD2 | Marching Milde
-  dl $0F933F                                ; $038CD5 | Giant Milde
-  dl $0F98BD                                ; $038CD8 | Large Milde
-  dl $039A6B                                ; $038CDB | Mountain backgrounds at fight with Hookbill the Koopa
-  dl $039A6B                                ; $038CDE | (BG3) Ghost with Flatbed Ferry on its head
-  dl $039A6B                                ; $038CE1 | Sluggy the Unshaven
-  dl $039A6B                                ; $038CE4 | Chomp signboard.
-  dl $0EFF20                                ; $038CE7 | Fishin' Lakitu
-  dl $039A6B                                ; $038CEA | Flower pot, key / 6 stars / 6 coins / nothing
-  dl $039A6B                                ; $038CED | (BG3) Soft thing
-  dl $039A6B                                ; $038CF0 | Snowball
-  dl $039A6B                                ; $038CF3 | Closer, in Naval Piranha's room
-  dl $039A6B                                ; $038CF6 | Falling Rock
-  dl $039A6B                                ; $038CF9 | Piscatory Pete, Blue / Gold
-  dl $039A6B                                ; $038CFC | Perying Mantas
-  dl $039A6B                                ; $038CFF | Loch Nestor
-  dl $039A6B                                ; $038D02 | Boo Blah, normal / upside down
-  dl $039A6B                                ; $038D05 | Boo Blah with Piro Dangle, normal / upside down
-  dl $039A6B                                ; $038D08 | Heading cactus
-  dl $039A6B                                ; $038D0B | Green Needlenose
-  dl $039A6B                                ; $038D0E | Gusty, left / right / infinite right / infinite left
-  dl $039A6B                                ; $038D11 | Burt, two / one
-  dl $039A6B                                ; $038D14 | Goonie, right / towards Yoshi / generator right / generator left
-  dl $039A6B                                ; $038D17 | 3 Flightless Goonies
-  dl $06BB3E                                ; $038D1A | Cloud Drop, moving vertically
-  dl $06BC9A                                ; $038D1D | Cloud Drop, moving horizontally
-  dl $039A6B                                ; $038D20 | Flamer Guy, jumping around
-  dl $039A6B                                ; $038D23 | Flamer Guy, walking around
-  dl $039A6B                                ; $038D26 | Eggo-Dil
-  dl $039A6B                                ; $038D29 | Eggo-Dil's face
-  dl $039A6B                                ; $038D2C | Petal of Eggo-Dil
-  dl $039A6B                                ; $038D2F | Bubble-Plant
-  dl $07882D                                ; $038D32 | Stilt Guy, green / red / yellow / purple
-  dl $039F9F                                ; $038D35 | Woozy Guy, green / red / yellow / purple
-  dl $039A6B                                ; $038D38 | Egg-Plant / Needlenose-Plant
-  dl $039A6B                                ; $038D3B | Slugger
-  dl $039A6B                                ; $038D3E | Parent and children of Huffin' Puffins
-  dl $039A6B                                ; $038D41 | Barney Bubble
-  dl $039A6B                                ; $038D44 | Blow Hard
-  dl $039A6B                                ; $038D47 | Yellow Needlenose
-  dl $039A6B                                ; $038D4A | Flower
-  dl $039A6B                                ; $038D4D | Spear Guy, long spear
-  dl $039A6B                                ; $038D50 | Spear Guy, short spear
-  dl $07D857                                ; $038D53 | Zeus Guy
-  dl $039A6B                                ; $038D56 | Energy of Zeus Guy
-  dl $039A6B                                ; $038D59 | Poochy
-  dl $039A6B                                ; $038D5C | Bubbled 1-up
-  dl $039A6B                                ; $038D5F | Spiky mace
-  dl $039A6B                                ; $038D62 | Spiky mace, double-ended
-  dl $039A6B                                ; $038D65 | Boo Guys spinning spiky mace
-  dl $039A6B                                ; $038D68 | Jean de Fillet, right / left
-  dl $039A6B                                ; $038D6B | Boo Guys, carrying bombs towards left.
-  dl $039A6B                                ; $038D6E | Boo Guys, carrying bombs towards right
-  dl $039F9F                                ; $038D71 | Seed of watermelon
-  dl $039A6B                                ; $038D74 | Milde
-  dl $039A6B                                ; $038D77 | Tap-Tap
-  dl $039A6B                                ; $038D7A | Tap-Tap, stays on ledges
-  dl $039A6B                                ; $038D7D | Hopping Tap-Tap
-  dl $039A6B                                ; $038D80 | Chained spike ball, controlled by Boo Guy
-  dl $039A6B                                ; $038D83 | Boo Guy, rotating a pulley, right / left
-  dl $039A6B                                ; $038D86 | Crate, 6 stars
-  dl $039A6B                                ; $038D89 | Boo Man Bluff
-  dl $039A6B                                ; $038D8C | Flower
-  dl $039A6B                                ; $038D8F | Georgette Jelly
-  dl $039A6B                                ; $038D92 | Splashed Georgette Jelly
-  dl $039A6B                                ; $038D95 | Snifit
-  dl $039A6B                                ; $038D98 | Bullet, shot by Snifit
-  dl $039A6B                                ; $038D9B | Coin, gravity affected
-  dl $039A6B                                ; $038D9E | Floating round platform on water
-  dl $039A6B                                ; $038DA1 | Donut Lift
-  dl $039A6B                                ; $038DA4 | Giant Donut Lift
-  dl $039A6B                                ; $038DA7 | Spooky
-  dl $039A6B                                ; $038DAA | Green Glove
-  dl $07AAEC                                ; $038DAD | Lakitu, one / two
-  dl $039A6B                                ; $038DB0 | Lakitu's cloud
-  dl $039A6B                                ; $038DB3 | Spiny Egg
-  dl $039A6B                                ; $038DB6 | Brown Arrow Wheel
-  dl $039A6B                                ; $038DB9 | Blue Arrow Wheel
-  dl $039A6B                                ; $038DBC | Double-ended arrow lift
-  dl $039A6B                                ; $038DBF | Explosion of Number Platform
-  dl $039A6B                                ; $038DC2 | ? bucket, Bandit
-  dl $039A6B                                ; $038DC5 | ? bucket, 5 coins
-  dl $039F9F                                ; $038DC8 | Stretch, green / red / yellow / purple
-  dl $039A6B                                ; $038DCB | Kamek, for the ending scene / flying and chases
-  dl $039A6B                                ; $038DCE | Spiked log held by chain and pulley
-  dl $039A6B                                ; $038DD1 | ? Pulley
-  dl $039A6B                                ; $038DD4 | Ground shake
-  dl $039A6B                                ; $038DD7 | Fuzzy
-  dl $039A6B                                ; $038DDA | Shy Guy, with Bandit hidden
-  dl $039A6B                                ; $038DDD | Fat Guy, red / green
-  dl $0CF848                                ; $038DE0 | Fly Guy carrying red coin / Whirly Fly Guy
-  dl $039A6B                                ; $038DE3 | Yoshi, in the intro scene
-  dl $039A6B                                ; $038DE6 | unknown
-  dl $039A6B                                ; $038DE9 | Lava Drop, moving horizontally
-  dl $039A6B                                ; $038DEC | Lava Drop, moving vertically
-  dl $039A6B                                ; $038DEF | Locked door
-  dl $039A6B                                ; $038DF2 | Lemon Drop
-  dl $049087                                ; $038DF5 | Lantern Ghost
-  dl $039A6B                                ; $038DF8 | Baby Bowser
-  dl $039A6B                                ; $038DFB | Raven, always circling, anticlockwise / clockwise
-  dl $039A6B                                ; $038DFE | Raven, anticlockwise / clockwise initially
-  dl $039A6B                                ; $038E01 | 3x6 Falling Rock
-  dl $039A6B                                ; $038E04 | 3x3 Falling Rock
-  dl $039A6B                                ; $038E07 | 3x9 Falling Rock
-  dl $039A6B                                ; $038E0A | 6x3 Falling Rock
-  dl $039A6B                                ; $038E0D | Stomach Acid
-  dl $039A6B                                ; $038E10 | Flipper, downwards
-  dl $039A6B                                ; $038E13 | Fang, dangling
-  dl $039A6B                                ; $038E16 | Fang, flying wavily
-  dl $039A6B                                ; $038E19 | Flopsy Fish, swimming around
-  dl $039A6B                                ; $038E1C | Flopsy Fish, swimming and occasionally jumps vertically
-  dl $039A6B                                ; $038E1F | Flopsy Fish, swimming and jumps in an arc
-  dl $039A6B                                ; $038E22 | Flopsy Fish, jumps 3 times in an arc, right / left
-  dl $039A6B                                ; $038E25 | Spray Fish
-  dl $039A6B                                ; $038E28 | Flipper, rightwards / leftwards
-  dl $07B8B9                                ; $038E2B | Blue Sluggy, falling down / crawing ceiling
-  dl $07B8B9                                ; $038E2E | Pink Sluggy, falling down / crawing ceiling but doesn't move
-  dl $039A6B                                ; $038E31 | Horizontal entrance, towards left
-  dl $039A6B                                ; $038E34 | Large Spring Ball
-  dl $039A6B                                ; $038E37 | Arrow cloud, up
-  dl $039A6B                                ; $038E3A | Arrow cloud, up right
-  dl $039A6B                                ; $038E3D | Arrow cloud, right
-  dl $039A6B                                ; $038E40 | Arrow cloud, down right
-  dl $039A6B                                ; $038E43 | Arrow cloud, down
-  dl $039A6B                                ; $038E46 | Arrow cloud, down left
-  dl $039A6B                                ; $038E49 | Arrow cloud, left
-  dl $039A6B                                ; $038E4C | Arrow cloud, up left
-  dl $039A6B                                ; $038E4F | Arrow cloud, rotating
-  dl $039A6B                                ; $038E52 | Flutter
-  dl $039A6B                                ; $038E55 | Goonie with Shy Guy
-  dl $039A6B                                ; $038E58 | Shark Chomp
-  dl $039A6B                                ; $038E5B | Very Fat Goonie
-  dl $039A6B                                ; $038E5E | Cactus Jack, one / three
-  dl $07C689                                ; $038E61 | Wall Lakitu
-  dl $039A6B                                ; $038E64 | Bowling Goonie
-  dl $039A6B                                ; $038E67 | Grunt, walking
-  dl $039A6B                                ; $038E6A | Grunt, running
-  dl $039A6B                                ; $038E6D | Dancing Spear Guy
-  dl $039A6B                                ; $038E70 | Green switch for green spiked platform
-  dl $039A6B                                ; $038E73 | Red switch for red spiked platform
-  dl $039A6B                                ; $038E76 | Pink Pinwheel with Shy Guys, clockwise / anticlockwise
-  dl $039A6B                                ; $038E79 | Green spiked platform
-  dl $039A6B                                ; $038E7C | Red spiked platform
-  dl $039A6B                                ; $038E7F | Bonus Item, red coin / key / flower / door
-  dl $039A6B                                ; $038E82 | Two spiked platforms with one switch in the center
-  dl $039A6B                                ; $038E85 | Bouncing green Needlenose
-  dl $039A6B                                ; $038E88 | Nipper Plant
-  dl $039A6B                                ; $038E8B | Nipper Spore
-  dl $07F03E                                ; $038E8E | Thunder Lakitu, one / two
-  dl $07E3C8                                ; $038E91 | Green Koopa shell
-  dl $07E3C8                                ; $038E94 | Red Koopa shell
-  dl $07E3BD                                ; $038E97 | Green Beach Koopa
-  dl $07E3BD                                ; $038E9A | Red Beach Koopa
-  dl $07E3DF                                ; $038E9D | Green Koopa
-  dl $07E3F9                                ; $038EA0 | Red Koopa
-  dl $07E730                                ; $038EA3 | Green Para Koopa, jumping forth.
-  dl $07E74D                                ; $038EA6 | Red Para Koopa, flying horizontally
-  dl $07E74D                                ; $038EA9 | Red Para Koopa, flying vertically
-  dl $07EB45                                ; $038EAC | Aqua Lakitu
-  dl $039A6B                                ; $038EAF | Naval Piranha
-  dl $039A6B                                ; $038EB2 | Naval Bud
-  dl $039A6B                                ; $038EB5 | Baron Von Zeppelin, red Suy Guy
-  dl $039A6B                                ; $038EB8 | Baron Von Zeppelin, Needlenose
-  dl $039A6B                                ; $038EBB | Baron Von Zeppelin, bomb
-  dl $039A6B                                ; $038EBE | Baron Von Zeppelin, Bandit
-  dl $039A6B                                ; $038EC1 | Baron Von Zeppelin, large Spring Ball
-  dl $039A6B                                ; $038EC4 | Baron Von Zeppelin, 1-up
-  dl $039A6B                                ; $038EC7 | Baron Von Zeppelin, key
-  dl $039A6B                                ; $038ECA | Baron Von Zeppelin, 5 coins
-  dl $039A6B                                ; $038ECD | Baron Von Zeppelin, watermelon
-  dl $039A6B                                ; $038ED0 | Baron Von Zeppelin, fire watermelon
-  dl $039A6B                                ; $038ED3 | Baron Von Zeppelin, icy watermelon
-  dl $039A6B                                ; $038ED6 | Baron Von Zeppelin, crate, 6 stars.
-  dl $039A6B                                ; $038ED9 | Baron Von Zeppelin
-  dl $039A6B                                ; $038EDC | Spinning Log
-  dl $0F8636                                ; $038EDF | Crazee Dayzee
-  dl $039A6B                                ; $038EE2 | Dragonfly
-  dl $039A6B                                ; $038EE5 | Butterfly
-  dl $039F9F                                ; $038EE8 | Bumpty
-  dl $039A6B                                ; $038EEB | Active line guided green Flatbed Ferry, left
-  dl $039A6B                                ; $038EEE | Active line guided green Flatbed Ferry, right
-  dl $039A6B                                ; $038EF1 | Active line guided yellow Flatbed Ferry, left
-  dl $039A6B                                ; $038EF4 | Active line guided yellow Flatbed Ferry, right
-  dl $039A6B                                ; $038EF7 | Line guided green Flatbed Ferry, left
-  dl $039A6B                                ; $038EFA | Line guided green Flatbed Ferry, right
-  dl $039A6B                                ; $038EFD | Line guided yellow Flatbed Ferry, left
-  dl $039A6B                                ; $038F00 | Line guided yellow Flatbed Ferry, right
-  dl $039A6B                                ; $038F03 | Line guided red Flatbed Ferry, left
-  dl $039A6B                                ; $038F06 | Line guided red Flatbed Ferry, right
-  dl $039A6B                                ; $038F09 | Whirling lift
-  dl $039A6B                                ; $038F0C | Falling icicle
-  dl $039A6B                                ; $038F0F | Sparrow
-  dl $039A6B                                ; $038F12 | Mufti Guy, green / red / yellow / purple
-  dl $039A6B                                ; $038F15 | Caged Ghost, squeezing in sewer
-  dl $039A6B                                ; $038F18 | Blargg
-  dl $039A6B                                ; $038F1B | unknown
-  dl $039A6B                                ; $038F1E | Unbalanced snowy platform
-  dl $039A6B                                ; $038F21 | Arrow sign, up / right / left / down
-  dl $039A6B                                ; $038F24 | Diagonal arrow sign, up left / up right / down left / down right
-  dl $039A6B                                ; $038F27 | Dizzy Dandy
-  dl $0C8FE3                                ; $038F2A | Boo Guy
-  dl $039F9F                                ; $038F2D | Bumpty, tackles at Yoshi
-  dl $039F9F                                ; $038F30 | Flying Bumpty, flying aronnd / flying straightly
-  dl $0C9C48                                ; $038F33 | Skeleton Goonie
-  dl $039A6B                                ; $038F36 | Flightless Skeleton Goonie
-  dl $0C9FDE                                ; $038F39 | Skeleton Goonie with a bomb
-  dl $039A6B                                ; $038F3C | Firebar, double-ended, clockwise / anticlockwise
-  dl $039A6B                                ; $038F3F | Firebar, clockwise / anticlockwise
-  dl $039A6B                                ; $038F42 | Star
-  dl $039A6B                                ; $038F45 | Little Skull Mouser
-  dl $039A6B                                ; $038F48 | Cork, seals 3D pipe
-  dl $039F9F                                ; $038F4B | Grinder, runs away
-  dl $039F9F                                ; $038F4E | Grinder, spits seeds of watermelon
-  dl $039F9F                                ; $038F51 | Short Fuse / Seedy Sally, right / left
-  dl $039F9F                                ; $038F54 | Grinder, grasps Baby Mario
-  dl $039F9F                                ; $038F57 | Grinder, climbing, spits seeds of watermelon
-  dl $039A6B                                ; $038F5A | Hot Lips
-  dl $0CC2A4                                ; $038F5D | Boo Balloon, coin / !-switch
-  dl $039A6B                                ; $038F60 | Frog
-  dl $0CC795                                ; $038F63 | Kamek, shoots magic at Yoshi.
-  dl $039A6B                                ; $038F66 | Kamek's magic
-  dl $039A6B                                ; $038F69 | Coin
-  dl $039A6B                                ; $038F6C | (BG3) Balloon
-  dl $039A6B                                ; $038F6F | Coin Cannon for Mini Battle
-  dl $039A6B                                ; $038F72 | Coin for Mini Battle
-  dl $039A6B                                ; $038F75 | Bandit for Mini Battle
-  dl $039A6B                                ; $038F78 | Checkered Platform for Mini Battle
-  dl $039A6B                                ; $038F7B | Bandit for Mini Battle
-  dl $039A6B                                ; $038F7E | Red Balloon for Mini Battle
-  dl $039F9F                                ; $038F81 | Bandit for Mini Battle
-  dl $039A6B                                ; $038F84 | Watermelon Pot for Mini Battle
-  dl $039A6B                                ; $038F87 | possibly Bandit for Mini Battle
+  dl Return_039A6B                          ; $038A5C | Log, floating on water / lava
+  dl Return_039A6B                          ; $038A5F | Closed door
+  dl Return_039A6B                          ; $038A62 | Naval Piranha's stalk
+  dl Return_039A6B                          ; $038A65 | Crate, key
+  dl Return_039A6B                          ; $038A68 | Item from Star Mario block
+  dl head_bop_common                        ; $038A6B | Icy watermelon
+  dl Return_039A6B                          ; $038A6E | Chill
+  dl head_bop_common                        ; $038A71 | Watermelon
+  dl Return_039A6B                          ; $038A74 | Rubble
+  dl head_bop_common                        ; $038A77 | Fire watermelon
+  dl Return_039A6B                          ; $038A7A | Kaboomba
+  dl Return_039A6B                          ; $038A7D | Cannonball of Kaboomba
+  dl Return_039A6B                          ; $038A80 | Raphael the Raven
+  dl Return_039A6B                          ; $038A83 | Goal
+  dl Return_039A6B                          ; $038A86 | G O A L !
+  dl Return_039A6B                          ; $038A89 | BONUS CHALLENGE
+  dl Return_039A6B                          ; $038A8C | Caged Ghost, round mound
+  dl Return_039A6B                          ; $038A8F | Item Card
+  dl Return_039A6B                          ; $038A92 | Boss Door
+  dl Return_039A6B                          ; $038A95 | Boss Explosion
+  dl Return_039A6B                          ; $038A98 | Key from defeated boss
+  dl Return_039A6B                          ; $038A9B | Torpedo of Yoshi Submarine
+  dl Return_039A6B                          ; $038A9E | Bigger Boo
+  dl headbop_frog                           ; $038AA1 | Frog Pirate
+  dl Return_039A6B                          ; $038AA4 | Flame of Red Watermelon
+  dl Return_039A6B                          ; $038AA7 | Bubble
+  dl Return_039A6B                          ; $038AAA | Ski lift
+  dl Return_039A6B                          ; $038AAD | Vertical log, floating on lava
+  dl Return_039A6B                          ; $038AB0 | Dr. Freezegood, nothing / 6 stars / 1-up / Bumpty
+  dl Return_039A6B                          ; $038AB3 | Dr. Freezegood, with ski lift
+  dl head_bonk_lantern_ghost                ; $038AB6 | Shy Guy, green / red / yellow / purple
+  dl Return_039A6B                          ; $038AB9 | Rotating Doors
+  dl head_bop_bandit                        ; $038ABC | Bandit
+  dl Return_039A6B                          ; $038ABF | ? bucket
+  dl head_bop_flashing_egg                  ; $038AC2 | Flashing Egg
+  dl head_bop_common                        ; $038AC5 | Red Egg
+  dl head_bop_common                        ; $038AC8 | Yellow Egg
+  dl head_bop_common                        ; $038ACB | Green Egg
+  dl Return_039A6B                          ; $038ACE | Giant Egg, for battle with Bowser
+  dl head_bop_common                        ; $038AD1 | Key
+  dl head_bop_common                        ; $038AD4 | Huffin' Puffin, running away
+  dl head_bop_common                        ; $038AD7 | Giant Egg, for battle with Prince Froggy?
+  dl head_bop_common                        ; $038ADA | Red Giant Egg
+  dl head_bop_common                        ; $038ADD | Green Giant Egg
+  dl Return_039A6B                          ; $038AE0 | Lunge Fish
+  dl Return_039A6B                          ; $038AE3 | Salvo the Slime
+  dl Return_039A6B                          ; $038AE6 | Salvo the Slime's eyes
+  dl Return_039A6B                          ; $038AE9 | Little Mouser's Nest
+  dl head_bop_common                        ; $038AEC | Little Mouser
+  dl Return_039A6B                          ; $038AEF | Potted Spiked Fun Guy
+  dl Return_039A6B                          ; $038AF2 | Little Mouser, looking around, in nest / behind stuff
+  dl head_bop_common                        ; $038AF5 | Little Mouser, from nest
+  dl Return_039A6B                          ; $038AF8 | Rogger the Potted Ghost
+  dl Return_039A6B                          ; $038AFB | Falling down Rogger the Potted Ghost?
+  dl Return_039A6B                          ; $038AFE | (BG3) Falling down wall
+  dl Return_039A6B                          ; $038B01 | Grim Leecher
+  dl Return_039A6B                          ; $038B04 | Flame spat by Rogger the Potted Ghost
+  dl Return_039A6B                          ; $038B07 | (BG3) Spinning wooden platform
+  dl Return_039A6B                          ; $038B0A | 3 Mini-Ravens
+  dl Return_039A6B                          ; $038B0D | Mini-Raven
+  dl Return_039A6B                          ; $038B10 | Tap-Tap the Red Nose
+  dl Return_039A6B                          ; $038B13 | (BG3) Seesaw
+  dl Return_039A6B                          ; $038B16 | Skinny platform
+  dl Return_039A6B                          ; $038B19 | Slime
+  dl Return_039A6B                          ; $038B1C | Baby Luigi
+  dl Return_039A6B                          ; $038B1F | Stork
+  dl Return_039A6B                          ; $038B22 | Vertical pipe entrance
+  dl head_bop_common                        ; $038B25 | Red Giant Shy Guy
+  dl head_bop_common                        ; $038B28 | Green Giant Shy Guy
+  dl Return_039A6B                          ; $038B2B | Prince Froggy, throat / before fight / throat with uvula / after fight
+  dl Return_039A6B                          ; $038B2E | Burt the Bushful
+  dl Return_039A6B                          ; $038B31 | Shy Guy for Rogger the Potted Ghost
+  dl Return_039A6B                          ; $038B34 | Kamek, for scenes before boss fights
+  dl Return_039A6B                          ; $038B37 | The head of fire of the Thunder Lakitu
+  dl Return_039A6B                          ; $038B3A | Fire of Thunder Lakitu
+  dl Return_039A6B                          ; $038B3D | Hypocenter of the thunder.
+  dl Return_039A6B                          ; $038B40 | Upside down Blow Hard
+  dl Return_039A6B                          ; $038B43 | unknown
+  dl Return_039A6B                          ; $038B46 | Locked door
+  dl Return_039A6B                          ; $038B49 | Middle ring
+  dl Return_039A6B                          ; $038B4C | (BG3) Board
+  dl Return_039A6B                          ; $038B4F | (BG3) Large log
+  dl Return_039A6B                          ; $038B52 | Balloon
+  dl Return_039A6B                          ; $038B55 | Kamek, says \OH MY!!!\""
+  dl Return_039A6B                          ; $038B58 | Upside down Wild Piranha
+  dl Return_039A6B                          ; $038B5B | Green Pinwheel
+  dl Return_039A6B                          ; $038B5E | Pink Pinwheel
+  dl Return_039A6B                          ; $038B61 | (BG3) Sewer ghost with Flatbed Ferry on its head
+  dl head_bop_common                        ; $038B64 | Green Solo Toady
+  dl Return_039A6B                          ; $038B67 | Continuous Super Star
+  dl Return_039A6B                          ; $038B6A | Spark of Raphael the Raven.
+  dl head_bop_bandit                        ; $038B6D | Coin Bandit
+  dl head_bop_common                        ; $038B70 | Pink Toadie
+  dl Return_039A6B                          ; $038B73 | [CRASH]
+  dl Return_039A6B                          ; $038B76 | (BG3) Plank
+  dl Return_039A6B                          ; $038B79 | (BG3) Plank
+  dl Return_039A6B                          ; $038B7C | Bomb
+  dl Return_039A6B                          ; $038B7F | Baby Mario
+  dl head_bop_goomba                        ; $038B82 | Goomba
+  dl Return_039A6B                          ; $038B85 | Muddy Buddy
+  dl Return_039A6B                          ; $038B88 | Pink Pinwheel, (X: direction) (Y: size)
+  dl Return_039A6B                          ; $038B8B | Red coin
+  dl Return_039A6B                          ; $038B8E | Wild Piranha
+  dl Return_039A6B                          ; $038B91 | Hidden Winged Cloud, stars / seed / flower / 1-up
+  dl Return_039A6B                          ; $038B94 | Flashing Egg Block
+  dl Return_039A6B                          ; $038B97 | Red Egg Block
+  dl Return_039A6B                          ; $038B9A | Yellow Egg Block
+  dl Return_039A6B                          ; $038B9D | Hit green Egg Block
+  dl Return_039A6B                          ; $038BA0 | Large Spring Ball
+  dl Return_039A6B                          ; $038BA3 | Hootie the Blue Fish, clockwise
+  dl Return_039A6B                          ; $038BA6 | Hootie the Blue Fish, anticlockwise
+  dl Return_039A6B                          ; $038BA9 | Spring Ball
+  dl Return_039A6B                          ; $038BAC | Clawdaddy
+  dl Return_039A6B                          ; $038BAF | Big Boo with 3 Boos / Big Boo / Big Boo with 3 Boos / Boo
+  dl Return_039A6B                          ; $038BB2 | Train Bandit
+  dl Return_039A6B                          ; $038BB5 | (BG3) Balloon Pumper with red balloon
+  dl Return_039A6B                          ; $038BB8 | Spike
+  dl Return_039A6B                          ; $038BBB | Spiked ball
+  dl Return_039A6B                          ; $038BBE | Piro Dangle, clockwise
+  dl Return_039A6B                          ; $038BC1 | Piro Dangle, anticlockwise
+  dl Return_039A6B                          ; $038BC4 | Biting Bullet Bill Blaster
+  dl Return_039A6B                          ; $038BC7 | Bouncing Bullet Bill Blaster
+  dl Return_039A6B                          ; $038BCA | Bullet Bill Blaster
+  dl head_bop_special_bullet_bill           ; $038BCD | Biting Bullet Bill
+  dl head_bop_special_bullet_bill           ; $038BD0 | Bouncing Bullet Bill
+  dl head_bop_bullet_bill                   ; $038BD3 | Bullet Bill
+  dl Return_039A6B                          ; $038BD6 | Dent of castella
+  dl Return_039A6B                          ; $038BD9 | Log seesaw
+  dl Return_039A6B                          ; $038BDC | Lava Bubble
+  dl Return_039A6B                          ; $038BDF | Lava Bubble, jumps across
+  dl Return_039A6B                          ; $038BE2 | Chain Chomp
+  dl Return_039A6B                          ; $038BE5 | Cloud
+  dl Return_039A6B                          ; $038BE8 | Teleport sprite
+  dl Return_039A6B                          ; $038BEB | Harry Hedgehog
+  dl Return_039A6B                          ; $038BEE | [CRASH]
+  dl Return_039A6B                          ; $038BF1 | Red Egg, gives 1-up
+  dl Return_039A6B                          ; $038BF4 | Super Star
+  dl Return_039A6B                          ; $038BF7 | Red Flatbed Ferry, moving horizontally
+  dl Return_039A6B                          ; $038BFA | Pink Flatbed Ferry, moving vertically
+  dl Return_039A6B                          ; $038BFD | Mock Up, green / red
+  dl Return_039A6B                          ; $038C00 | Yoshi, at the Goal
+  dl Return_039A6B                          ; $038C03 | Fly Guy, 5 stars / red coin / 1-up / 1-up
+  dl Return_039A6B                          ; $038C06 | Kamek, at Bowser's room
+  dl Return_039A6B                          ; $038C09 | Swing of Grinders
+  dl Return_039A6B                          ; $038C0C | (BG3) Dangling Ghost
+  dl head_bop_4_toadies                     ; $038C0F | 4 Toadies
+  dl Return_039A6B                          ; $038C12 | Melon Bug
+  dl Return_039A6B                          ; $038C15 | Door
+  dl Return_039A6B                          ; $038C18 | Expansion Block
+  dl Return_039A6B                          ; $038C1B | Blue checkered block
+  dl Return_039A6B                          ; $038C1E | Red checkered block
+  dl Return_039A6B                          ; $038C21 | POW
+  dl Return_039A6B                          ; $038C24 | Yoshi Block
+  dl Return_039A6B                          ; $038C27 | Spiny Egg
+  dl Return_039A6B                          ; $038C2A | Chained green Flatbed Ferry
+  dl Return_039A6B                          ; $038C2D | Mace Guy
+  dl Return_039A6B                          ; $038C30 | Mace
+  dl Return_039A6B                          ; $038C33 | !-switch
+  dl Return_039A6B                          ; $038C36 | Chomp Rock
+  dl Return_039A6B                          ; $038C39 | Wild Ptooie Piranha, spits 1 / 3 Needlenose
+  dl Return_039A6B                          ; $038C3C | Tulip
+  dl Return_039A6B                          ; $038C3F | Pot of Potted Spiked Fun Guy
+  dl Return_039A6B                          ; $038C42 | Fireball of Thunder Lakitu
+  dl head_bop_bandit                        ; $038C45 | Bandit, getting under cover, left
+  dl head_bop_bandit                        ; $038C48 | Bandit, getting under cover, right
+  dl Return_039A6B                          ; $038C4B | Nep-Enut / Gargantua Blargg
+  dl Return_039A6B                          ; $038C4E | Incoming Chomp
+  dl Return_039A6B                          ; $038C51 | Flcok of Incoming Chomps
+  dl Return_039A6B                          ; $038C54 | Falling Incoming Chomp
+  dl Return_039A6B                          ; $038C57 | Shadow of falling Incoming Chomp
+  dl Return_039A6B                          ; $038C5A | Shy Guy in background
+  dl Return_039A6B                          ; $038C5D | Fill Eggs
+  dl Return_039A6B                          ; $038C60 | Sign Arrow and Shadow
+  dl Return_039A6B                          ; $038C63 | Hint Block
+  dl Return_039A6B                          ; $038C66 | Hookbill the Koopa
+  dl Return_039A6B                          ; $038C69 | Morph Bubble, Car
+  dl Return_039A6B                          ; $038C6C | Morph Bubble, Mole Tank
+  dl Return_039A6B                          ; $038C6F | Morph Bubble, Helicopter
+  dl Return_039A6B                          ; $038C72 | Morph Bubble, Train
+  dl Return_039A6B                          ; $038C75 | Wind of Fuzzy
+  dl Return_039A6B                          ; $038C78 | Morph Bubble, Submarine
+  dl Return_039A6B                          ; $038C7B | Hidden Winged Cloud, 1-up / 5 stars / !-switch / 5 stars
+  dl Return_039A6B                          ; $038C7E | Winged Cloud, 8 coins
+  dl Return_039A6B                          ; $038C81 | Winged Cloud, bubbled 1-up
+  dl Return_039A6B                          ; $038C84 | Winged Cloud, flower
+  dl Return_039A6B                          ; $038C87 | Winged Cloud, POW
+  dl Return_039A6B                          ; $038C8A | Winged Cloud, stairs, right / left
+  dl Return_039A6B                          ; $038C8D | Winged Cloud, platform, right / left
+  dl Return_039A6B                          ; $038C90 | Winged Cloud, Bandit
+  dl Return_039A6B                          ; $038C93 | Winged Cloud, coin (object)
+  dl Return_039A6B                          ; $038C96 | Winged Cloud, 1-up
+  dl Return_039A6B                          ; $038C99 | Winged Cloud, key
+  dl Return_039A6B                          ; $038C9C | Winged Cloud, 3 stars
+  dl Return_039A6B                          ; $038C9F | Winged Cloud, 5 stars
+  dl Return_039A6B                          ; $038CA2 | Winged Cloud, door
+  dl Return_039A6B                          ; $038CA5 | Winged Cloud, ground eater
+  dl Return_039A6B                          ; $038CA8 | Winged Cloud, watermelon
+  dl Return_039A6B                          ; $038CAB | Winged Cloud, fire watermelon
+  dl Return_039A6B                          ; $038CAE | Winged Cloud, icy watermelon
+  dl Return_039A6B                          ; $038CB1 | Winged Cloud, seed of sunflower with 3 leaves
+  dl Return_039A6B                          ; $038CB4 | Winged Cloud, seed of sunflower with 6 leaves
+  dl Return_039A6B                          ; $038CB7 | Winged Cloud, [CRASH]
+  dl Return_039A6B                          ; $038CBA | Boss Door of Bowser's room
+  dl Return_039A6B                          ; $038CBD | Winged Cloud, random item.
+  dl Return_039A6B                          ; $038CC0 | Winged Cloud, !-switch / !-switch
+  dl Return_039A6B                          ; $038CC3 | Baron Von Zeppelin, Giant Egg
+  dl Return_039A6B                          ; $038CC6 | Bowser's flame
+  dl Return_039A6B                          ; $038CC9 | Bowser's quake
+  dl Return_039A6B                          ; $038CCC | Horizontal entrance, towards right
+  dl Return_039A6B                          ; $038CCF | Hidden entrance, revealed by an ! switch
+  dl Return_039A6B                          ; $038CD2 | Marching Milde
+  dl main_giant_milde                       ; $038CD5 | Giant Milde
+  dl main_large_milde                       ; $038CD8 | Large Milde
+  dl Return_039A6B                          ; $038CDB | Mountain backgrounds at fight with Hookbill the Koopa
+  dl Return_039A6B                          ; $038CDE | (BG3) Ghost with Flatbed Ferry on its head
+  dl Return_039A6B                          ; $038CE1 | Sluggy the Unshaven
+  dl Return_039A6B                          ; $038CE4 | Chomp signboard.
+  dl headbop_fishin_lakitu                  ; $038CE7 | Fishin' Lakitu
+  dl Return_039A6B                          ; $038CEA | Flower pot, key / 6 stars / 6 coins / nothing
+  dl Return_039A6B                          ; $038CED | (BG3) Soft thing
+  dl Return_039A6B                          ; $038CF0 | Snowball
+  dl Return_039A6B                          ; $038CF3 | Closer, in Naval Piranha's room
+  dl Return_039A6B                          ; $038CF6 | Falling Rock
+  dl Return_039A6B                          ; $038CF9 | Piscatory Pete, Blue / Gold
+  dl Return_039A6B                          ; $038CFC | Perying Mantas
+  dl Return_039A6B                          ; $038CFF | Loch Nestor
+  dl Return_039A6B                          ; $038D02 | Boo Blah, normal / upside down
+  dl Return_039A6B                          ; $038D05 | Boo Blah with Piro Dangle, normal / upside down
+  dl Return_039A6B                          ; $038D08 | Heading cactus
+  dl Return_039A6B                          ; $038D0B | Green Needlenose
+  dl Return_039A6B                          ; $038D0E | Gusty, left / right / infinite right / infinite left
+  dl Return_039A6B                          ; $038D11 | Burt, two / one
+  dl Return_039A6B                          ; $038D14 | Goonie, right / towards Yoshi / generator right / generator left
+  dl Return_039A6B                          ; $038D17 | 3 Flightless Goonies
+  dl head_bop_cloud_drop_vertical           ; $038D1A | Cloud Drop, moving vertically
+  dl head_bop_cloud_drop_horizontal         ; $038D1D | Cloud Drop, moving horizontally
+  dl Return_039A6B                          ; $038D20 | Flamer Guy, jumping around
+  dl Return_039A6B                          ; $038D23 | Flamer Guy, walking around
+  dl Return_039A6B                          ; $038D26 | Eggo-Dil
+  dl Return_039A6B                          ; $038D29 | Eggo-Dil's face
+  dl Return_039A6B                          ; $038D2C | Petal of Eggo-Dil
+  dl Return_039A6B                          ; $038D2F | Bubble-Plant
+  dl head_bop_stilt_guy                     ; $038D32 | Stilt Guy, green / red / yellow / purple
+  dl head_bop_common                        ; $038D35 | Woozy Guy, green / red / yellow / purple
+  dl Return_039A6B                          ; $038D38 | Egg-Plant / Needlenose-Plant
+  dl Return_039A6B                          ; $038D3B | Slugger
+  dl Return_039A6B                          ; $038D3E | Parent and children of Huffin' Puffins
+  dl Return_039A6B                          ; $038D41 | Barney Bubble
+  dl Return_039A6B                          ; $038D44 | Blow Hard
+  dl Return_039A6B                          ; $038D47 | Yellow Needlenose
+  dl Return_039A6B                          ; $038D4A | Flower
+  dl Return_039A6B                          ; $038D4D | Spear Guy, long spear
+  dl Return_039A6B                          ; $038D50 | Spear Guy, short spear
+  dl head_bop_zeus_guy                      ; $038D53 | Zeus Guy
+  dl Return_039A6B                          ; $038D56 | Energy of Zeus Guy
+  dl Return_039A6B                          ; $038D59 | Poochy
+  dl Return_039A6B                          ; $038D5C | Bubbled 1-up
+  dl Return_039A6B                          ; $038D5F | Spiky mace
+  dl Return_039A6B                          ; $038D62 | Spiky mace, double-ended
+  dl Return_039A6B                          ; $038D65 | Boo Guys spinning spiky mace
+  dl Return_039A6B                          ; $038D68 | Jean de Fillet, right / left
+  dl Return_039A6B                          ; $038D6B | Boo Guys, carrying bombs towards left.
+  dl Return_039A6B                          ; $038D6E | Boo Guys, carrying bombs towards right
+  dl head_bop_common                        ; $038D71 | Seed of watermelon
+  dl Return_039A6B                          ; $038D74 | Milde
+  dl Return_039A6B                          ; $038D77 | Tap-Tap
+  dl Return_039A6B                          ; $038D7A | Tap-Tap, stays on ledges
+  dl Return_039A6B                          ; $038D7D | Hopping Tap-Tap
+  dl Return_039A6B                          ; $038D80 | Chained spike ball, controlled by Boo Guy
+  dl Return_039A6B                          ; $038D83 | Boo Guy, rotating a pulley, right / left
+  dl Return_039A6B                          ; $038D86 | Crate, 6 stars
+  dl Return_039A6B                          ; $038D89 | Boo Man Bluff
+  dl Return_039A6B                          ; $038D8C | Flower
+  dl Return_039A6B                          ; $038D8F | Georgette Jelly
+  dl Return_039A6B                          ; $038D92 | Splashed Georgette Jelly
+  dl Return_039A6B                          ; $038D95 | Snifit
+  dl Return_039A6B                          ; $038D98 | Bullet, shot by Snifit
+  dl Return_039A6B                          ; $038D9B | Coin, gravity affected
+  dl Return_039A6B                          ; $038D9E | Floating round platform on water
+  dl Return_039A6B                          ; $038DA1 | Donut Lift
+  dl Return_039A6B                          ; $038DA4 | Giant Donut Lift
+  dl Return_039A6B                          ; $038DA7 | Spooky
+  dl Return_039A6B                          ; $038DAA | Green Glove
+  dl head_bop_lakitu                        ; $038DAD | Lakitu, one / two
+  dl Return_039A6B                          ; $038DB0 | Lakitu's cloud
+  dl Return_039A6B                          ; $038DB3 | Spiny Egg
+  dl Return_039A6B                          ; $038DB6 | Brown Arrow Wheel
+  dl Return_039A6B                          ; $038DB9 | Blue Arrow Wheel
+  dl Return_039A6B                          ; $038DBC | Double-ended arrow lift
+  dl Return_039A6B                          ; $038DBF | Explosion of Number Platform
+  dl Return_039A6B                          ; $038DC2 | ? bucket, Bandit
+  dl Return_039A6B                          ; $038DC5 | ? bucket, 5 coins
+  dl head_bop_common                        ; $038DC8 | Stretch, green / red / yellow / purple
+  dl Return_039A6B                          ; $038DCB | Kamek, for the ending scene / flying and chases
+  dl Return_039A6B                          ; $038DCE | Spiked log held by chain and pulley
+  dl Return_039A6B                          ; $038DD1 | ? Pulley
+  dl Return_039A6B                          ; $038DD4 | Ground shake
+  dl Return_039A6B                          ; $038DD7 | Fuzzy
+  dl Return_039A6B                          ; $038DDA | Shy Guy, with Bandit hidden
+  dl Return_039A6B                          ; $038DDD | Fat Guy, red / green
+  dl head_bop_fly_guy                       ; $038DE0 | Fly Guy carrying red coin / Whirly Fly Guy
+  dl Return_039A6B                          ; $038DE3 | Yoshi, in the intro scene
+  dl Return_039A6B                          ; $038DE6 | unknown
+  dl Return_039A6B                          ; $038DE9 | Lava Drop, moving horizontally
+  dl Return_039A6B                          ; $038DEC | Lava Drop, moving vertically
+  dl Return_039A6B                          ; $038DEF | Locked door
+  dl Return_039A6B                          ; $038DF2 | Lemon Drop
+  dl head_bonk_lantern_ghost                ; $038DF5 | Lantern Ghost
+  dl Return_039A6B                          ; $038DF8 | Baby Bowser
+  dl Return_039A6B                          ; $038DFB | Raven, always circling, anticlockwise / clockwise
+  dl Return_039A6B                          ; $038DFE | Raven, anticlockwise / clockwise initially
+  dl Return_039A6B                          ; $038E01 | 3x6 Falling Rock
+  dl Return_039A6B                          ; $038E04 | 3x3 Falling Rock
+  dl Return_039A6B                          ; $038E07 | 3x9 Falling Rock
+  dl Return_039A6B                          ; $038E0A | 6x3 Falling Rock
+  dl Return_039A6B                          ; $038E0D | Stomach Acid
+  dl Return_039A6B                          ; $038E10 | Flipper, downwards
+  dl Return_039A6B                          ; $038E13 | Fang, dangling
+  dl Return_039A6B                          ; $038E16 | Fang, flying wavily
+  dl Return_039A6B                          ; $038E19 | Flopsy Fish, swimming around
+  dl Return_039A6B                          ; $038E1C | Flopsy Fish, swimming and occasionally jumps vertically
+  dl Return_039A6B                          ; $038E1F | Flopsy Fish, swimming and jumps in an arc
+  dl Return_039A6B                          ; $038E22 | Flopsy Fish, jumps 3 times in an arc, right / left
+  dl Return_039A6B                          ; $038E25 | Spray Fish
+  dl Return_039A6B                          ; $038E28 | Flipper, rightwards / leftwards
+  dl head_bop_sluggy                        ; $038E2B | Blue Sluggy, falling down / crawing ceiling
+  dl head_bop_sluggy                        ; $038E2E | Pink Sluggy, falling down / crawing ceiling but doesn't move
+  dl Return_039A6B                          ; $038E31 | Horizontal entrance, towards left
+  dl Return_039A6B                          ; $038E34 | Large Spring Ball
+  dl Return_039A6B                          ; $038E37 | Arrow cloud, up
+  dl Return_039A6B                          ; $038E3A | Arrow cloud, up right
+  dl Return_039A6B                          ; $038E3D | Arrow cloud, right
+  dl Return_039A6B                          ; $038E40 | Arrow cloud, down right
+  dl Return_039A6B                          ; $038E43 | Arrow cloud, down
+  dl Return_039A6B                          ; $038E46 | Arrow cloud, down left
+  dl Return_039A6B                          ; $038E49 | Arrow cloud, left
+  dl Return_039A6B                          ; $038E4C | Arrow cloud, up left
+  dl Return_039A6B                          ; $038E4F | Arrow cloud, rotating
+  dl Return_039A6B                          ; $038E52 | Flutter
+  dl Return_039A6B                          ; $038E55 | Goonie with Shy Guy
+  dl Return_039A6B                          ; $038E58 | Shark Chomp
+  dl Return_039A6B                          ; $038E5B | Very Fat Goonie
+  dl Return_039A6B                          ; $038E5E | Cactus Jack, one / three
+  dl head_bop_wall_lakitu                   ; $038E61 | Wall Lakitu
+  dl Return_039A6B                          ; $038E64 | Bowling Goonie
+  dl Return_039A6B                          ; $038E67 | Grunt, walking
+  dl Return_039A6B                          ; $038E6A | Grunt, running
+  dl Return_039A6B                          ; $038E6D | Dancing Spear Guy
+  dl Return_039A6B                          ; $038E70 | Green switch for green spiked platform
+  dl Return_039A6B                          ; $038E73 | Red switch for red spiked platform
+  dl Return_039A6B                          ; $038E76 | Pink Pinwheel with Shy Guys, clockwise / anticlockwise
+  dl Return_039A6B                          ; $038E79 | Green spiked platform
+  dl Return_039A6B                          ; $038E7C | Red spiked platform
+  dl Return_039A6B                          ; $038E7F | Bonus Item, red coin / key / flower / door
+  dl Return_039A6B                          ; $038E82 | Two spiked platforms with one switch in the center
+  dl Return_039A6B                          ; $038E85 | Bouncing green Needlenose
+  dl Return_039A6B                          ; $038E88 | Nipper Plant
+  dl Return_039A6B                          ; $038E8B | Nipper Spore
+  dl head_bop_thunder_lakitu                ; $038E8E | Thunder Lakitu, one / two
+  dl CODE_07E3C8                            ; $038E91 | Green Koopa shell
+  dl CODE_07E3C8                            ; $038E94 | Red Koopa shell
+  dl CODE_07E3BD                            ; $038E97 | Green Beach Koopa
+  dl CODE_07E3BD                            ; $038E9A | Red Beach Koopa
+  dl CODE_07E3DF                            ; $038E9D | Green Koopa
+  dl CODE_07E3F9                            ; $038EA0 | Red Koopa
+  dl CODE_07E730                            ; $038EA3 | Green Para Koopa, jumping forth.
+  dl CODE_07E74D                            ; $038EA6 | Red Para Koopa, flying horizontally
+  dl CODE_07E74D                            ; $038EA9 | Red Para Koopa, flying vertically
+  dl CODE_07EB45                            ; $038EAC | Aqua Lakitu
+  dl Return_039A6B                          ; $038EAF | Naval Piranha
+  dl Return_039A6B                          ; $038EB2 | Naval Bud
+  dl Return_039A6B                          ; $038EB5 | Baron Von Zeppelin, red Suy Guy
+  dl Return_039A6B                          ; $038EB8 | Baron Von Zeppelin, Needlenose
+  dl Return_039A6B                          ; $038EBB | Baron Von Zeppelin, bomb
+  dl Return_039A6B                          ; $038EBE | Baron Von Zeppelin, Bandit
+  dl Return_039A6B                          ; $038EC1 | Baron Von Zeppelin, large Spring Ball
+  dl Return_039A6B                          ; $038EC4 | Baron Von Zeppelin, 1-up
+  dl Return_039A6B                          ; $038EC7 | Baron Von Zeppelin, key
+  dl Return_039A6B                          ; $038ECA | Baron Von Zeppelin, 5 coins
+  dl Return_039A6B                          ; $038ECD | Baron Von Zeppelin, watermelon
+  dl Return_039A6B                          ; $038ED0 | Baron Von Zeppelin, fire watermelon
+  dl Return_039A6B                          ; $038ED3 | Baron Von Zeppelin, icy watermelon
+  dl Return_039A6B                          ; $038ED6 | Baron Von Zeppelin, crate, 6 stars.
+  dl Return_039A6B                          ; $038ED9 | Baron Von Zeppelin
+  dl Return_039A6B                          ; $038EDC | Spinning Log
+  dl head_bop_crazee_daisy                  ; $038EDF | Crazee Dayzee
+  dl Return_039A6B                          ; $038EE2 | Dragonfly
+  dl Return_039A6B                          ; $038EE5 | Butterfly
+  dl head_bop_common                        ; $038EE8 | Bumpty
+  dl Return_039A6B                          ; $038EEB | Active line guided green Flatbed Ferry, left
+  dl Return_039A6B                          ; $038EEE | Active line guided green Flatbed Ferry, right
+  dl Return_039A6B                          ; $038EF1 | Active line guided yellow Flatbed Ferry, left
+  dl Return_039A6B                          ; $038EF4 | Active line guided yellow Flatbed Ferry, right
+  dl Return_039A6B                          ; $038EF7 | Line guided green Flatbed Ferry, left
+  dl Return_039A6B                          ; $038EFA | Line guided green Flatbed Ferry, right
+  dl Return_039A6B                          ; $038EFD | Line guided yellow Flatbed Ferry, left
+  dl Return_039A6B                          ; $038F00 | Line guided yellow Flatbed Ferry, right
+  dl Return_039A6B                          ; $038F03 | Line guided red Flatbed Ferry, left
+  dl Return_039A6B                          ; $038F06 | Line guided red Flatbed Ferry, right
+  dl Return_039A6B                          ; $038F09 | Whirling lift
+  dl Return_039A6B                          ; $038F0C | Falling icicle
+  dl Return_039A6B                          ; $038F0F | Sparrow
+  dl Return_039A6B                          ; $038F12 | Mufti Guy, green / red / yellow / purple
+  dl Return_039A6B                          ; $038F15 | Caged Ghost, squeezing in sewer
+  dl Return_039A6B                          ; $038F18 | Blargg
+  dl Return_039A6B                          ; $038F1B | unknown
+  dl Return_039A6B                          ; $038F1E | Unbalanced snowy platform
+  dl Return_039A6B                          ; $038F21 | Arrow sign, up / right / left / down
+  dl Return_039A6B                          ; $038F24 | Diagonal arrow sign, up left / up right / down left / down right
+  dl Return_039A6B                          ; $038F27 | Dizzy Dandy
+  dl head_bop_boo_guy                       ; $038F2A | Boo Guy
+  dl head_bop_common                        ; $038F2D | Bumpty, tackles at Yoshi
+  dl head_bop_common                        ; $038F30 | Flying Bumpty, flying aronnd / flying straightly
+  dl head_bop_skeleton_goonie               ; $038F33 | Skeleton Goonie
+  dl Return_039A6B                          ; $038F36 | Flightless Skeleton Goonie
+  dl head_bop_skeleton_goonie_bomb          ; $038F39 | Skeleton Goonie with a bomb
+  dl Return_039A6B                          ; $038F3C | Firebar, double-ended, clockwise / anticlockwise
+  dl Return_039A6B                          ; $038F3F | Firebar, clockwise / anticlockwise
+  dl Return_039A6B                          ; $038F42 | Star
+  dl Return_039A6B                          ; $038F45 | Little Skull Mouser
+  dl Return_039A6B                          ; $038F48 | Cork, seals 3D pipe
+  dl head_bop_common                        ; $038F4B | Grinder, runs away
+  dl head_bop_common                        ; $038F4E | Grinder, spits seeds of watermelon
+  dl head_bop_common                        ; $038F51 | Short Fuse / Seedy Sally, right / left
+  dl head_bop_common                        ; $038F54 | Grinder, grasps Baby Mario
+  dl head_bop_common                        ; $038F57 | Grinder, climbing, spits seeds of watermelon
+  dl Return_039A6B                          ; $038F5A | Hot Lips
+  dl head_bop_boo_balloon                   ; $038F5D | Boo Balloon, coin / !-switch
+  dl Return_039A6B                          ; $038F60 | Frog
+  dl head_bop_kamek_magic                   ; $038F63 | Kamek, shoots magic at Yoshi.
+  dl Return_039A6B                          ; $038F66 | Kamek's magic
+  dl Return_039A6B                          ; $038F69 | Coin
+  dl Return_039A6B                          ; $038F6C | (BG3) Balloon
+  dl Return_039A6B                          ; $038F6F | Coin Cannon for Mini Battle
+  dl Return_039A6B                          ; $038F72 | Coin for Mini Battle
+  dl Return_039A6B                          ; $038F75 | Bandit for Mini Battle
+  dl Return_039A6B                          ; $038F78 | Checkered Platform for Mini Battle
+  dl Return_039A6B                          ; $038F7B | Bandit for Mini Battle
+  dl Return_039A6B                          ; $038F7E | Red Balloon for Mini Battle
+  dl head_bop_common                        ; $038F81 | Bandit for Mini Battle
+  dl Return_039A6B                          ; $038F84 | Watermelon Pot for Mini Battle
+  dl Return_039A6B                          ; $038F87 | possibly Bandit for Mini Battle
 ; end sprite head_bops table
 
 ; sprite riding_yoshi routine table: $8F8A - 94B7
@@ -1350,448 +1350,448 @@ head_bops:
 ; $12A: bandit shyguy
 ; $134: baby bowser
 sprite_ridings:
-  dl $039A6B                                ; $038F8A |
-  dl $039A6B                                ; $038F8D |
-  dl $039A6B                                ; $038F90 |
-  dl $039A6B                                ; $038F93 |
-  dl $039A6B                                ; $038F96 |
-  dl $039A6B                                ; $038F99 |
-  dl $039A6B                                ; $038F9C |
-  dl $039A6B                                ; $038F9F |
-  dl $039A6B                                ; $038FA2 |
-  dl $039A6B                                ; $038FA5 |
-  dl $039A6B                                ; $038FA8 |
-  dl $039A6B                                ; $038FAB |
-  dl $039A6B                                ; $038FAE |
-  dl $039A6B                                ; $038FB1 |
-  dl $039A6B                                ; $038FB4 |
-  dl $039A6B                                ; $038FB7 |
-  dl $039A6B                                ; $038FBA |
-  dl $039A6B                                ; $038FBD |
-  dl $039A6B                                ; $038FC0 |
-  dl $039A6B                                ; $038FC3 |
-  dl $039A6B                                ; $038FC6 |
-  dl $039A6B                                ; $038FC9 |
-  dl $039A6B                                ; $038FCC |
-  dl $039A6B                                ; $038FCF |
-  dl $039A6B                                ; $038FD2 |
-  dl $039A6B                                ; $038FD5 |
-  dl $039A6B                                ; $038FD8 |
-  dl $039A6B                                ; $038FDB |
-  dl $039A6B                                ; $038FDE |
-  dl $039A6B                                ; $038FE1 |
-  dl $039A6B                                ; $038FE4 |
-  dl $039A6B                                ; $038FE7 |
-  dl $039A6B                                ; $038FEA |
-  dl $039A6B                                ; $038FED |
-  dl $039A6B                                ; $038FF0 |
-  dl $039A6B                                ; $038FF3 |
-  dl $039A6B                                ; $038FF6 |
-  dl $039A6B                                ; $038FF9 |
-  dl $039A6B                                ; $038FFC |
-  dl $039A6B                                ; $038FFF |
-  dl $039A6B                                ; $039002 |
-  dl $039A6B                                ; $039005 |
-  dl $039A6B                                ; $039008 |
-  dl $039A6B                                ; $03900B |
-  dl $039A6B                                ; $03900E |
-  dl $039A6B                                ; $039011 |
-  dl $039A6B                                ; $039014 |
-  dl $039A6B                                ; $039017 |
-  dl $039A6B                                ; $03901A |
-  dl $039A6B                                ; $03901D |
-  dl $039A6B                                ; $039020 |
-  dl $039A6B                                ; $039023 |
-  dl $039A6B                                ; $039026 |
-  dl $039A6B                                ; $039029 |
-  dl $039A6B                                ; $03902C |
-  dl $04A0AB                                ; $03902F | grim leecher
-  dl $039A6B                                ; $039032 |
-  dl $039A6B                                ; $039035 |
-  dl $039A6B                                ; $039038 |
-  dl $039A6B                                ; $03903B |
-  dl $039A6B                                ; $03903E |
-  dl $039A6B                                ; $039041 |
-  dl $039A6B                                ; $039044 |
-  dl $039A6B                                ; $039047 |
-  dl $039A6B                                ; $03904A |
-  dl $039A6B                                ; $03904D |
-  dl $039A6B                                ; $039050 |
-  dl $039A6B                                ; $039053 |
-  dl $039A6B                                ; $039056 |
-  dl $039A6B                                ; $039059 |
-  dl $039A6B                                ; $03905C |
-  dl $039A6B                                ; $03905F |
-  dl $039A6B                                ; $039062 |
-  dl $039A6B                                ; $039065 |
-  dl $039A6B                                ; $039068 |
-  dl $039A6B                                ; $03906B |
-  dl $039A6B                                ; $03906E |
-  dl $039A6B                                ; $039071 |
-  dl $039A6B                                ; $039074 |
-  dl $039A6B                                ; $039077 |
-  dl $039A6B                                ; $03907A |
-  dl $039A6B                                ; $03907D |
-  dl $039A6B                                ; $039080 |
-  dl $039A6B                                ; $039083 |
-  dl $039A6B                                ; $039086 |
-  dl $039A6B                                ; $039089 |
-  dl $039A6B                                ; $03908C |
-  dl $039A6B                                ; $03908F |
-  dl $039A6B                                ; $039092 |
-  dl $039A6B                                ; $039095 |
-  dl $039A6B                                ; $039098 |
-  dl $039A6B                                ; $03909B |
-  dl $039A6B                                ; $03909E |
-  dl $039A6B                                ; $0390A1 |
-  dl $039A6B                                ; $0390A4 |
-  dl $039A6B                                ; $0390A7 |
-  dl $039A6B                                ; $0390AA |
-  dl $06CF1A                                ; $0390AD | baby mario
-  dl $039A6B                                ; $0390B0 |
-  dl $039A6B                                ; $0390B3 |
-  dl $039A6B                                ; $0390B6 |
-  dl $039A6B                                ; $0390B9 |
-  dl $039A6B                                ; $0390BC |
-  dl $039A6B                                ; $0390BF |
-  dl $039A6B                                ; $0390C2 |
-  dl $039A6B                                ; $0390C5 |
-  dl $039A6B                                ; $0390C8 |
-  dl $039A6B                                ; $0390CB |
-  dl $039A6B                                ; $0390CE |
-  dl $039A6B                                ; $0390D1 |
-  dl $039A6B                                ; $0390D4 |
-  dl $039A6B                                ; $0390D7 |
-  dl $039A6B                                ; $0390DA |
-  dl $039A6B                                ; $0390DD |
-  dl $039A6B                                ; $0390E0 |
-  dl $039A6B                                ; $0390E3 |
-  dl $039A6B                                ; $0390E6 |
-  dl $039A6B                                ; $0390E9 |
-  dl $039A6B                                ; $0390EC |
-  dl $039A6B                                ; $0390EF |
-  dl $039A6B                                ; $0390F2 |
-  dl $039A6B                                ; $0390F5 |
-  dl $039A6B                                ; $0390F8 |
-  dl $039A6B                                ; $0390FB |
-  dl $039A6B                                ; $0390FE |
-  dl $039A6B                                ; $039101 |
-  dl $039A6B                                ; $039104 |
-  dl $039A6B                                ; $039107 |
-  dl $039A6B                                ; $03910A |
-  dl $039A6B                                ; $03910D |
-  dl $039A6B                                ; $039110 |
-  dl $039A6B                                ; $039113 |
-  dl $039A6B                                ; $039116 |
-  dl $039A6B                                ; $039119 |
-  dl $039A6B                                ; $03911C |
-  dl $039A6B                                ; $03911F |
-  dl $039A6B                                ; $039122 |
-  dl $039A6B                                ; $039125 |
-  dl $039A6B                                ; $039128 |
-  dl $039A6B                                ; $03912B |
-  dl $039A6B                                ; $03912E |
-  dl $039A6B                                ; $039131 |
-  dl $039A6B                                ; $039134 |
-  dl $039A6B                                ; $039137 |
-  dl $039A6B                                ; $03913A |
-  dl $039A6B                                ; $03913D |
-  dl $039A6B                                ; $039140 |
-  dl $039A6B                                ; $039143 |
-  dl $039A6B                                ; $039146 |
-  dl $039A6B                                ; $039149 |
-  dl $039A6B                                ; $03914C |
-  dl $039A6B                                ; $03914F |
-  dl $039A6B                                ; $039152 |
-  dl $039A6B                                ; $039155 |
-  dl $039A6B                                ; $039158 |
-  dl $039A6B                                ; $03915B |
-  dl $039A6B                                ; $03915E |
-  dl $039A6B                                ; $039161 |
-  dl $039A6B                                ; $039164 |
-  dl $039A6B                                ; $039167 |
-  dl $039A6B                                ; $03916A |
-  dl $039A6B                                ; $03916D |
-  dl $039A6B                                ; $039170 |
-  dl $039A6B                                ; $039173 |
-  dl $039A6B                                ; $039176 |
-  dl $039A6B                                ; $039179 |
-  dl $039A6B                                ; $03917C |
-  dl $039A6B                                ; $03917F |
-  dl $039A6B                                ; $039182 |
-  dl $039A6B                                ; $039185 |
-  dl $039A6B                                ; $039188 |
-  dl $039A6B                                ; $03918B |
-  dl $039A6B                                ; $03918E |
-  dl $039A6B                                ; $039191 |
-  dl $039A6B                                ; $039194 |
-  dl $039A6B                                ; $039197 |
-  dl $039A6B                                ; $03919A |
-  dl $039A6B                                ; $03919D |
-  dl $039A6B                                ; $0391A0 |
-  dl $039A6B                                ; $0391A3 |
-  dl $039A6B                                ; $0391A6 |
-  dl $039A6B                                ; $0391A9 |
-  dl $039A6B                                ; $0391AC |
-  dl $039A6B                                ; $0391AF |
-  dl $039A6B                                ; $0391B2 |
-  dl $039A6B                                ; $0391B5 |
-  dl $039A6B                                ; $0391B8 |
-  dl $039A6B                                ; $0391BB |
-  dl $039A6B                                ; $0391BE |
-  dl $039A6B                                ; $0391C1 |
-  dl $039A6B                                ; $0391C4 |
-  dl $039A6B                                ; $0391C7 |
-  dl $039A6B                                ; $0391CA |
-  dl $039A6B                                ; $0391CD |
-  dl $039A6B                                ; $0391D0 |
-  dl $039A6B                                ; $0391D3 |
-  dl $039A6B                                ; $0391D6 |
-  dl $039A6B                                ; $0391D9 |
-  dl $039A6B                                ; $0391DC |
-  dl $039A6B                                ; $0391DF |
-  dl $039A6B                                ; $0391E2 |
-  dl $039A6B                                ; $0391E5 |
-  dl $039A6B                                ; $0391E8 |
-  dl $039A6B                                ; $0391EB |
-  dl $039A6B                                ; $0391EE |
-  dl $039A6B                                ; $0391F1 |
-  dl $039A6B                                ; $0391F4 |
-  dl $039A6B                                ; $0391F7 |
-  dl $039A6B                                ; $0391FA |
-  dl $039A6B                                ; $0391FD |
-  dl $039A6B                                ; $039200 |
-  dl $039A6B                                ; $039203 |
-  dl $039A6B                                ; $039206 |
-  dl $039A6B                                ; $039209 |
-  dl $039A6B                                ; $03920C |
-  dl $039A6B                                ; $03920F |
-  dl $039A6B                                ; $039212 |
-  dl $039A6B                                ; $039215 |
-  dl $039A6B                                ; $039218 |
-  dl $039A6B                                ; $03921B |
-  dl $039A6B                                ; $03921E |
-  dl $039A6B                                ; $039221 |
-  dl $039A6B                                ; $039224 |
-  dl $039A6B                                ; $039227 |
-  dl $039A6B                                ; $03922A |
-  dl $039A6B                                ; $03922D |
-  dl $039A6B                                ; $039230 |
-  dl $039A6B                                ; $039233 |
-  dl $039A6B                                ; $039236 |
-  dl $039A6B                                ; $039239 |
-  dl $039A6B                                ; $03923C |
-  dl $039A6B                                ; $03923F |
-  dl $039A6B                                ; $039242 |
-  dl $039A6B                                ; $039245 |
-  dl $039A6B                                ; $039248 |
-  dl $039A6B                                ; $03924B |
-  dl $039A6B                                ; $03924E |
-  dl $039A6B                                ; $039251 |
-  dl $039A6B                                ; $039254 |
-  dl $039A6B                                ; $039257 |
-  dl $039A6B                                ; $03925A |
-  dl $039A6B                                ; $03925D |
-  dl $039A6B                                ; $039260 |
-  dl $039A6B                                ; $039263 |
-  dl $039A6B                                ; $039266 |
-  dl $039A6B                                ; $039269 |
-  dl $039A6B                                ; $03926C |
-  dl $039A6B                                ; $03926F |
-  dl $039A6B                                ; $039272 |
-  dl $039A6B                                ; $039275 |
-  dl $039A6B                                ; $039278 |
-  dl $039A6B                                ; $03927B |
-  dl $039A6B                                ; $03927E |
-  dl $039A6B                                ; $039281 |
-  dl $039A6B                                ; $039284 |
-  dl $039A6B                                ; $039287 |
-  dl $039A6B                                ; $03928A |
-  dl $039A6B                                ; $03928D |
-  dl $039A6B                                ; $039290 |
-  dl $039A6B                                ; $039293 |
-  dl $039A6B                                ; $039296 |
-  dl $039A6B                                ; $039299 |
-  dl $039A6B                                ; $03929C |
-  dl $039A6B                                ; $03929F |
-  dl $039A6B                                ; $0392A2 |
-  dl $039A6B                                ; $0392A5 |
-  dl $039A6B                                ; $0392A8 |
-  dl $039A6B                                ; $0392AB |
-  dl $039A6B                                ; $0392AE |
-  dl $039A6B                                ; $0392B1 |
-  dl $039A6B                                ; $0392B4 |
-  dl $039A6B                                ; $0392B7 |
-  dl $039A6B                                ; $0392BA |
-  dl $039A6B                                ; $0392BD |
-  dl $039A6B                                ; $0392C0 |
-  dl $039A6B                                ; $0392C3 |
-  dl $039A6B                                ; $0392C6 |
-  dl $039A6B                                ; $0392C9 |
-  dl $039A6B                                ; $0392CC |
-  dl $039A6B                                ; $0392CF |
-  dl $039A6B                                ; $0392D2 |
-  dl $039A6B                                ; $0392D5 |
-  dl $039A6B                                ; $0392D8 |
-  dl $039A6B                                ; $0392DB |
-  dl $039A6B                                ; $0392DE |
-  dl $039A6B                                ; $0392E1 |
-  dl $039A6B                                ; $0392E4 |
-  dl $039A6B                                ; $0392E7 |
-  dl $039A6B                                ; $0392EA |
-  dl $039A6B                                ; $0392ED |
-  dl $039A6B                                ; $0392F0 |
-  dl $039A6B                                ; $0392F3 |
-  dl $039A6B                                ; $0392F6 |
-  dl $039A6B                                ; $0392F9 |
-  dl $039A6B                                ; $0392FC |
-  dl $039A6B                                ; $0392FF |
-  dl $039A6B                                ; $039302 |
-  dl $039A6B                                ; $039305 |
-  dl $049094                                ; $039308 | bandit shyguy
-  dl $039A6B                                ; $03930B |
-  dl $039A6B                                ; $03930E |
-  dl $039A6B                                ; $039311 |
-  dl $039A6B                                ; $039314 |
-  dl $039A6B                                ; $039317 |
-  dl $039A6B                                ; $03931A |
-  dl $039A6B                                ; $03931D |
-  dl $039A6B                                ; $039320 |
-  dl $039A6B                                ; $039323 |
-  dl $0DE9F9                                ; $039326 | Baby Bowser
-  dl $039A6B                                ; $039329 |
-  dl $039A6B                                ; $03932C |
-  dl $039A6B                                ; $03932F |
-  dl $039A6B                                ; $039332 |
-  dl $039A6B                                ; $039335 |
-  dl $039A6B                                ; $039338 |
-  dl $039A6B                                ; $03933B |
-  dl $039A6B                                ; $03933E |
-  dl $039A6B                                ; $039341 |
-  dl $039A6B                                ; $039344 |
-  dl $039A6B                                ; $039347 |
-  dl $039A6B                                ; $03934A |
-  dl $039A6B                                ; $03934D |
-  dl $039A6B                                ; $039350 |
-  dl $039A6B                                ; $039353 |
-  dl $039A6B                                ; $039356 |
-  dl $039A6B                                ; $039359 |
-  dl $039A6B                                ; $03935C |
-  dl $039A6B                                ; $03935F |
-  dl $039A6B                                ; $039362 |
-  dl $039A6B                                ; $039365 |
-  dl $039A6B                                ; $039368 |
-  dl $039A6B                                ; $03936B |
-  dl $039A6B                                ; $03936E |
-  dl $039A6B                                ; $039371 |
-  dl $039A6B                                ; $039374 |
-  dl $039A6B                                ; $039377 |
-  dl $039A6B                                ; $03937A |
-  dl $039A6B                                ; $03937D |
-  dl $039A6B                                ; $039380 |
-  dl $039A6B                                ; $039383 |
-  dl $039A6B                                ; $039386 |
-  dl $039A6B                                ; $039389 |
-  dl $039A6B                                ; $03938C |
-  dl $039A6B                                ; $03938F |
-  dl $039A6B                                ; $039392 |
-  dl $039A6B                                ; $039395 |
-  dl $039A6B                                ; $039398 |
-  dl $039A6B                                ; $03939B |
-  dl $039A6B                                ; $03939E |
-  dl $039A6B                                ; $0393A1 |
-  dl $039A6B                                ; $0393A4 |
-  dl $039A6B                                ; $0393A7 |
-  dl $039A6B                                ; $0393AA |
-  dl $039A6B                                ; $0393AD |
-  dl $039A6B                                ; $0393B0 |
-  dl $039A6B                                ; $0393B3 |
-  dl $039A6B                                ; $0393B6 |
-  dl $039A6B                                ; $0393B9 |
-  dl $039A6B                                ; $0393BC |
-  dl $039A6B                                ; $0393BF |
-  dl $039A6B                                ; $0393C2 |
-  dl $039A6B                                ; $0393C5 |
-  dl $039A6B                                ; $0393C8 |
-  dl $039A6B                                ; $0393CB |
-  dl $039A6B                                ; $0393CE |
-  dl $039A6B                                ; $0393D1 |
-  dl $039A6B                                ; $0393D4 |
-  dl $039A6B                                ; $0393D7 |
-  dl $039A6B                                ; $0393DA |
-  dl $039A6B                                ; $0393DD |
-  dl $039A6B                                ; $0393E0 |
-  dl $039A6B                                ; $0393E3 |
-  dl $039A6B                                ; $0393E6 |
-  dl $039A6B                                ; $0393E9 |
-  dl $039A6B                                ; $0393EC |
-  dl $039A6B                                ; $0393EF |
-  dl $039A6B                                ; $0393F2 |
-  dl $039A6B                                ; $0393F5 |
-  dl $039A6B                                ; $0393F8 |
-  dl $039A6B                                ; $0393FB |
-  dl $039A6B                                ; $0393FE |
-  dl $039A6B                                ; $039401 |
-  dl $039A6B                                ; $039404 |
-  dl $039A6B                                ; $039407 |
-  dl $039A6B                                ; $03940A |
-  dl $039A6B                                ; $03940D |
-  dl $039A6B                                ; $039410 |
-  dl $039A6B                                ; $039413 |
-  dl $039A6B                                ; $039416 |
-  dl $039A6B                                ; $039419 |
-  dl $039A6B                                ; $03941C |
-  dl $039A6B                                ; $03941F |
-  dl $039A6B                                ; $039422 |
-  dl $039A6B                                ; $039425 |
-  dl $039A6B                                ; $039428 |
-  dl $039A6B                                ; $03942B |
-  dl $039A6B                                ; $03942E |
-  dl $039A6B                                ; $039431 |
-  dl $039A6B                                ; $039434 |
-  dl $039A6B                                ; $039437 |
-  dl $039A6B                                ; $03943A |
-  dl $039A6B                                ; $03943D |
-  dl $039A6B                                ; $039440 |
-  dl $039A6B                                ; $039443 |
-  dl $039A6B                                ; $039446 |
-  dl $039A6B                                ; $039449 |
-  dl $039A6B                                ; $03944C |
-  dl $039A6B                                ; $03944F |
-  dl $039A6B                                ; $039452 |
-  dl $039A6B                                ; $039455 |
-  dl $039A6B                                ; $039458 |
-  dl $039A6B                                ; $03945B |
-  dl $039A6B                                ; $03945E |
-  dl $039A6B                                ; $039461 |
-  dl $039A6B                                ; $039464 |
-  dl $039A6B                                ; $039467 |
-  dl $039A6B                                ; $03946A |
-  dl $039A6B                                ; $03946D |
-  dl $039A6B                                ; $039470 |
-  dl $039A6B                                ; $039473 |
-  dl $039A6B                                ; $039476 |
-  dl $039A6B                                ; $039479 |
-  dl $039A6B                                ; $03947C |
-  dl $039A6B                                ; $03947F |
-  dl $039A6B                                ; $039482 |
-  dl $039A6B                                ; $039485 |
-  dl $039A6B                                ; $039488 |
-  dl $039A6B                                ; $03948B |
-  dl $039A6B                                ; $03948E |
-  dl $039A6B                                ; $039491 |
-  dl $039A6B                                ; $039494 |
-  dl $039A6B                                ; $039497 |
-  dl $039A6B                                ; $03949A |
-  dl $039A6B                                ; $03949D |
-  dl $039A6B                                ; $0394A0 |
-  dl $039A6B                                ; $0394A3 |
-  dl $039A6B                                ; $0394A6 |
-  dl $039A6B                                ; $0394A9 |
-  dl $039A6B                                ; $0394AC |
-  dl $039A6B                                ; $0394AF |
-  dl $039A6B                                ; $0394B2 |
-  dl $039A6B                                ; $0394B5 |
+  dl Return_039A6B                          ; $038F8A |
+  dl Return_039A6B                          ; $038F8D |
+  dl Return_039A6B                          ; $038F90 |
+  dl Return_039A6B                          ; $038F93 |
+  dl Return_039A6B                          ; $038F96 |
+  dl Return_039A6B                          ; $038F99 |
+  dl Return_039A6B                          ; $038F9C |
+  dl Return_039A6B                          ; $038F9F |
+  dl Return_039A6B                          ; $038FA2 |
+  dl Return_039A6B                          ; $038FA5 |
+  dl Return_039A6B                          ; $038FA8 |
+  dl Return_039A6B                          ; $038FAB |
+  dl Return_039A6B                          ; $038FAE |
+  dl Return_039A6B                          ; $038FB1 |
+  dl Return_039A6B                          ; $038FB4 |
+  dl Return_039A6B                          ; $038FB7 |
+  dl Return_039A6B                          ; $038FBA |
+  dl Return_039A6B                          ; $038FBD |
+  dl Return_039A6B                          ; $038FC0 |
+  dl Return_039A6B                          ; $038FC3 |
+  dl Return_039A6B                          ; $038FC6 |
+  dl Return_039A6B                          ; $038FC9 |
+  dl Return_039A6B                          ; $038FCC |
+  dl Return_039A6B                          ; $038FCF |
+  dl Return_039A6B                          ; $038FD2 |
+  dl Return_039A6B                          ; $038FD5 |
+  dl Return_039A6B                          ; $038FD8 |
+  dl Return_039A6B                          ; $038FDB |
+  dl Return_039A6B                          ; $038FDE |
+  dl Return_039A6B                          ; $038FE1 |
+  dl Return_039A6B                          ; $038FE4 |
+  dl Return_039A6B                          ; $038FE7 |
+  dl Return_039A6B                          ; $038FEA |
+  dl Return_039A6B                          ; $038FED |
+  dl Return_039A6B                          ; $038FF0 |
+  dl Return_039A6B                          ; $038FF3 |
+  dl Return_039A6B                          ; $038FF6 |
+  dl Return_039A6B                          ; $038FF9 |
+  dl Return_039A6B                          ; $038FFC |
+  dl Return_039A6B                          ; $038FFF |
+  dl Return_039A6B                          ; $039002 |
+  dl Return_039A6B                          ; $039005 |
+  dl Return_039A6B                          ; $039008 |
+  dl Return_039A6B                          ; $03900B |
+  dl Return_039A6B                          ; $03900E |
+  dl Return_039A6B                          ; $039011 |
+  dl Return_039A6B                          ; $039014 |
+  dl Return_039A6B                          ; $039017 |
+  dl Return_039A6B                          ; $03901A |
+  dl Return_039A6B                          ; $03901D |
+  dl Return_039A6B                          ; $039020 |
+  dl Return_039A6B                          ; $039023 |
+  dl Return_039A6B                          ; $039026 |
+  dl Return_039A6B                          ; $039029 |
+  dl Return_039A6B                          ; $03902C |
+  dl ride_grim_leecher                      ; $03902F | grim leecher
+  dl Return_039A6B                          ; $039032 |
+  dl Return_039A6B                          ; $039035 |
+  dl Return_039A6B                          ; $039038 |
+  dl Return_039A6B                          ; $03903B |
+  dl Return_039A6B                          ; $03903E |
+  dl Return_039A6B                          ; $039041 |
+  dl Return_039A6B                          ; $039044 |
+  dl Return_039A6B                          ; $039047 |
+  dl Return_039A6B                          ; $03904A |
+  dl Return_039A6B                          ; $03904D |
+  dl Return_039A6B                          ; $039050 |
+  dl Return_039A6B                          ; $039053 |
+  dl Return_039A6B                          ; $039056 |
+  dl Return_039A6B                          ; $039059 |
+  dl Return_039A6B                          ; $03905C |
+  dl Return_039A6B                          ; $03905F |
+  dl Return_039A6B                          ; $039062 |
+  dl Return_039A6B                          ; $039065 |
+  dl Return_039A6B                          ; $039068 |
+  dl Return_039A6B                          ; $03906B |
+  dl Return_039A6B                          ; $03906E |
+  dl Return_039A6B                          ; $039071 |
+  dl Return_039A6B                          ; $039074 |
+  dl Return_039A6B                          ; $039077 |
+  dl Return_039A6B                          ; $03907A |
+  dl Return_039A6B                          ; $03907D |
+  dl Return_039A6B                          ; $039080 |
+  dl Return_039A6B                          ; $039083 |
+  dl Return_039A6B                          ; $039086 |
+  dl Return_039A6B                          ; $039089 |
+  dl Return_039A6B                          ; $03908C |
+  dl Return_039A6B                          ; $03908F |
+  dl Return_039A6B                          ; $039092 |
+  dl Return_039A6B                          ; $039095 |
+  dl Return_039A6B                          ; $039098 |
+  dl Return_039A6B                          ; $03909B |
+  dl Return_039A6B                          ; $03909E |
+  dl Return_039A6B                          ; $0390A1 |
+  dl Return_039A6B                          ; $0390A4 |
+  dl Return_039A6B                          ; $0390A7 |
+  dl Return_039A6B                          ; $0390AA |
+  dl riding_baby_mario                      ; $0390AD | baby mario
+  dl Return_039A6B                          ; $0390B0 |
+  dl Return_039A6B                          ; $0390B3 |
+  dl Return_039A6B                          ; $0390B6 |
+  dl Return_039A6B                          ; $0390B9 |
+  dl Return_039A6B                          ; $0390BC |
+  dl Return_039A6B                          ; $0390BF |
+  dl Return_039A6B                          ; $0390C2 |
+  dl Return_039A6B                          ; $0390C5 |
+  dl Return_039A6B                          ; $0390C8 |
+  dl Return_039A6B                          ; $0390CB |
+  dl Return_039A6B                          ; $0390CE |
+  dl Return_039A6B                          ; $0390D1 |
+  dl Return_039A6B                          ; $0390D4 |
+  dl Return_039A6B                          ; $0390D7 |
+  dl Return_039A6B                          ; $0390DA |
+  dl Return_039A6B                          ; $0390DD |
+  dl Return_039A6B                          ; $0390E0 |
+  dl Return_039A6B                          ; $0390E3 |
+  dl Return_039A6B                          ; $0390E6 |
+  dl Return_039A6B                          ; $0390E9 |
+  dl Return_039A6B                          ; $0390EC |
+  dl Return_039A6B                          ; $0390EF |
+  dl Return_039A6B                          ; $0390F2 |
+  dl Return_039A6B                          ; $0390F5 |
+  dl Return_039A6B                          ; $0390F8 |
+  dl Return_039A6B                          ; $0390FB |
+  dl Return_039A6B                          ; $0390FE |
+  dl Return_039A6B                          ; $039101 |
+  dl Return_039A6B                          ; $039104 |
+  dl Return_039A6B                          ; $039107 |
+  dl Return_039A6B                          ; $03910A |
+  dl Return_039A6B                          ; $03910D |
+  dl Return_039A6B                          ; $039110 |
+  dl Return_039A6B                          ; $039113 |
+  dl Return_039A6B                          ; $039116 |
+  dl Return_039A6B                          ; $039119 |
+  dl Return_039A6B                          ; $03911C |
+  dl Return_039A6B                          ; $03911F |
+  dl Return_039A6B                          ; $039122 |
+  dl Return_039A6B                          ; $039125 |
+  dl Return_039A6B                          ; $039128 |
+  dl Return_039A6B                          ; $03912B |
+  dl Return_039A6B                          ; $03912E |
+  dl Return_039A6B                          ; $039131 |
+  dl Return_039A6B                          ; $039134 |
+  dl Return_039A6B                          ; $039137 |
+  dl Return_039A6B                          ; $03913A |
+  dl Return_039A6B                          ; $03913D |
+  dl Return_039A6B                          ; $039140 |
+  dl Return_039A6B                          ; $039143 |
+  dl Return_039A6B                          ; $039146 |
+  dl Return_039A6B                          ; $039149 |
+  dl Return_039A6B                          ; $03914C |
+  dl Return_039A6B                          ; $03914F |
+  dl Return_039A6B                          ; $039152 |
+  dl Return_039A6B                          ; $039155 |
+  dl Return_039A6B                          ; $039158 |
+  dl Return_039A6B                          ; $03915B |
+  dl Return_039A6B                          ; $03915E |
+  dl Return_039A6B                          ; $039161 |
+  dl Return_039A6B                          ; $039164 |
+  dl Return_039A6B                          ; $039167 |
+  dl Return_039A6B                          ; $03916A |
+  dl Return_039A6B                          ; $03916D |
+  dl Return_039A6B                          ; $039170 |
+  dl Return_039A6B                          ; $039173 |
+  dl Return_039A6B                          ; $039176 |
+  dl Return_039A6B                          ; $039179 |
+  dl Return_039A6B                          ; $03917C |
+  dl Return_039A6B                          ; $03917F |
+  dl Return_039A6B                          ; $039182 |
+  dl Return_039A6B                          ; $039185 |
+  dl Return_039A6B                          ; $039188 |
+  dl Return_039A6B                          ; $03918B |
+  dl Return_039A6B                          ; $03918E |
+  dl Return_039A6B                          ; $039191 |
+  dl Return_039A6B                          ; $039194 |
+  dl Return_039A6B                          ; $039197 |
+  dl Return_039A6B                          ; $03919A |
+  dl Return_039A6B                          ; $03919D |
+  dl Return_039A6B                          ; $0391A0 |
+  dl Return_039A6B                          ; $0391A3 |
+  dl Return_039A6B                          ; $0391A6 |
+  dl Return_039A6B                          ; $0391A9 |
+  dl Return_039A6B                          ; $0391AC |
+  dl Return_039A6B                          ; $0391AF |
+  dl Return_039A6B                          ; $0391B2 |
+  dl Return_039A6B                          ; $0391B5 |
+  dl Return_039A6B                          ; $0391B8 |
+  dl Return_039A6B                          ; $0391BB |
+  dl Return_039A6B                          ; $0391BE |
+  dl Return_039A6B                          ; $0391C1 |
+  dl Return_039A6B                          ; $0391C4 |
+  dl Return_039A6B                          ; $0391C7 |
+  dl Return_039A6B                          ; $0391CA |
+  dl Return_039A6B                          ; $0391CD |
+  dl Return_039A6B                          ; $0391D0 |
+  dl Return_039A6B                          ; $0391D3 |
+  dl Return_039A6B                          ; $0391D6 |
+  dl Return_039A6B                          ; $0391D9 |
+  dl Return_039A6B                          ; $0391DC |
+  dl Return_039A6B                          ; $0391DF |
+  dl Return_039A6B                          ; $0391E2 |
+  dl Return_039A6B                          ; $0391E5 |
+  dl Return_039A6B                          ; $0391E8 |
+  dl Return_039A6B                          ; $0391EB |
+  dl Return_039A6B                          ; $0391EE |
+  dl Return_039A6B                          ; $0391F1 |
+  dl Return_039A6B                          ; $0391F4 |
+  dl Return_039A6B                          ; $0391F7 |
+  dl Return_039A6B                          ; $0391FA |
+  dl Return_039A6B                          ; $0391FD |
+  dl Return_039A6B                          ; $039200 |
+  dl Return_039A6B                          ; $039203 |
+  dl Return_039A6B                          ; $039206 |
+  dl Return_039A6B                          ; $039209 |
+  dl Return_039A6B                          ; $03920C |
+  dl Return_039A6B                          ; $03920F |
+  dl Return_039A6B                          ; $039212 |
+  dl Return_039A6B                          ; $039215 |
+  dl Return_039A6B                          ; $039218 |
+  dl Return_039A6B                          ; $03921B |
+  dl Return_039A6B                          ; $03921E |
+  dl Return_039A6B                          ; $039221 |
+  dl Return_039A6B                          ; $039224 |
+  dl Return_039A6B                          ; $039227 |
+  dl Return_039A6B                          ; $03922A |
+  dl Return_039A6B                          ; $03922D |
+  dl Return_039A6B                          ; $039230 |
+  dl Return_039A6B                          ; $039233 |
+  dl Return_039A6B                          ; $039236 |
+  dl Return_039A6B                          ; $039239 |
+  dl Return_039A6B                          ; $03923C |
+  dl Return_039A6B                          ; $03923F |
+  dl Return_039A6B                          ; $039242 |
+  dl Return_039A6B                          ; $039245 |
+  dl Return_039A6B                          ; $039248 |
+  dl Return_039A6B                          ; $03924B |
+  dl Return_039A6B                          ; $03924E |
+  dl Return_039A6B                          ; $039251 |
+  dl Return_039A6B                          ; $039254 |
+  dl Return_039A6B                          ; $039257 |
+  dl Return_039A6B                          ; $03925A |
+  dl Return_039A6B                          ; $03925D |
+  dl Return_039A6B                          ; $039260 |
+  dl Return_039A6B                          ; $039263 |
+  dl Return_039A6B                          ; $039266 |
+  dl Return_039A6B                          ; $039269 |
+  dl Return_039A6B                          ; $03926C |
+  dl Return_039A6B                          ; $03926F |
+  dl Return_039A6B                          ; $039272 |
+  dl Return_039A6B                          ; $039275 |
+  dl Return_039A6B                          ; $039278 |
+  dl Return_039A6B                          ; $03927B |
+  dl Return_039A6B                          ; $03927E |
+  dl Return_039A6B                          ; $039281 |
+  dl Return_039A6B                          ; $039284 |
+  dl Return_039A6B                          ; $039287 |
+  dl Return_039A6B                          ; $03928A |
+  dl Return_039A6B                          ; $03928D |
+  dl Return_039A6B                          ; $039290 |
+  dl Return_039A6B                          ; $039293 |
+  dl Return_039A6B                          ; $039296 |
+  dl Return_039A6B                          ; $039299 |
+  dl Return_039A6B                          ; $03929C |
+  dl Return_039A6B                          ; $03929F |
+  dl Return_039A6B                          ; $0392A2 |
+  dl Return_039A6B                          ; $0392A5 |
+  dl Return_039A6B                          ; $0392A8 |
+  dl Return_039A6B                          ; $0392AB |
+  dl Return_039A6B                          ; $0392AE |
+  dl Return_039A6B                          ; $0392B1 |
+  dl Return_039A6B                          ; $0392B4 |
+  dl Return_039A6B                          ; $0392B7 |
+  dl Return_039A6B                          ; $0392BA |
+  dl Return_039A6B                          ; $0392BD |
+  dl Return_039A6B                          ; $0392C0 |
+  dl Return_039A6B                          ; $0392C3 |
+  dl Return_039A6B                          ; $0392C6 |
+  dl Return_039A6B                          ; $0392C9 |
+  dl Return_039A6B                          ; $0392CC |
+  dl Return_039A6B                          ; $0392CF |
+  dl Return_039A6B                          ; $0392D2 |
+  dl Return_039A6B                          ; $0392D5 |
+  dl Return_039A6B                          ; $0392D8 |
+  dl Return_039A6B                          ; $0392DB |
+  dl Return_039A6B                          ; $0392DE |
+  dl Return_039A6B                          ; $0392E1 |
+  dl Return_039A6B                          ; $0392E4 |
+  dl Return_039A6B                          ; $0392E7 |
+  dl Return_039A6B                          ; $0392EA |
+  dl Return_039A6B                          ; $0392ED |
+  dl Return_039A6B                          ; $0392F0 |
+  dl Return_039A6B                          ; $0392F3 |
+  dl Return_039A6B                          ; $0392F6 |
+  dl Return_039A6B                          ; $0392F9 |
+  dl Return_039A6B                          ; $0392FC |
+  dl Return_039A6B                          ; $0392FF |
+  dl Return_039A6B                          ; $039302 |
+  dl Return_039A6B                          ; $039305 |
+  dl ride_bandit_shyguy                     ; $039308 | bandit shyguy
+  dl Return_039A6B                          ; $03930B |
+  dl Return_039A6B                          ; $03930E |
+  dl Return_039A6B                          ; $039311 |
+  dl Return_039A6B                          ; $039314 |
+  dl Return_039A6B                          ; $039317 |
+  dl Return_039A6B                          ; $03931A |
+  dl Return_039A6B                          ; $03931D |
+  dl Return_039A6B                          ; $039320 |
+  dl Return_039A6B                          ; $039323 |
+  dl riding_baby_bowser                     ; $039326 | Baby Bowser
+  dl Return_039A6B                          ; $039329 |
+  dl Return_039A6B                          ; $03932C |
+  dl Return_039A6B                          ; $03932F |
+  dl Return_039A6B                          ; $039332 |
+  dl Return_039A6B                          ; $039335 |
+  dl Return_039A6B                          ; $039338 |
+  dl Return_039A6B                          ; $03933B |
+  dl Return_039A6B                          ; $03933E |
+  dl Return_039A6B                          ; $039341 |
+  dl Return_039A6B                          ; $039344 |
+  dl Return_039A6B                          ; $039347 |
+  dl Return_039A6B                          ; $03934A |
+  dl Return_039A6B                          ; $03934D |
+  dl Return_039A6B                          ; $039350 |
+  dl Return_039A6B                          ; $039353 |
+  dl Return_039A6B                          ; $039356 |
+  dl Return_039A6B                          ; $039359 |
+  dl Return_039A6B                          ; $03935C |
+  dl Return_039A6B                          ; $03935F |
+  dl Return_039A6B                          ; $039362 |
+  dl Return_039A6B                          ; $039365 |
+  dl Return_039A6B                          ; $039368 |
+  dl Return_039A6B                          ; $03936B |
+  dl Return_039A6B                          ; $03936E |
+  dl Return_039A6B                          ; $039371 |
+  dl Return_039A6B                          ; $039374 |
+  dl Return_039A6B                          ; $039377 |
+  dl Return_039A6B                          ; $03937A |
+  dl Return_039A6B                          ; $03937D |
+  dl Return_039A6B                          ; $039380 |
+  dl Return_039A6B                          ; $039383 |
+  dl Return_039A6B                          ; $039386 |
+  dl Return_039A6B                          ; $039389 |
+  dl Return_039A6B                          ; $03938C |
+  dl Return_039A6B                          ; $03938F |
+  dl Return_039A6B                          ; $039392 |
+  dl Return_039A6B                          ; $039395 |
+  dl Return_039A6B                          ; $039398 |
+  dl Return_039A6B                          ; $03939B |
+  dl Return_039A6B                          ; $03939E |
+  dl Return_039A6B                          ; $0393A1 |
+  dl Return_039A6B                          ; $0393A4 |
+  dl Return_039A6B                          ; $0393A7 |
+  dl Return_039A6B                          ; $0393AA |
+  dl Return_039A6B                          ; $0393AD |
+  dl Return_039A6B                          ; $0393B0 |
+  dl Return_039A6B                          ; $0393B3 |
+  dl Return_039A6B                          ; $0393B6 |
+  dl Return_039A6B                          ; $0393B9 |
+  dl Return_039A6B                          ; $0393BC |
+  dl Return_039A6B                          ; $0393BF |
+  dl Return_039A6B                          ; $0393C2 |
+  dl Return_039A6B                          ; $0393C5 |
+  dl Return_039A6B                          ; $0393C8 |
+  dl Return_039A6B                          ; $0393CB |
+  dl Return_039A6B                          ; $0393CE |
+  dl Return_039A6B                          ; $0393D1 |
+  dl Return_039A6B                          ; $0393D4 |
+  dl Return_039A6B                          ; $0393D7 |
+  dl Return_039A6B                          ; $0393DA |
+  dl Return_039A6B                          ; $0393DD |
+  dl Return_039A6B                          ; $0393E0 |
+  dl Return_039A6B                          ; $0393E3 |
+  dl Return_039A6B                          ; $0393E6 |
+  dl Return_039A6B                          ; $0393E9 |
+  dl Return_039A6B                          ; $0393EC |
+  dl Return_039A6B                          ; $0393EF |
+  dl Return_039A6B                          ; $0393F2 |
+  dl Return_039A6B                          ; $0393F5 |
+  dl Return_039A6B                          ; $0393F8 |
+  dl Return_039A6B                          ; $0393FB |
+  dl Return_039A6B                          ; $0393FE |
+  dl Return_039A6B                          ; $039401 |
+  dl Return_039A6B                          ; $039404 |
+  dl Return_039A6B                          ; $039407 |
+  dl Return_039A6B                          ; $03940A |
+  dl Return_039A6B                          ; $03940D |
+  dl Return_039A6B                          ; $039410 |
+  dl Return_039A6B                          ; $039413 |
+  dl Return_039A6B                          ; $039416 |
+  dl Return_039A6B                          ; $039419 |
+  dl Return_039A6B                          ; $03941C |
+  dl Return_039A6B                          ; $03941F |
+  dl Return_039A6B                          ; $039422 |
+  dl Return_039A6B                          ; $039425 |
+  dl Return_039A6B                          ; $039428 |
+  dl Return_039A6B                          ; $03942B |
+  dl Return_039A6B                          ; $03942E |
+  dl Return_039A6B                          ; $039431 |
+  dl Return_039A6B                          ; $039434 |
+  dl Return_039A6B                          ; $039437 |
+  dl Return_039A6B                          ; $03943A |
+  dl Return_039A6B                          ; $03943D |
+  dl Return_039A6B                          ; $039440 |
+  dl Return_039A6B                          ; $039443 |
+  dl Return_039A6B                          ; $039446 |
+  dl Return_039A6B                          ; $039449 |
+  dl Return_039A6B                          ; $03944C |
+  dl Return_039A6B                          ; $03944F |
+  dl Return_039A6B                          ; $039452 |
+  dl Return_039A6B                          ; $039455 |
+  dl Return_039A6B                          ; $039458 |
+  dl Return_039A6B                          ; $03945B |
+  dl Return_039A6B                          ; $03945E |
+  dl Return_039A6B                          ; $039461 |
+  dl Return_039A6B                          ; $039464 |
+  dl Return_039A6B                          ; $039467 |
+  dl Return_039A6B                          ; $03946A |
+  dl Return_039A6B                          ; $03946D |
+  dl Return_039A6B                          ; $039470 |
+  dl Return_039A6B                          ; $039473 |
+  dl Return_039A6B                          ; $039476 |
+  dl Return_039A6B                          ; $039479 |
+  dl Return_039A6B                          ; $03947C |
+  dl Return_039A6B                          ; $03947F |
+  dl Return_039A6B                          ; $039482 |
+  dl Return_039A6B                          ; $039485 |
+  dl Return_039A6B                          ; $039488 |
+  dl Return_039A6B                          ; $03948B |
+  dl Return_039A6B                          ; $03948E |
+  dl Return_039A6B                          ; $039491 |
+  dl Return_039A6B                          ; $039494 |
+  dl Return_039A6B                          ; $039497 |
+  dl Return_039A6B                          ; $03949A |
+  dl Return_039A6B                          ; $03949D |
+  dl Return_039A6B                          ; $0394A0 |
+  dl Return_039A6B                          ; $0394A3 |
+  dl Return_039A6B                          ; $0394A6 |
+  dl Return_039A6B                          ; $0394A9 |
+  dl Return_039A6B                          ; $0394AC |
+  dl Return_039A6B                          ; $0394AF |
+  dl Return_039A6B                          ; $0394B2 |
+  dl Return_039A6B                          ; $0394B5 |
 ; end sprite_ridings table
 
 ; remove all sprites (ambient and regular) and disable drawing
@@ -2526,46 +2526,53 @@ handle_sprite:
   STA !s_cur_spr_y_prev                     ; $039A1B |
   LDA !s_sprite_disable_flag                ; $039A1E |
   ORA $0B55                                 ; $039A21 |
-  ORA !r_cur_item_used                      ; $039A24 |\ Skip processing some timers if item being used
-  BNE CODE_039A49                           ; $039A27 |/
+  ORA !r_cur_item_used                      ; $039A24 |\ Skip processing all but one timer
+  BNE .nodec_spr_timer_4                    ; $039A27 |/ if item being used
 
   LDA !s_spr_timer_1,x                      ; $039A29 |\
-  BEQ CODE_039A31                           ; $039A2C | | Decrement timer if non-zero
+  BEQ .nodec_spr_timer_1                    ; $039A2C | | Decrement timer if non-zero
   DEC !s_spr_timer_1,x                      ; $039A2E |/
 
-CODE_039A31:
+.nodec_spr_timer_1
   LDA !s_spr_timer_2,x                      ; $039A31 |\
-  BEQ CODE_039A39                           ; $039A34 | | Decrement timer if non-zero
+  BEQ .nodec_spr_timer_2                    ; $039A34 | | Decrement timer if non-zero
   DEC !s_spr_timer_2,x                      ; $039A36 |/
 
-CODE_039A39:
+.nodec_spr_timer_2
   LDA !s_spr_timer_3,x                      ; $039A39 |\
-  BEQ CODE_039A41                           ; $039A3C | | Decrement timer if non-zero
+  BEQ .nodec_spr_timer_3                    ; $039A3C | | Decrement timer if non-zero
   DEC !s_spr_timer_3,x                      ; $039A3E |/
 
-CODE_039A41:
+.nodec_spr_timer_3
   LDA !s_spr_timer_4,x                      ; $039A41 |\
-  BEQ CODE_039A49                           ; $039A44 | | Decrement timer if non-zero
+  BEQ .nodec_spr_timer_4                    ; $039A44 | | Decrement timer if non-zero
   DEC !s_spr_timer_4,x                      ; $039A46 |/
 
-CODE_039A49:
+.nodec_spr_timer_4
   LDY !s_spr_timer_nopause,x                ; $039A49 |\
-  BEQ CODE_039A51                           ; $039A4C | | Decrement timer if non-zero
+  BEQ .nodec_spr_timer_5                    ; $039A4C | | Decrement timer if non-zero
   DEC !s_spr_timer_nopause,x                ; $039A4E |/
 
-CODE_039A51:
+.nodec_spr_timer_5
   LDY !s_spr_state,x                        ; $039A51 |\
-  LDA $9A57,y                               ; $039A54 | | indexes into table based on sprite state
+  LDA sprite_state_routines-2,y             ; $039A54 | | indexes into table based on sprite state
   PHA                                       ; $039A57 | | effectively jumps to address in table + 1
   RTS                                       ; $039A58 |/
 
 ; table of addresses used just above, pushed onto stack before RTS'ing
 sprite_state_routines:
-  dw $9A6D, $9A6D, $A246                    ; $039A59 |
-  dw $9AC7, $A11C, $9F8C                    ; $039A5F |
-  dw $A084, $9A8F, $A00A                    ; $039A65 |
+  dw spr_state_init-1                       ; $039A59 | state $02
+  dw spr_state_init-1                       ; $039A5B | state $04
+  dw spr_state_turn_star-1                  ; $039A5D | state $06
+  dw spr_state_tongued-1                    ; $039A5F | state $08
+  dw spr_state_ride_yoshi-1                 ; $039A61 | state $0A
+  dw spr_state_die_collision-1              ; $039A63 | state $0C
+  dw spr_state_on_head_bop-1                ; $039A65 | state $0E
+  dw spr_state_main-1                       ; $039A67 | state $10
+  dw spr_state_die_burning-1                ; $039A69 | state $12
 
 ; this gets jumped to as a routine for many sprites - insta-return (do nothing)
+Return_039A6B:
   RTL                                       ; $039A6B |
 
 ; perhaps another entry point to init_sprite
@@ -2573,7 +2580,7 @@ sprite_state_routines:
   PLB                                       ; $039A6D |
 
 ; sprite states $02 and $04: newly inited, needs initing
-init_sprite:
+spr_state_init:
   LDA #$0010                                ; $039A6E |\
   STA !s_spr_state,x                        ; $039A71 |/  change sprite state to active
   LDA !s_spr_id,x                           ; $039A74 |\  grab sprite ID
@@ -2581,9 +2588,9 @@ init_sprite:
   ADC !s_spr_id,x                           ; $039A78 | | multiply by 3
   REP #$10                                  ; $039A7B | |
   TAY                                       ; $039A7D | | index into table, giving us:
-  LDA $8000,y                               ; $039A7E |/  initing routine address
+  LDA sprite_inits,y                        ; $039A7E |/  initing routine address
   STA $00                                   ; $039A81 |
-  LDA $8002,y                               ; $039A83 |
+  LDA sprite_inits+2,y                      ; $039A83 | get bank
   STA $02                                   ; $039A86 |
   SEP #$10                                  ; $039A88 |
   TAY                                       ; $039A8A |
@@ -2592,16 +2599,16 @@ init_sprite:
   JML [$7960]                               ; $039A8D | this should contain the initing routine address loaded just above
 
 ; sprite state $10: sprite is alive / active, needs updating
-main_sprite:
+spr_state_main:
   LDA !s_spr_id,x                           ; $039A90 |
   ASL A                                     ; $039A93 |
   ADC !s_spr_id,x                           ; $039A94 |
   REP #$10                                  ; $039A97 |
   PHX                                       ; $039A99 |
   TAX                                       ; $039A9A |
-  LDA $03852E,x                             ; $039A9B | main routine address
+  LDA.l sprite_mains,x                      ; $039A9B | main routine address
   STA $00                                   ; $039A9F |
-  LDA $038530,x                             ; $039AA1 |
+  LDA.l sprite_mains+2,x                    ; $039AA1 | get bank
   STA $02                                   ; $039AA5 |
   PLX                                       ; $039AA7 |
   SEP #$10                                  ; $039AA8 |
@@ -2619,8 +2626,8 @@ main_sprite:
   dw $FFFA, $FFFA                           ; $039AC4 |
 
 ; sprite state $08 - in yoshi's tongue and/or mouth
-tongued_sprite:
-  JSL $039A90                               ; $039AC8 |
+spr_state_tongued:
+  JSL spr_state_main                        ; $039AC8 |
   LDA !s_spr_oam_1,x                        ; $039ACC |
   AND #$FFF3                                ; $039ACF |
   STA !s_spr_oam_1,x                        ; $039AD2 |
@@ -2702,7 +2709,7 @@ CODE_039B55:
   BCC CODE_039B66                           ; $039B5B |
   CMP #$002C                                ; $039B5D |
   BCS CODE_039B66                           ; $039B60 |
-  JML $03BF87                               ; $039B62 |
+  JML CODE_03BF87                           ; $039B62 |
 
 CODE_039B66:
   LDY #$01                                  ; $039B66 |
@@ -3215,6 +3222,7 @@ CODE_039F8C:
   RTL                                       ; $039F8C |
 
 ; sprite state $0C: dying from collision
+spr_state_die_collision:
   JSL $039A90                               ; $039F8D |
   JSL despawn_sprite_stage_ID               ; $039F91 |
   TXY                                       ; $039F95 |
@@ -3284,6 +3292,7 @@ CODE_03A004:
   RTL                                       ; $03A00A |
 
 ; sprite state $12: burning to death
+spr_state_die_burning:
   JSL $039A90                               ; $03A00B | call $10 first
   LDA #$0060                                ; $03A00F |
   STA !s_spr_bitwise_settings_1,x           ; $03A012 |
@@ -3332,7 +3341,7 @@ CODE_03A084:
   RTL                                       ; $03A084 |
 
 ; sprite state $0E: on head bop
-sprite_on_head_bop:
+spr_state_on_head_bop:
   LDA !s_spr_id,x                           ; $03A085 |
   ASL A                                     ; $03A088 |
   ADC !s_spr_id,x                           ; $03A089 |
@@ -3406,7 +3415,7 @@ CODE_03A0E4:
   BRA CODE_03A0DB                           ; $03A11B |
 
 ; sprite state $0A: riding yoshi
-sprite_riding_yoshi:
+spr_state_ride_yoshi:
   JSL $039A90                               ; $03A11D |
   PHK                                       ; $03A121 |
   PLB                                       ; $03A122 |
@@ -3571,6 +3580,7 @@ CODE_03A229:
   BRA CODE_03A1FA                           ; $03A245 |
 
 ; sprite state $06: turning into a star
+spr_state_turn_star:
   JSL $02808C                               ; $03A247 |
   JSL $039A90                               ; $03A24B |
   PHK                                       ; $03A24F |
@@ -3636,7 +3646,7 @@ CODE_03A2AF:
 CODE_03A2C6:
   RTL                                       ; $03A2C6 |
 
-; l sub
+CODE_03A2C7:
   LDA !s_spr_cam_x_pos,x                    ; $03A2C7 |
   CLC                                       ; $03A2CA |
   ADC #$0040                                ; $03A2CB |
@@ -4733,7 +4743,7 @@ CODE_03AA4F:
 CODE_03AA51:
   RTL                                       ; $03AA51 |
 
-; sub
+CODE_03AA52:
   LDY !s_spr_draw_priority,x                ; $03AA52 |\
   CPY #$FF                                  ; $03AA55 | | if disabled drawing, return
   BEQ CODE_03AA9C                           ; $03AA57 |/
@@ -5273,6 +5283,7 @@ CODE_03AE4D:
   RTL                                       ; $03AE5F |
 
 ; l sub
+CODE_03AE60:
   PHX                                       ; $03AE60 |
   PHB                                       ; $03AE61 |
   PHK                                       ; $03AE62 |
@@ -5408,6 +5419,7 @@ CODE_03AF1E:
 ; sub $AF23
 ; Handles frozen sprites and 'projectile state' (ie spat)
 ; A 16-bit - X/Y 8-bit
+CODE_03AF23:
   LDA !s_spr_collision_state,x              ; $03AF23 |
   BEQ CODE_03AF42                           ; $03AF26 | If 'projectile state' off
   LDY !s_spr_dyntile_index,x                ; $03AF28 |
@@ -5421,7 +5433,7 @@ CODE_03AF1E:
   BRA CODE_03AF42                           ; $03AF3C |
 
 CODE_03AF3E:
-  JSL $03AA52                               ; $03AF3E | ?
+  JSL CODE_03AA52                           ; $03AF3E | ?
 
 CODE_03AF42:
   LDY !s_spr_state,x                        ; $03AF42 |\
@@ -6516,7 +6528,7 @@ init_flashing_egg:
 
 init_egg:
   LDA !s_spr_wildcard_2_lo,x                ; $03B746 |
-  BNE CODE_03B759                           ; $03B749 |
+  BNE init_egg_return                       ; $03B749 |
   JSL $03D3F8                               ; $03B74B |
   BEQ CODE_03B755                           ; $03B74F |
   JML despawn_sprite_free_slot              ; $03B751 |
@@ -6524,7 +6536,7 @@ init_egg:
 CODE_03B755:
   JSL $0ED844                               ; $03B755 |
 
-CODE_03B759:
+init_egg_return:
   RTL                                       ; $03B759 | do nothing special on green & giant eggs
 
 ; data table
@@ -6610,7 +6622,7 @@ CODE_03B7CD:
   STZ !s_player_x_speed                     ; $03B7FC |
   STZ !s_player_flutter_state               ; $03B7FF |
   LDX $12                                   ; $03B802 |
-  JSL $03BF87                               ; $03B804 |
+  JSL CODE_03BF87                           ; $03B804 |
   JSL despawn_sprite_free_slot              ; $03B808 |
   LDA #$0061                                ; $03B80C |
   TXY                                       ; $03B80F |
@@ -6633,7 +6645,7 @@ CODE_03B83B:
   RTL                                       ; $03B83B |
 
 CODE_03B83C:
-  JSL $03B9DD                               ; $03B83C |
+  JSL CODE_03B9DD                           ; $03B83C |
   LDA !s_super_mario_timer                  ; $03B840 |
   DEC A                                     ; $03B843 |
   BNE CODE_03B876                           ; $03B844 |
@@ -6659,7 +6671,7 @@ main_flashing_egg:
   JSL $03B75E                               ; $03B86E |
 
 main_egg:
-  JSL $03B9DD                               ; $03B872 |
+  JSL CODE_03B9DD                           ; $03B872 |
 
 CODE_03B876:
   LDA !s_spr_wildcard_6_lo_dp,x             ; $03B876 |
@@ -6862,6 +6874,7 @@ CODE_03B9C6:
 ; end main_egg
 
 ; l sub
+CODE_03B9DD:
   LDY !s_spr_state,x                        ; $03B9DD |
   CPY #$08                                  ; $03B9E0 |
   BNE CODE_03BA43                           ; $03B9E2 |
@@ -6924,7 +6937,7 @@ CODE_03BA43:
   RTL                                       ; $03BA52 |
 
 CODE_03BA53:
-  JML $03AF23                               ; $03BA53 |
+  JML CODE_03AF23                           ; $03BA53 |
 
 CODE_03BA57:
   LDY #$34                                  ; $03BA57 |
@@ -7016,7 +7029,7 @@ CODE_03BADF:
   STA $7782,y                               ; $03BB16 |
 
 CODE_03BB19:
-  JML $03AF23                               ; $03BB19 |
+  JML CODE_03AF23                           ; $03BB19 |
 
 ; end B9DD
 
@@ -7605,6 +7618,7 @@ CODE_03BF6B:
   RTL                                       ; $03BF86 |
 
 ; l sub
+CODE_03BF87:
   LDY !s_spr_wildcard_6_lo,x                ; $03BF87 |
   BEQ CODE_03BFF6                           ; $03BF8A |
   BMI CODE_03BFF6                           ; $03BF8C |
@@ -7703,7 +7717,7 @@ CODE_03C03E:
 
 ; l sub
   JSL despawn_sprite_stage_ID               ; $03C040 |
-  JSL $03BF87                               ; $03C044 |
+  JSL CODE_03BF87                           ; $03C044 |
   LDA !s_spr_x_pixel_pos,x                  ; $03C048 |
   STA $7960                                 ; $03C04B |
   LDA !s_spr_y_pixel_pos,x                  ; $03C04E |
@@ -7730,6 +7744,7 @@ init_special_winged_cloud:
   RTL                                       ; $03C083 |
 
 ; data table
+DATA_03C804:
   dw $00BE                                  ; $03C084 |
   dw $00C1                                  ; $03C086 |
   dw $00CC                                  ; $03C088 |
@@ -7778,7 +7793,7 @@ CODE_03C0CC:
   LSR A                                     ; $03C0E4 |
   LSR A                                     ; $03C0E5 |
   TAY                                       ; $03C0E6 |
-  LDA $C084,y                               ; $03C0E7 |
+  LDA DATA_03C804,y                         ; $03C0E7 |
   TXY                                       ; $03C0EA |
   JSL spawn_sprite                          ; $03C0EB |
   LDA #$0002                                ; $03C0EF |
@@ -8049,7 +8064,7 @@ CODE_03C2EF:
   STA !s_spr_draw_priority,x                ; $03C2F0 |
 
 CODE_03C2F3:
-  JSL $03AF23                               ; $03C2F3 |
+  JSL CODE_03AF23                           ; $03C2F3 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $03C2F7 |
   BEQ CODE_03C30A                           ; $03C2F9 |
   LDY #$00                                  ; $03C2FB |
@@ -8168,7 +8183,7 @@ CODE_03C3DE:
 CODE_03C3DF:
   DEC A                                     ; $03C3DF |
   BNE CODE_03C42D                           ; $03C3E0 |
-  JSL $03AF23                               ; $03C3E2 |
+  JSL CODE_03AF23                           ; $03C3E2 |
   JSL $03CC6B                               ; $03C3E6 |
   JSR CODE_03C4F1                           ; $03C3EA |
   LDA $7860,x                               ; $03C3ED |
@@ -8203,8 +8218,8 @@ CODE_03C42C:
 CODE_03C42D:
   DEC A                                     ; $03C42D |
   BNE CODE_03C481                           ; $03C42E |
-  JSL $03AA52                               ; $03C430 |
-  JSL $03AF23                               ; $03C434 |
+  JSL CODE_03AA52                           ; $03C430 |
+  JSL CODE_03AF23                           ; $03C434 |
   JSL $03CC6B                               ; $03C438 |
   JSL $03C4AE                               ; $03C43C |
   STZ !s_spr_x_speed_lo,x                   ; $03C440 |
@@ -8854,7 +8869,7 @@ CODE_03C93B:
   RTL                                       ; $03C94C |
 
 CODE_03C94D:
-  JSL $03AF23                               ; $03C94D |
+  JSL CODE_03AF23                           ; $03C94D |
   LDA !s_spr_y_speed_lo,x                   ; $03C951 |
   CMP #$0100                                ; $03C954 |
   BPL CODE_03C966                           ; $03C957 |
@@ -9631,7 +9646,7 @@ main_flower_vine:
 CODE_03CF66:
   LDA !r_msg_box_state                      ; $03CF66 |
   BNE CODE_03CF81                           ; $03CF69 |
-  JSL $03AF23                               ; $03CF6B |
+  JSL CODE_03AF23                           ; $03CF6B |
   JSL $03CC6B                               ; $03CF6F |
   LDA $7860,x                               ; $03CF73 |
   AND #$0001                                ; $03CF76 |
@@ -9737,7 +9752,7 @@ CODE_03D037:
   RTL                                       ; $03D03F |
 
 CODE_03D040:
-  JSL $03AF23                               ; $03D040 |
+  JSL CODE_03AF23                           ; $03D040 |
   TXA                                       ; $03D044 |
   STA !gsu_r1                               ; $03D045 |
   LDX #$09                                  ; $03D048 |
@@ -10588,7 +10603,7 @@ CODE_03D678:
   STA $0001                                 ; $03D688 |
   LDY $0C18                                 ; $03D68B |
   LDA $00                                   ; $03D68E |
-  JSL $00BEA6                               ; $03D690 |
+  JSL CODE_00BEA6                           ; $03D690 |
   LDA $00                                   ; $03D694 |
   LSR A                                     ; $03D696 |
   CLC                                       ; $03D697 |
@@ -11135,7 +11150,7 @@ CODE_03DA88:
   PHX                                       ; $03DADC |
   PLB                                       ; $03DADD |
   TYX                                       ; $03DADE |
-  JSL $07B1B6                               ; $03DADF |
+  JSL init_fang_flying                      ; $03DADF |
   PLB                                       ; $03DAE3 |
   INC !s_spr_gsu_morph_1_lo,x               ; $03DAE4 |
 
@@ -11214,7 +11229,7 @@ CODE_03DB30:
   PHX                                       ; $03DB76 |
   PLB                                       ; $03DB77 |
   TYX                                       ; $03DB78 |
-  JSL $07B1B6                               ; $03DB79 |
+  JSL init_fang_flying                      ; $03DB79 |
   PLB                                       ; $03DB7D |
   INC !s_spr_gsu_morph_1_lo,x               ; $03DB7E |
 
@@ -11559,7 +11574,7 @@ CODE_03DDE2:
   PHX                                       ; $03DE3F |
   PLB                                       ; $03DE40 |
   TYX                                       ; $03DE41 |
-  JSL $07BB20                               ; $03DE42 |
+  JSL init_flutter                          ; $03DE42 |
   PLB                                       ; $03DE46 |
   LDA !s_spr_oam_1,x                        ; $03DE47 |
   AND #$FFF3                                ; $03DE4A |
@@ -11651,7 +11666,7 @@ CODE_03DE9C:
   PHX                                       ; $03DF00 |
   PLB                                       ; $03DF01 |
   TYX                                       ; $03DF02 |
-  JSL $0F8B36                               ; $03DF03 |
+  JSL init_nipper_spore                     ; $03DF03 |
   PLB                                       ; $03DF07 |
 
 CODE_03DF08:
@@ -11766,7 +11781,7 @@ CODE_03DF4B:
   LDY #$07                                  ; $03DFE3 |
   PHY                                       ; $03DFE5 |
   PLB                                       ; $03DFE6 |
-  JSL $07F196                               ; $03DFE7 |
+  JSL init_bvz_needlenose    ; $03DFE7 |
   PLB                                       ; $03DFEB |
 
 CODE_03DFEC:
@@ -11863,7 +11878,7 @@ CODE_03E01F:
   LDY #$07                                  ; $03E0A0 |
   PHY                                       ; $03E0A2 |
   PLB                                       ; $03E0A3 |
-  JSL $07F191                               ; $03E0A4 |
+  JSL init_bvz_bomb                         ; $03E0A4 |
   PLB                                       ; $03E0A8 |
 
 CODE_03E0A9:
@@ -12356,11 +12371,11 @@ main_kamek_ending:
   LDX $12                                   ; $03E415 |
   LDA !s_spr_anim_frame,x                   ; $03E417 |
   BNE CODE_03E423                           ; $03E41A |
-  JSL $03AA52                               ; $03E41C |
+  JSL CODE_03AA52                           ; $03E41C |
   JSR CODE_03E70C                           ; $03E420 |
 
 CODE_03E423:
-  JSL $03AF23                               ; $03E423 |
+  JSL CODE_03AF23                           ; $03E423 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $03E427 |
   TYX                                       ; $03E429 |
   JMP ($E42D,x)                             ; $03E42A | pointer table
@@ -12793,7 +12808,7 @@ CODE_03E762:
 
 main_kamek_chasing:
   LDX $12                                   ; $03E78F |
-  JSL $03AF23                               ; $03E791 |
+  JSL CODE_03AF23                           ; $03E791 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $03E795 |
   TYX                                       ; $03E797 |
   JMP ($E79B,x)                             ; $03E798 | pointer table
@@ -13010,7 +13025,7 @@ CODE_03E915:
   RTS                                       ; $03E924 |
 
 main_inflating_balloon:
-  JSL $03AA52                               ; $03E925 |
+  JSL CODE_03AA52                           ; $03E925 |
   JSR CODE_03EC0B                           ; $03E929 |
   LDA !s_spr_state,x                        ; $03E92C |
   CMP #$0008                                ; $03E92F |
@@ -13021,7 +13036,7 @@ main_inflating_balloon:
   JSL $03D3F3                               ; $03E93C |
 
 CODE_03E940:
-  JSL $03AF23                               ; $03E940 |
+  JSL CODE_03AF23                           ; $03E940 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $03E944 |
   CMP #$0008                                ; $03E946 |
   BEQ CODE_03E94E                           ; $03E949 |
@@ -13542,7 +13557,7 @@ main_flyguy:
   LDX $12                                   ; $03ED2B |
   JSR CODE_03F183                           ; $03ED2D |
   JSR CODE_03EECA                           ; $03ED30 |
-  JSL $03AF23                               ; $03ED33 |
+  JSL CODE_03AF23                           ; $03ED33 |
   JSL $03A5B7                               ; $03ED37 |
   JSR CODE_03F07F                           ; $03ED3B |
   LDA $14                                   ; $03ED3E |
@@ -14024,7 +14039,7 @@ CODE_03F0D0:
 
 CODE_03F0EF:
   JSR CODE_03F142                           ; $03F0EF |
-  JSL $03AF23                               ; $03F0F2 |
+  JSL CODE_03AF23                           ; $03F0F2 |
   LDA !s_spr_timer_4,x                      ; $03F0F6 |
   CMP #$0001                                ; $03F0F9 |
   BNE CODE_03F105                           ; $03F0FC |
@@ -14226,7 +14241,7 @@ init_kaboomba:
   RTL                                       ; $03F330 |
 
 main_kaboomba:
-  JSL $03AF23                               ; $03F331 |
+  JSL CODE_03AF23                           ; $03F331 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $03F335 |
   TAX                                       ; $03F337 |
   JSR ($F388,x)                             ; $03F338 | table address
@@ -14612,7 +14627,7 @@ CODE_03F604:
   STA !s_spr_oam_1,x                        ; $03F613 |
 
 CODE_03F616:
-  JSL $03AF23                               ; $03F616 |
+  JSL CODE_03AF23                           ; $03F616 |
   LDA !s_spr_wildcard_6_lo_dp,x             ; $03F61A |
   BEQ CODE_03F677                           ; $03F61C |
   JSR CODE_03F6B8                           ; $03F61E |

--- a/disassembly/bank03.asm
+++ b/disassembly/bank03.asm
@@ -2339,7 +2339,7 @@ CODE_039895:
   JSL push_sound_queue                      ; $0398A3 |/
 
 CODE_0398A7:
-  JSL $008AB6                               ; $0398A7 |
+  JSL handle_ambient_sprites                ; $0398A7 |
   LDA !s_cam_event_flag                     ; $0398AB |
   DEC A                                     ; $0398AE |
   BMI CODE_0398B7                           ; $0398AF |
@@ -3113,7 +3113,7 @@ CODE_039EA6:
   JSL push_sound_queue                      ; $039EA9 |/
 
 CODE_039EAD:
-  JSL $03A520                               ; $039EAD |
+  JSL CODE_03A520                           ; $039EAD |
   JSL $0CF957                               ; $039EB1 |
   BRA CODE_039ECA                           ; $039EB5 |
 
@@ -3975,6 +3975,8 @@ CODE_03A4C3:
   LDA !s_spr_x_pixel_pos,x                  ; $03A4EC |
   STA $0000                                 ; $03A4EF |
   LDA !s_spr_y_pixel_pos,x                  ; $03A4F2 |
+
+CODE_03A4F5:
   STA $0002                                 ; $03A4F5 |
   LDA #$0226                                ; $03A4F8 |
   JSL spawn_ambient_sprite                  ; $03A4FB |
@@ -3989,6 +3991,8 @@ CODE_03A4C3:
   STA $7782,y                               ; $03A517 |
   LDA #$FE80                                ; $03A51A |
   STA $71E2,y                               ; $03A51D |
+
+CODE_03A520:
   INC !r_coins_collected                    ; $03A520 | -- entry point
   LDA !r_coins_collected                    ; $03A523 |
   CMP #$0064                                ; $03A526 |
@@ -6006,7 +6010,7 @@ CODE_03B36D:
   BRA CODE_03B3BE                           ; $03B371 |
 
 CODE_03B373:
-  JSL $03A520                               ; $03B373 |
+  JSL CODE_03A520                           ; $03B373 |
   LDA #$0009                                ; $03B377 |\ play sound #$09
   JSL push_sound_queue                      ; $03B37A |/
   BRA CODE_03B3BE                           ; $03B37E |
@@ -7174,12 +7178,12 @@ CODE_03BC2A:
   STA !s_spr_wildcard_1_lo,x                ; $03BC2A |
   REP #$10                                  ; $03BC2D |
   PLX                                       ; $03BC2F |
-  LDA $00E9D4,x                             ; $03BC30 |
+  LDA raphael_mode7_matrix_b_c,x            ; $03BC30 |
   ASL A                                     ; $03BC34 |
   ASL A                                     ; $03BC35 |
   ASL A                                     ; $03BC36 |
   STA !gsu_r2                               ; $03BC37 |
-  LDA $00E954,x                             ; $03BC3A |
+  LDA raphael_mode7_matrix_a_d,x            ; $03BC3A |
   ASL A                                     ; $03BC3E |
   ASL A                                     ; $03BC3F |
   ASL A                                     ; $03BC40 |
@@ -9833,7 +9837,7 @@ CODE_03D0C0:
   CMP #$000A                                ; $03D0CB |
   BCC CODE_03D0DA                           ; $03D0CE |
   REP #$10                                  ; $03D0D0 |
-  JSL $04AC9C                               ; $03D0D2 |
+  JSL player_death_spike                    ; $03D0D2 |
   SEP #$10                                  ; $03D0D6 |
   BRA CODE_03D111                           ; $03D0D8 |
 
@@ -9860,7 +9864,7 @@ CODE_03D0F4:
   CMP #$0012                                ; $03D0FC |
   BCC CODE_03D10B                           ; $03D0FF |
   REP #$10                                  ; $03D101 |
-  JSL $04AC9C                               ; $03D103 |
+  JSL player_death_spike                    ; $03D103 |
   SEP #$10                                  ; $03D107 |
   BRA CODE_03D111                           ; $03D109 |
 
@@ -10462,7 +10466,7 @@ CODE_03D57E:
   STA !r_header_bg1_palette                 ; $03D58A |
   ASL A                                     ; $03D58D |
   TAX                                       ; $03D58E |
-  LDA $00B874,x                             ; $03D58F |
+  LDA bg1_palette_ptrs,x                    ; $03D58F |
   TAX                                       ; $03D593 |
   PHY                                       ; $03D594 |
   PHB                                       ; $03D595 |
@@ -10578,7 +10582,7 @@ CODE_03D640:
   ADC !r_header_bg1_tileset                 ; $03D652 |
   ADC $0C14                                 ; $03D655 |
   TAX                                       ; $03D658 |
-  LDA $00AF39,x                             ; $03D659 |
+  LDA bg1_tileset_files,x                   ; $03D659 |
   AND #$00FF                                ; $03D65D |
   JSL decompress_lc_lz1_l                   ; $03D660 | decompress LC_LZ1
   STA $0C16                                 ; $03D664 |
@@ -13666,7 +13670,7 @@ CODE_03EDE1:
   TXY                                       ; $03EE12 |
   REP #$10                                  ; $03EE13 |
   LDX !s_spr_wildcard_5_lo_dp,y             ; $03EE15 |
-  LDA $00E9D4,x                             ; $03EE17 |
+  LDA raphael_mode7_matrix_b_c,x            ; $03EE17 |
   CMP #$8000                                ; $03EE1B |
   ROR A                                     ; $03EE1E |
   CMP #$8000                                ; $03EE1F |
@@ -13709,10 +13713,10 @@ CODE_03EE45:
   REP #$10                                  ; $03EE61 |
   AND #$01FE                                ; $03EE63 |
   TAX                                       ; $03EE66 |
-  LDA $00E9D4,x                             ; $03EE67 |
+  LDA raphael_mode7_matrix_b_c,x            ; $03EE67 |
   ASL A                                     ; $03EE6B |
   STA !s_spr_y_speed_lo,y                   ; $03EE6C |
-  LDA $00E954,x                             ; $03EE6F |
+  LDA raphael_mode7_matrix_a_d,x            ; $03EE6F |
   ASL A                                     ; $03EE73 |
   PHA                                       ; $03EE74 |
   LDA !s_spr_wildcard_4_hi,y                ; $03EE75 |
@@ -14055,7 +14059,7 @@ CODE_03F105:
   TXY                                       ; $03F114 |
   REP #$10                                  ; $03F115 |
   LDX !s_spr_wildcard_5_lo_dp,y             ; $03F117 |
-  LDA $00E954,x                             ; $03F119 | foreign table
+  LDA raphael_mode7_matrix_a_d,x            ; $03F119 | foreign table
   CMP #$8000                                ; $03F11D |
   ROR A                                     ; $03F120 |
   STA !s_spr_x_speed_lo,y                   ; $03F121 |

--- a/disassembly/bank04.asm
+++ b/disassembly/bank04.asm
@@ -5,7 +5,7 @@ org $048000
   RTS                                       ; $048001 |
 
 init_melon:
-  JSL $02A007                               ; $048002 |
+  JSL CODE_02A007                           ; $048002 |
   STZ !s_spr_wildcard_2_lo,x                ; $048006 |
   LDA !s_spr_x_pixel_pos,x                  ; $048009 |
   CLC                                       ; $04800C |
@@ -25,7 +25,7 @@ init_melon:
   RTL                                       ; $048030 |
 
 main_melon:
-  JSL $03AF23                               ; $048031 |
+  JSL CODE_03AF23                           ; $048031 |
   LDA !s_spr_id,x                           ; $048035 |
   CMP #$0005                                ; $048038 |
   BNE CODE_048041                           ; $04803B |
@@ -182,7 +182,7 @@ CODE_048149:
 
 main_torpedo:
   JSL $03AA2E                               ; $04816B |
-  JSL $03AF23                               ; $04816F |
+  JSL CODE_03AF23                           ; $04816F |
   INC !s_spr_wildcard_3_lo_dp,x             ; $048173 |
   JSL despawn_sprite_threshold_B            ; $048175 |
   BCS CODE_0481C4                           ; $048179 |
@@ -444,7 +444,7 @@ init_melon_flame:
   dw $FFF8                                  ; $04833B |
 
 main_melon_flame:
-  JSL $03AF23                               ; $04833D |
+  JSL CODE_03AF23                           ; $04833D |
   REP #$10                                  ; $048341 |
   LDA !s_spr_wildcard_2_lo,x                ; $048343 |
   TAX                                       ; $048346 |
@@ -553,7 +553,7 @@ init_chill:
   RTL                                       ; $048428 |
 
 main_chill:
-  JSL $03AF23                               ; $048429 |
+  JSL CODE_03AF23                           ; $048429 |
   LDA !s_spr_timer_1,x                      ; $04842D |
   BNE CODE_048441                           ; $048430 |
   LDA #$0006                                ; $048432 |
@@ -660,7 +660,7 @@ init_bubble:
   dw $0200                                  ; $04850B |
 
 main_bubble:
-  JSL $03AF23                               ; $04850D |
+  JSL CODE_03AF23                           ; $04850D |
   LDA !s_spr_timer_1,x                      ; $048511 |
   BNE CODE_048579                           ; $048514 |
   LDA !s_spr_timer_2,x                      ; $048516 |
@@ -936,7 +936,7 @@ CODE_04871A:
   RTL                                       ; $04871A |
 
 CODE_04871B:
-  JSL $03AF23                               ; $04871B |
+  JSL CODE_03AF23                           ; $04871B |
   REP #$10                                  ; $04871F |
   LDA !s_spr_wildcard_2_lo,x                ; $048721 |
   TAX                                       ; $048724 |
@@ -1161,7 +1161,7 @@ CODE_0488D6:
   RTL                                       ; $0488DB |
 
 main_lava_log:
-  JSL $03AF23                               ; $0488DC |
+  JSL CODE_03AF23                           ; $0488DC |
   LDY $7862,x                               ; $0488E0 |
   BEQ CODE_0488FA                           ; $0488E3 |
   LDA !s_spr_y_speed_lo,x                   ; $0488E5 |
@@ -1317,7 +1317,7 @@ init_shy_guy:
 
 CODE_0489F8:
   JSL $048A18                               ; $0489F8 |
-  JSL $02A007                               ; $0489FC |
+  JSL CODE_02A007                           ; $0489FC |
   LDA #$0018                                ; $048A00 | entry
   STA !s_spr_timer_1,x                      ; $048A03 |
   LDA #$0004                                ; $048A06 |
@@ -1390,7 +1390,7 @@ main_shy_guy:
   JML $03B273                               ; $048A86 |
 
 CODE_048A8A:
-  JSL $03AF23                               ; $048A8A |
+  JSL CODE_03AF23                           ; $048A8A |
 
 CODE_048A8E:
   LDY !s_spr_wildcard_5_lo_dp,x             ; $048A8E |
@@ -2194,11 +2194,13 @@ CODE_04906B:
 
 CODE_049086:
   RTL                                       ; $049086 |
-
+head_bonk_lantern_ghost:
   JSR CODE_048B20                           ; $049087 |
   LDA #$0001                                ; $04908A |
   STA !s_spr_anim_frame,x                   ; $04908D |
   JML $039F9F                               ; $049090 |
+
+ride_bandit_shyguy:
   JSR CODE_04909B                           ; $049094 |
   JSR CODE_0490AF                           ; $049097 |
   RTL                                       ; $04909A |
@@ -2287,7 +2289,7 @@ CODE_049132:
 main_stretch:
   LDA !s_spr_dyntile_index,x                ; $049147 |
   BMI CODE_049150                           ; $04914A |
-  JSL $03AA52                               ; $04914C |
+  JSL CODE_03AA52                           ; $04914C |
 
 CODE_049150:
   LDA !s_spr_state,x                        ; $049150 |
@@ -2303,7 +2305,7 @@ CODE_049150:
   STA !s_spr_wildcard_1_lo,x                ; $049169 |
 
 CODE_04916C:
-  JSL $03AF23                               ; $04916C |
+  JSL CODE_03AF23                           ; $04916C |
   TXY                                       ; $049170 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $049171 |
   ASL A                                     ; $049173 |
@@ -2725,7 +2727,7 @@ main_mufti_guy:
   STA !s_spr_state,x                        ; $0494CF |
 
 CODE_0494D2:
-  JSL $03AF23                               ; $0494D2 |
+  JSL CODE_03AF23                           ; $0494D2 |
   TXY                                       ; $0494D6 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0494D7 |
   ASL A                                     ; $0494D9 |
@@ -2997,7 +2999,7 @@ lunge_fish_state_ptr:
   dw $9A61                                  ; $0496F8 | state 09
 
 main_lunge_fish:
-  JSL $03AF23                               ; $0496FA |
+  JSL CODE_03AF23                           ; $0496FA |
   TXY                                       ; $0496FE |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0496FF |
   ASL A                                     ; $049701 |
@@ -3670,7 +3672,7 @@ main_potted_spiked_guy:
 CODE_049C1F:
   LDA $9C02,y                               ; $049C1F |
   STA !s_spr_bitwise_settings_3,x           ; $049C22 |
-  JSL $03AF23                               ; $049C25 |
+  JSL CODE_03AF23                           ; $049C25 |
   TXY                                       ; $049C29 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $049C2A |
   ASL A                                     ; $049C2C |
@@ -3778,8 +3780,8 @@ main_pot_of_potted_spiked_guy:
   RTL                                       ; $049CFB |
 
 CODE_049CFC:
-  JSL $03AF23                               ; $049CFC |
-  JSL $03A2C7                               ; $049D00 |
+  JSL CODE_03AF23                           ; $049CFC |
+  JSL CODE_03A2C7                           ; $049D00 |
   BCC CODE_049D12                           ; $049D04 |
   LDY !s_spr_gsu_morph_2_lo,x               ; $049D06 |
   BEQ CODE_049D0E                           ; $049D09 |
@@ -3949,7 +3951,7 @@ init_grim_leecher:
   dw $A03C                                  ; $049E2E |
 
 main_grim_leecher:
-  JSL $03AF23                               ; $049E30 |
+  JSL CODE_03AF23                           ; $049E30 |
   TXY                                       ; $049E34 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $049E35 |
   ASL A                                     ; $049E37 |
@@ -4277,6 +4279,7 @@ CODE_04A09C:
   dw $A0B8                                  ; $04A0A7 |
   dw $A128                                  ; $04A0A9 |
 
+ride_grim_leecher:
   TXY                                       ; $04A0AB |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $04A0AC |
   ASL A                                     ; $04A0AE |
@@ -4624,14 +4627,14 @@ main_large_log_bg3:
   STA !r_reg_tm_mirror                      ; $04A36F |
 
 CODE_04A372:
-  JSL $03AF23                               ; $04A372 |
+  JSL CODE_03AF23                           ; $04A372 |
   JSR CODE_04A2E6                           ; $04A376 |
   BCC CODE_04A3A0                           ; $04A379 |
   LDX #$08                                  ; $04A37B |
   LDA #$D46A                                ; $04A37D |
   JSL r_gsu_init_1                          ; $04A380 | GSU init
   REP #$10                                  ; $04A384 |
-  JSL $00BE39                               ; $04A386 |
+  JSL CODE_00BE39                           ; $04A386 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $04A38A |
@@ -4825,7 +4828,7 @@ CODE_04A4FF:
   DEC $0DFB                                 ; $04A509 |
   BNE CODE_04A578                           ; $04A50C |
   REP #$10                                  ; $04A50E |
-  JSL $00BE39                               ; $04A510 |
+  JSL CODE_00BE39                           ; $04A510 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $04A514 |
@@ -5071,7 +5074,7 @@ CODE_04A6EB:
   RTL                                       ; $04A6F7 |
 
 main_red_platform:
-  JSL $03AF23                               ; $04A6F8 |
+  JSL CODE_03AF23                           ; $04A6F8 |
   LDA !s_spr_x_pixel_pos,x                  ; $04A6FC |
   CMP !s_spr_wildcard_2_lo,x                ; $04A6FF |
   BMI CODE_04A709                           ; $04A702 |
@@ -5117,7 +5120,7 @@ CODE_04A735:
   JMP CODE_04A6D8                           ; $04A74F |
 
 main_pink_platform:
-  JSL $03AF23                               ; $04A752 |
+  JSL CODE_03AF23                           ; $04A752 |
   LDA !s_spr_y_pixel_pos,x                  ; $04A756 |
   CMP !s_spr_wildcard_2_lo,x                ; $04A759 |
   BMI CODE_04A763                           ; $04A75C |
@@ -5285,6 +5288,7 @@ init_line_guided_platform:
   STA !s_spr_gsu_morph_1_lo,x               ; $04A881 |
   LDA $A868,y                               ; $04A884 |
   STA !s_spr_gsu_morph_2_lo,x               ; $04A887 |
+init_line_guide_platform_inactive:
   LDA #$0080                                ; $04A88A | init inactive platform
   STA !s_spr_wildcard_1_lo,x                ; $04A88D |
   LDA #$0185                                ; $04A890 |
@@ -5307,7 +5311,7 @@ CODE_04A8AB:
   RTL                                       ; $04A8B7 |
 
 main_line_guided_platform:
-  JSL $03AF23                               ; $04A8B8 |
+  JSL CODE_03AF23                           ; $04A8B8 |
   LDA !s_spr_x_pixel_pos,x                  ; $04A8BC |
   STA $00                                   ; $04A8BF |
   LDA !s_spr_y_pixel_pos,x                  ; $04A8C1 |
@@ -5488,8 +5492,8 @@ init_whirling_lift:
   RTL                                       ; $04AA31 |
 
 main_whirling_lift:
-  JSL $03AA52                               ; $04AA32 |
-  JSL $03AF23                               ; $04AA36 |
+  JSL CODE_03AA52                           ; $04AA32 |
+  JSL CODE_03AF23                           ; $04AA36 |
   STZ $0E                                   ; $04AA3A |
   LDA !s_spr_x_pixel_pos,x                  ; $04AA3C |
   STA $00                                   ; $04AA3F |
@@ -5926,7 +5930,7 @@ CODE_04AD66:
   BNE CODE_04AD66                           ; $04ADB8 |
   SEP #$10                                  ; $04ADBA |
   PLX                                       ; $04ADBC |
-  JSL $03AF23                               ; $04ADBD |
+  JSL CODE_03AF23                           ; $04ADBD |
   LDA !s_player_y_speed                     ; $04ADC1 |
   BPL CODE_04ADC9                           ; $04ADC4 |
   JMP CODE_04AE51                           ; $04ADC6 |
@@ -6198,10 +6202,10 @@ init_water_platform:
 main_water_platform:
   LDY !s_spr_dyntile_index,x                ; $04AFC0 |
   BMI CODE_04AFC9                           ; $04AFC3 |
-  JSL $03AA52                               ; $04AFC5 |
+  JSL CODE_03AA52                           ; $04AFC5 |
 
 CODE_04AFC9:
-  JSL $03AF23                               ; $04AFC9 |
+  JSL CODE_03AF23                           ; $04AFC9 |
   LDY #$04                                  ; $04AFCD |
   JSR CODE_04AEDF                           ; $04AFCF |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $04AFD2 |
@@ -6416,7 +6420,7 @@ CODE_04B13C:
 
 main_seesaw:
   JSR CODE_04B2B3                           ; $04B15B |
-  JSL $03AF23                               ; $04B15E |
+  JSL CODE_03AF23                           ; $04B15E |
   JSR CODE_04B169                           ; $04B162 |
   JSR CODE_04B191                           ; $04B165 |
   RTL                                       ; $04B168 |
@@ -6642,7 +6646,7 @@ CODE_04B2CF:
   LDA #$E447                                ; $04B2FA |
   JSL r_gsu_init_1                          ; $04B2FD | GSU init
   REP #$10                                  ; $04B301 |
-  JSL $00BE39                               ; $04B303 |
+  JSL CODE_00BE39                           ; $04B303 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $04B307 |
@@ -6893,13 +6897,13 @@ main_bigger_boo:
   BEQ CODE_04B4FE                           ; $04B4F6 |
 
 CODE_04B4F8:
-  JSL $03AF23                               ; $04B4F8 |
+  JSL CODE_03AF23                           ; $04B4F8 |
   BRA CODE_04B50B                           ; $04B4FC |
 
 CODE_04B4FE:
   JSR CODE_04B541                           ; $04B4FE |
   JSR CODE_04B5A2                           ; $04B501 |
-  JSL $03AF23                               ; $04B504 |
+  JSL CODE_03AF23                           ; $04B504 |
   JSR CODE_04B712                           ; $04B508 |
 
 CODE_04B50B:
@@ -6943,7 +6947,7 @@ CODE_04B54B:
   RTS                                       ; $04B54B |
 
 CODE_04B54C:
-  JSL $03AA52                               ; $04B54C |
+  JSL CODE_03AA52                           ; $04B54C |
   REP #$10                                  ; $04B550 |
   LDA !s_spr_oam_pointer,x                  ; $04B552 |
   CLC                                       ; $04B555 |
@@ -7004,7 +7008,7 @@ CODE_04B5A2:
   LDA #$E315                                ; $04B5E0 |
   JSL r_gsu_init_1                          ; $04B5E3 | GSU init
   REP #$10                                  ; $04B5E7 |
-  JSL $00BE39                               ; $04B5E9 |
+  JSL CODE_00BE39                           ; $04B5E9 |
 
   db $40, $50, $7E, $72                     ; $04B5ED |
   db $33, $70, $48, $03                     ; $04B5F1 |
@@ -7023,7 +7027,7 @@ CODE_04B601:
   LDA #$D46A                                ; $04B603 |
   JSL r_gsu_init_1                          ; $04B606 | GSU init
   REP #$10                                  ; $04B60A |
-  JSL $00BE39                               ; $04B60C |
+  JSL CODE_00BE39                           ; $04B60C |
 
   db $40, $50, $7E, $72                     ; $04B610 |
   db $33, $70, $48, $03                     ; $04B614 |
@@ -8301,7 +8305,7 @@ CODE_04C30D:
 
 CODE_04C311:
   JSR CODE_04C332                           ; $04C311 |
-  JSL $03AF23                               ; $04C314 |
+  JSL CODE_03AF23                           ; $04C314 |
   LDA !s_spr_oam_pointer,x                  ; $04C318 |
   BMI CODE_04C331                           ; $04C31B |
   LDY !s_spr_draw_priority,x                ; $04C31D |
@@ -9040,7 +9044,7 @@ main_bubbled_1_up:
   SEP #$10                                  ; $04C8B6 |
 
 CODE_04C8B8:
-  JSL $03AF23                               ; $04C8B8 |
+  JSL CODE_03AF23                           ; $04C8B8 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $04C8BC |
   BNE CODE_04C8C3                           ; $04C8BE |
   INC !s_spr_wildcard_5_lo_dp,x             ; $04C8C0 |
@@ -9135,7 +9139,7 @@ init_coin_with_gravity:
   RTL                                       ; $04C97A |
 
 main_coin_with_gravity:
-  JSL $03AF23                               ; $04C97B |
+  JSL CODE_03AF23                           ; $04C97B |
   LDA $7974                                 ; $04C97F |
   LSR A                                     ; $04C982 |
   LSR A                                     ; $04C983 |
@@ -9252,7 +9256,7 @@ init_thunder_lakitu_fire_stuff:
 
 ; the fuck is this sprite even
 main_head_of_fire:
-  JSL $03AF23                               ; $04CA62 |
+  JSL CODE_03AF23                           ; $04CA62 |
   LDA $7860,x                               ; $04CA66 |
   BIT #$0001                                ; $04CA69 |
   BEQ CODE_04CA73                           ; $04CA6C |
@@ -9311,7 +9315,7 @@ CODE_04CABC:
 
 ; "fire" and "hypocenter of thunder"
 main_thunder_lakitu_fire_stuff:
-  JSL $03AF23                               ; $04CAFE |
+  JSL CODE_03AF23                           ; $04CAFE |
   LDA !s_spr_timer_2,x                      ; $04CB02 |
   BNE CODE_04CB36                           ; $04CB05 |
   DEC !s_spr_wildcard_4_lo_dp,x             ; $04CB07 |
@@ -9374,7 +9378,7 @@ CODE_04CB52:
 ; both normal and giant
 main_donut_lift:
   STZ !s_spr_facing_dir,x                   ; $04CB7C |
-  JSL $03AF23                               ; $04CB7F |
+  JSL CODE_03AF23                           ; $04CB7F |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $04CB83 |
   BEQ CODE_04CB8B                           ; $04CB85 |
   JML despawn_sprite_stage_ID               ; $04CB87 |
@@ -9469,7 +9473,8 @@ init_number_platform_explosion:
   dw $7602, $7603, $7777, $7778             ; $04CC35 |
   dw $7604, $7605, $7779, $777A             ; $04CC3D |
 
-  JSL $03AF23                               ; $04CC45 |
+main_number_platform_explosion:
+  JSL CODE_03AF23                           ; $04CC45 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $04CC49 |
   BNE CODE_04CC50                           ; $04CC4B |
   INC !s_spr_wildcard_5_lo_dp,x             ; $04CC4D |
@@ -9573,7 +9578,7 @@ CODE_04CCDC:
   JML $03B273                               ; $04CCFD |
 
 CODE_04CD01:
-  JSL $03AF23                               ; $04CD01 |
+  JSL CODE_03AF23                           ; $04CD01 |
 
 CODE_04CD05:
   TXY                                       ; $04CD05 |
@@ -9777,10 +9782,10 @@ init_spiked_ball:
 main_spiked_ball:
   LDY !s_spr_draw_priority,x                ; $04CE70 |
   BMI CODE_04CE79                           ; $04CE73 |
-  JSL $03AA52                               ; $04CE75 |
+  JSL CODE_03AA52                           ; $04CE75 |
 
 CODE_04CE79:
-  JSL $03AF23                               ; $04CE79 |
+  JSL CODE_03AF23                           ; $04CE79 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $04CE7D |
   LDA !s_spr_state,y                        ; $04CE7F |
   CMP #$0010                                ; $04CE82 |
@@ -10004,7 +10009,7 @@ CODE_04D022:
   JSL $04D1A0                               ; $04D033 |
 
 CODE_04D037:
-  JSL $03AF23                               ; $04D037 |
+  JSL CODE_03AF23                           ; $04D037 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $04D03B |
   BEQ CODE_04D042                           ; $04D03D |
   JMP CODE_04D0CB                           ; $04D03F |
@@ -10227,7 +10232,7 @@ CODE_04D1DB:
   RTL                                       ; $04D20B |
 
 main_mace_guy:
-  JSL $03A2C7                               ; $04D20C |
+  JSL CODE_03A2C7                           ; $04D20C |
   BCC CODE_04D223                           ; $04D210 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $04D212 |
   TYX                                       ; $04D214 |
@@ -10250,7 +10255,7 @@ CODE_04D230:
   JSR CODE_04D27E                           ; $04D230 |
 
 CODE_04D233:
-  JSL $03AF23                               ; $04D233 |
+  JSL CODE_03AF23                           ; $04D233 |
   STZ !s_spr_anim_frame,x                   ; $04D237 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $04D23A |
   LDA !s_spr_gsu_morph_2_lo,y               ; $04D23C |
@@ -10382,7 +10387,7 @@ CODE_04D31D:
 
 CODE_04D330:
   JSR CODE_04D3DA                           ; $04D330 |
-  JSL $03AF23                               ; $04D333 |
+  JSL CODE_03AF23                           ; $04D333 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $04D337 |
   BEQ CODE_04D387                           ; $04D339 |
   LDA !s_spr_y_pixel_pos,x                  ; $04D33B |
@@ -10733,7 +10738,7 @@ init_4_toadies:
 
 main_4_toadies:
   JSR CODE_04D7EA                           ; $04D5FC |
-  JSL $03AF23                               ; $04D5FF |
+  JSL CODE_03AF23                           ; $04D5FF |
   LDA !r_header_level_mode                  ; $04D603 |
   CMP #$0009                                ; $04D606 |
   BNE CODE_04D64C                           ; $04D609 |
@@ -11395,7 +11400,7 @@ init_spiky_mace_boo_guys:
   RTL                                       ; $04DAF5 |
 
 main_spiky_mace_boo_guys:
-  JSL $03AF23                               ; $04DAF6 |
+  JSL CODE_03AF23                           ; $04DAF6 |
   LDA !s_spr_timer_2,x                      ; $04DAFA |
   BNE CODE_04DB14                           ; $04DAFD |
   LDA #$0008                                ; $04DAFF |
@@ -11424,7 +11429,7 @@ init_cloud:
   dw $0030, $0040, $0050, $0060             ; $04DB23 |
 
 main_cloud:
-  JSL $03AF23                               ; $04DB2B |
+  JSL CODE_03AF23                           ; $04DB2B |
   LDA !s_spr_cam_x_pos,x                    ; $04DB2F |
   CMP #$0130                                ; $04DB32 |
   BMI CODE_04DB47                           ; $04DB35 |

--- a/disassembly/bank04.asm
+++ b/disassembly/bank04.asm
@@ -391,11 +391,11 @@ CODE_0482C6:
   STA !s_spr_facing_dir,x                   ; $0482CC |
   TXY                                       ; $0482CF |
   LDX $00                                   ; $0482D0 |
-  LDA $00E954,x                             ; $0482D2 |
+  LDA raphael_mode7_matrix_a_d,x            ; $0482D2 |
   ASL A                                     ; $0482D6 |
   ASL A                                     ; $0482D7 |
   STA !s_spr_x_speed_lo,y                   ; $0482D8 |
-  LDA $00E9D4,x                             ; $0482DB |
+  LDA raphael_mode7_matrix_b_c,x            ; $0482DB |
   EOR #$FFFF                                ; $0482DF |
   INC A                                     ; $0482E2 |
   ASL A                                     ; $0482E3 |
@@ -466,7 +466,7 @@ main_melon_flame:
   CLC                                       ; $048371 |
   ADC $8335,y                               ; $048372 |
   STA $6002                                 ; $048375 |
-  JSL $00E01F                               ; $048378 |
+  JSL CODE_00E01F                           ; $048378 |
   SEP #$10                                  ; $04837C |
   LDA #$0213                                ; $04837E |
   JSL spawn_ambient_sprite                  ; $048381 |
@@ -3347,7 +3347,7 @@ CODE_049990:
   STA $04                                   ; $04999E |
   LDA !s_spr_gsu_morph_2_lo,x               ; $0499A0 |
   STA $06                                   ; $0499A3 |
-  JSL $049B42                               ; $0499A5 |
+  JSL CODE_049B42                           ; $0499A5 |
   STA $0C                                   ; $0499A9 |
   LDA $04                                   ; $0499AB |
   STA !s_spr_wildcard_6_lo_dp,x             ; $0499AD |
@@ -3406,7 +3406,7 @@ CODE_049A10:
   LDA !s_spr_timer_2,x                      ; $049A12 |
   BNE CODE_049A10                           ; $049A15 |
   REP #$10                                  ; $049A17 |
-  JSL $04AC9C                               ; $049A19 |
+  JSL player_death_spike                    ; $049A19 |
   SEP #$10                                  ; $049A1D |
   PLA                                       ; $049A1F |\
   RTL                                       ; $049A20 |/ back out of sprite
@@ -3543,6 +3543,7 @@ CODE_049AA4:
   db $46, $47, $48, $49                     ; $049B3E |
 
 ; lunge fish sub
+CODE_049B42:
   PHB                                       ; $049B42 |
   PHK                                       ; $049B43 |
   PLB                                       ; $049B44 |
@@ -9225,6 +9226,7 @@ CODE_04CA1B:
 CODE_04CA26:
   RTL                                       ; $04CA26 |
 
+CODE_04CA27:
   PHB                                       ; $04CA27 |
   PHK                                       ; $04CA28 |
   PLB                                       ; $04CA29 |
@@ -12416,7 +12418,7 @@ CODE_04E2C5:
   LDA !r_yoshi_color                        ; $04E360 |
   ASL A                                     ; $04E363 |
   TAX                                       ; $04E364 |
-  LDA $00BA14,x                             ; $04E365 |
+  LDA yoshi_palette_ptrs,x                  ; $04E365 |
   CLC                                       ; $04E369 |
   ADC #$A000                                ; $04E36A |
   STA !gsu_r14                              ; $04E36D |
@@ -14002,8 +14004,10 @@ cross_section_next_state_B:
 cross_section_do_nothing_B:
   BRA cross_section_next_state_B            ; $04F1EE |
 
+DATA_04F1F0:
   dw $0FFE, $07FE, $0FFE                    ; $04F1F0 |
 
+CODE_04F1F6:
   LDA !s_player_disable_flag                ; $04F1F6 |
   ORA !s_sprite_disable_flag                ; $04F1F9 |
   ORA !r_cur_item_used                      ; $04F1FC |
@@ -14033,7 +14037,7 @@ CODE_04F221:
   DEY                                       ; $04F227 |
   BPL CODE_04F221                           ; $04F228 |
   PLX                                       ; $04F22A |
-  LDA $04F1F0,x                             ; $04F22B |
+  LDA.l DATA_04F1F0,x                       ; $04F22B |
   TAY                                       ; $04F22F |
   LDX #$07FE                                ; $04F230 |
 

--- a/disassembly/bank05.asm
+++ b/disassembly/bank05.asm
@@ -133,10 +133,10 @@ main_egg_block:
   STZ !s_spr_facing_dir,x                   ; $0580E1 |
   LDY !s_spr_anim_frame,x                   ; $0580E4 |
   BEQ CODE_0580ED                           ; $0580E7 |
-  JSL $03AA52                               ; $0580E9 |
+  JSL CODE_03AA52                           ; $0580E9 |
 
 CODE_0580ED:
-  JSL $03AF23                               ; $0580ED |
+  JSL CODE_03AF23                           ; $0580ED |
   TXY                                       ; $0580F1 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0580F2 |
   ASL A                                     ; $0580F4 |
@@ -379,10 +379,10 @@ init_large_spring_ball:
   BRA CODE_0582E5                           ; $0582DF |
 
 CODE_0582E1:
-  JSL $03AA52                               ; $0582E1 |
+  JSL CODE_03AA52                           ; $0582E1 |
 
 CODE_0582E5:
-  JSL $02A007                               ; $0582E5 |
+  JSL CODE_02A007                           ; $0582E5 |
   LDA !s_spr_y_pixel_pos,x                  ; $0582E9 |
   CLC                                       ; $0582EC |
   ADC #$0008                                ; $0582ED |
@@ -391,7 +391,7 @@ CODE_0582E5:
   RTL                                       ; $0582F6 |
 
 init_spring_ball:
-  JSL $02A007                               ; $0582F7 |
+  JSL CODE_02A007                           ; $0582F7 |
   LDY #$00                                  ; $0582FB |
   STY $0E                                   ; $0582FD |
   LDA #$0004                                ; $0582FF |
@@ -414,10 +414,10 @@ main_spring_ball:
 
 ; both sprite IDs
 main_large_spring_ball:
-  JSL $03AA52                               ; $058325 |
+  JSL CODE_03AA52                           ; $058325 |
 
 CODE_058329:
-  JSL $03AF23                               ; $058329 |
+  JSL CODE_03AF23                           ; $058329 |
   LDY #$00                                  ; $05832D |
   LDA !s_spr_id,x                           ; $05832F |
   CMP #$006F                                ; $058332 |
@@ -834,7 +834,7 @@ CODE_058655:
 
 CODE_058658:
   JSR CODE_058723                           ; $058658 |
-  JSL $03AF23                               ; $05865B |
+  JSL CODE_03AF23                           ; $05865B |
   LDA !s_spr_bitwise_settings_3,x           ; $05865F |
   AND #$0300                                ; $058662 |
   BNE CODE_058673                           ; $058665 |
@@ -945,7 +945,7 @@ CODE_058729:
   SEC                                       ; $05873C |
   SBC !s_bg1_cam_y                          ; $05873D |
   STA $0E                                   ; $058740 |
-  JSL $03AA52                               ; $058742 |
+  JSL CODE_03AA52                           ; $058742 |
   LDY !s_spr_facing_dir,x                   ; $058746 |
   LDA $871D,y                               ; $058749 |
   STA $00                                   ; $05874C |
@@ -1648,10 +1648,10 @@ init_lava_bubble:
 main_lava_bubble:
   LDA !s_spr_dyntile_index,x                ; $058CDA |
   BMI CODE_058CE3                           ; $058CDD |
-  JSL $03AA52                               ; $058CDF |
+  JSL CODE_03AA52                           ; $058CDF |
 
 CODE_058CE3:
-  JSL $03AF23                               ; $058CE3 |
+  JSL CODE_03AF23                           ; $058CE3 |
   LDY !s_spr_collision_id,x                 ; $058CE7 |
   BPL CODE_058CF2                           ; $058CEA |
   JSL player_hit_sprite                     ; $058CEC |
@@ -2262,7 +2262,7 @@ main_chain_chomp:
   BRA CODE_0591EF                           ; $0591E6 |
 
 CODE_0591E8:
-  JSL $03AA52                               ; $0591E8 |
+  JSL CODE_03AA52                           ; $0591E8 |
   LDA #$0020                                ; $0591EC |
 
 CODE_0591EF:
@@ -2350,7 +2350,7 @@ CODE_059256:
 CODE_059280:
   SEP #$10                                  ; $059280 |
   PLX                                       ; $059282 |
-  JSL $03AF23                               ; $059283 |
+  JSL CODE_03AF23                           ; $059283 |
   TXY                                       ; $059287 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $059288 |
   ASL A                                     ; $05928A |
@@ -3013,7 +3013,7 @@ CODE_059789:
   JSL $03AEFD                               ; $05978E |
 
 CODE_059792:
-  JSL $03AF23                               ; $059792 |
+  JSL CODE_03AF23                           ; $059792 |
   JSR CODE_05988A                           ; $059796 |
   JSR CODE_05989A                           ; $059799 |
   JSR CODE_0599DD                           ; $05979C |
@@ -3051,7 +3051,7 @@ CODE_0597CD:
   LDA #$950A                                ; $0597D9 |
   JSL r_gsu_init_1                          ; $0597DC | GSU init
   LDX $12                                   ; $0597E0 |
-  JSL $03AA52                               ; $0597E2 |
+  JSL CODE_03AA52                           ; $0597E2 |
   REP #$10                                  ; $0597E6 |
   LDA !s_spr_oam_pointer,x                  ; $0597E8 |
   CLC                                       ; $0597EB |
@@ -3490,8 +3490,8 @@ init_expansion_block:
   dw $9C42                                  ; $059B4C |
 
 main_expansion_block:
-  JSL $03AA52                               ; $059B4E |
-  JSL $03AF23                               ; $059B52 |
+  JSL CODE_03AA52                           ; $059B4E |
+  JSL CODE_03AF23                           ; $059B52 |
   TXY                                       ; $059B56 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $059B57 |
   ASL A                                     ; $059B59 |
@@ -3822,11 +3822,11 @@ init_checkered_block:
 
 ; blue and red
 main_checkered_block:
-  JSL $03AA52                               ; $059DBC |
+  JSL CODE_03AA52                           ; $059DBC |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $059DC0 |
   CPY #$01                                  ; $059DC2 |
   BEQ CODE_059DCC                           ; $059DC4 |
-  JSL $03AF23                               ; $059DC6 |
+  JSL CODE_03AF23                           ; $059DC6 |
   BRA CODE_059DD3                           ; $059DCA |
 
 CODE_059DCC:
@@ -4155,10 +4155,10 @@ CODE_05A040:
   LDY !s_spr_wildcard_5_lo_dp,x             ; $05A040 |
   CPY #$10                                  ; $05A042 |
   BEQ CODE_05A04A                           ; $05A044 |
-  JSL $03AF23                               ; $05A046 |
+  JSL CODE_03AF23                           ; $05A046 |
 
 CODE_05A04A:
-  JSL $03A2C7                               ; $05A04A |
+  JSL CODE_03A2C7                           ; $05A04A |
   BCC CODE_05A07B                           ; $05A04E |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $05A050 |
   CPY #$08                                  ; $05A052 |
@@ -5065,7 +5065,7 @@ CODE_05A757:
   dw $0010, $FFF0, $0000                    ; $05A763 |
 
 CODE_05A769:
-  JSL $03AA52                               ; $05A769 |
+  JSL CODE_03AA52                           ; $05A769 |
   LDA !s_spr_oam_yxppccct,x                 ; $05A76D |
   AND #$0080                                ; $05A770 |
   ASL A                                     ; $05A773 |
@@ -5235,7 +5235,7 @@ CODE_05A8CC:
   STA $0E                                   ; $05A8CC |
   STA !s_spr_y_hitbox_offset,x              ; $05A8CE |
   JSR CODE_05A769                           ; $05A8D1 |
-  JSL $03AF23                               ; $05A8D4 |
+  JSL CODE_03AF23                           ; $05A8D4 |
   TXY                                       ; $05A8D8 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05A8D9 |
   ASL A                                     ; $05A8DB |
@@ -5724,7 +5724,7 @@ main_small_burt:
 
 CODE_05ACB6:
   JSR CODE_05AE61                           ; $05ACB6 |
-  JSL $03AF23                               ; $05ACB9 |
+  JSL CODE_03AF23                           ; $05ACB9 |
   LDA #$0018                                ; $05ACBD |
   STA !gsu_r0                               ; $05ACC0 |
   LDA #$000E                                ; $05ACC3 |
@@ -6781,9 +6781,9 @@ main_balloon:
   JMP CODE_05B52B                           ; $05B4D0 |
 
 CODE_05B4D3:
-  JSL $03AA52                               ; $05B4D3 |
-  JSL $03AF23                               ; $05B4D7 |
-  JSL $03A2C7                               ; $05B4DB |
+  JSL CODE_03AA52                           ; $05B4D3 |
+  JSL CODE_03AF23                           ; $05B4D7 |
+  JSL CODE_03A2C7                           ; $05B4DB |
   BCC CODE_05B50F                           ; $05B4DF |
   LDA !s_spr_dyntile_index,x                ; $05B4E1 |
   CMP $0FE9                                 ; $05B4E4 |
@@ -6826,7 +6826,7 @@ CODE_05B52A:
   RTL                                       ; $05B52A |
 
 CODE_05B52B:
-  JSL $03AF23                               ; $05B52B |
+  JSL CODE_03AF23                           ; $05B52B |
   LDY !r_balloon_gen_flag                   ; $05B52F |
   BEQ CODE_05B50B                           ; $05B532 |
   LDA !s_spr_cam_x_pos,x                    ; $05B534 |
@@ -7099,7 +7099,7 @@ yoshi_block_ptr:
   dw $B85A                                  ; $05B758 |
 
 main_yoshi_block:
-  JSL $03AA52                               ; $05B75A |
+  JSL CODE_03AA52                           ; $05B75A |
   LDA !s_sprite_disable_flag                ; $05B75E |
   ORA $0B55                                 ; $05B761 |
   ORA !r_cur_item_used                      ; $05B764 |
@@ -7411,7 +7411,7 @@ CODE_05B9C3:
 
 main_eggo_dil:
   STZ !s_spr_facing_dir,x                   ; $05B9C8 |
-  JSL $03AF23                               ; $05B9CB |
+  JSL CODE_03AF23                           ; $05B9CB |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $05B9CF |
   BNE CODE_05B9ED                           ; $05B9D1 |
   LDA #$00EF                                ; $05B9D3 |
@@ -7437,7 +7437,7 @@ main_eggo_dil_face:
   STZ !s_spr_facing_dir,x                   ; $05B9FC |
   JSR CODE_05BA36                           ; $05B9FF |
   JSR CODE_05BB09                           ; $05BA02 |
-  JSL $03AF23                               ; $05BA05 |
+  JSL CODE_03AF23                           ; $05BA05 |
   LDY $0EDF                                 ; $05BA09 |
   BPL CODE_05BA1E                           ; $05BA0C |
   LDX $0EDD                                 ; $05BA0E |
@@ -7447,7 +7447,7 @@ main_eggo_dil_face:
   JML despawn_sprite_stage_ID               ; $05BA1A |
 
 CODE_05BA1E:
-  JSL $03A2C7                               ; $05BA1E |
+  JSL CODE_03A2C7                           ; $05BA1E |
   BCC CODE_05BA2A                           ; $05BA22 |
   LDY #$FF                                  ; $05BA24 |
   STY $0EDF                                 ; $05BA26 |
@@ -7476,7 +7476,7 @@ CODE_05BA36:
   RTS                                       ; $05BA51 |
 
 CODE_05BA52:
-  JSL $03AA52                               ; $05BA52 |
+  JSL CODE_03AA52                           ; $05BA52 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $05BA56 |
   SEC                                       ; $05BA59 |
   SBC #$0080                                ; $05BA5A |
@@ -7970,16 +7970,16 @@ main_eggo_dil_petal:
 CODE_05BE12:
   LDA !s_spr_collision_state,x              ; $05BE12 |
   BEQ CODE_05BE24                           ; $05BE15 |
-  JSL $03A2C7                               ; $05BE17 |
+  JSL CODE_03A2C7                           ; $05BE17 |
   BCC CODE_05BE24                           ; $05BE1B |
   JSR CODE_05BE5A                           ; $05BE1D |
   JML despawn_sprite_stage_ID               ; $05BE20 |
 
 CODE_05BE24:
-  JSL $03AF23                               ; $05BE24 |
+  JSL CODE_03AF23                           ; $05BE24 |
   LDY $0EDF                                 ; $05BE28 |
   BMI CODE_05BE3A                           ; $05BE2B |
-  JSL $03A2C7                               ; $05BE2D |
+  JSL CODE_03A2C7                           ; $05BE2D |
   BCC CODE_05BE4B                           ; $05BE31 |
   JSR CODE_05BE5A                           ; $05BE33 |
   JML despawn_sprite_stage_ID               ; $05BE36 |
@@ -8132,7 +8132,7 @@ CODE_05BF63:
   JSR CODE_05C06E                           ; $05BF66 |
 
 CODE_05BF69:
-  JSL $03AF23                               ; $05BF69 |
+  JSL CODE_03AF23                           ; $05BF69 |
   TXY                                       ; $05BF6D |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05BF6E |
   ASL A                                     ; $05BF70 |
@@ -8821,8 +8821,8 @@ bucket_obj_state_ptr:
 ; buckets with objects point here - bandit/coins
 main_bucket_obj:
   JSR CODE_05C4D5                           ; $05C4AD |
-  JSL $03AF23                               ; $05C4B0 |
-  JSL $03A2C7                               ; $05C4B4 |
+  JSL CODE_03AF23                           ; $05C4B0 |
+  JSL CODE_03A2C7                           ; $05C4B4 |
   BCC CODE_05C4C6                           ; $05C4B8 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $05C4BA |
   BEQ CODE_05C4C2                           ; $05C4BC |
@@ -8843,7 +8843,7 @@ CODE_05C4C6:
 
 ; bucket sub
 CODE_05C4D5:
-  JSL $03AA52                               ; $05C4D5 |
+  JSL CODE_03AA52                           ; $05C4D5 |
   LDA !s_spr_gsu_morph_2_hi,x               ; $05C4D9 |
   AND #$00FF                                ; $05C4DC |
   ASL A                                     ; $05C4DF |
@@ -9349,7 +9349,7 @@ bucket_state_ptr:
 ; regular empty bucket
 main_bucket:
   JSR CODE_05C4D5                           ; $05C8B6 |
-  JSL $03AF23                               ; $05C8B9 |
+  JSL CODE_03AF23                           ; $05C8B9 |
   TXY                                       ; $05C8BD |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05C8BE |
   ASL A                                     ; $05C8C0 |
@@ -9713,7 +9713,7 @@ freezegood_state_ptr:
   dw $D0E4                                  ; $05CB62 |
 
 main_freezegood:
-  JSL $03AA52                               ; $05CB64 |
+  JSL CODE_03AA52                           ; $05CB64 |
   LDA !s_spr_state,x                        ; $05CB68 |
   CMP #$0010                                ; $05CB6B |
   BEQ CODE_05CB7A                           ; $05CB6E |
@@ -9726,7 +9726,7 @@ CODE_05CB77:
   JSR CODE_05D152                           ; $05CB77 |
 
 CODE_05CB7A:
-  JSL $03AF23                               ; $05CB7A |
+  JSL CODE_03AF23                           ; $05CB7A |
   JSR CODE_05CB93                           ; $05CB7E |
   JSR CODE_05CBBC                           ; $05CB81 |
   TXY                                       ; $05CB84 |
@@ -10674,7 +10674,7 @@ CODE_05D26F:
   STA !s_spr_state,y                        ; $05D272 |
 
 CODE_05D275:
-  JSL $03AF23                               ; $05D275 |
+  JSL CODE_03AF23                           ; $05D275 |
   JSR CODE_05D37E                           ; $05D279 |
   TXY                                       ; $05D27C |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05D27D |
@@ -11172,11 +11172,11 @@ main_biting_bullet_bill:
   BMI CODE_05D673                           ; $05D668 |
   LDY $7723,x                               ; $05D66A |
   BMI CODE_05D673                           ; $05D66D |
-  JSL $03AA52                               ; $05D66F |
+  JSL CODE_03AA52                           ; $05D66F |
 
 CODE_05D673:
   JSR CODE_05D71D                           ; $05D673 |
-  JSL $03AF23                               ; $05D676 |
+  JSL CODE_03AF23                           ; $05D676 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $05D67A |
   BNE CODE_05D68B                           ; $05D67C |
   LDA !s_spr_timer_2,x                      ; $05D67E |
@@ -11240,7 +11240,7 @@ CODE_05D6E8:
 
 main_bullet_bill:
   JSR CODE_05D71D                           ; $05D6ED |
-  JSL $03AF23                               ; $05D6F0 |
+  JSL CODE_03AF23                           ; $05D6F0 |
   LDA #$0004                                ; $05D6F4 |
   STA !s_spr_draw_priority,x                ; $05D6F7 |
 
@@ -11461,7 +11461,8 @@ CODE_05D8AF:
 CODE_05D8B5:
   RTS                                       ; $05D8B5 |
 
-  JSL $03AA52                               ; $05D8B6 |
+head_bop_special_bullet_bill:
+  JSL CODE_03AA52                           ; $05D8B6 |
   LDA !s_sprite_disable_flag                ; $05D8BA |
   ORA $0B55                                 ; $05D8BD |
   ORA !r_cur_item_used                      ; $05D8C0 |
@@ -11476,6 +11477,7 @@ CODE_05D8B5:
 CODE_05D8D5:
   RTL                                       ; $05D8D5 |
 
+head_bop_bullet_bill:
   JML $039F9F                               ; $05D8D6 |
 
 init_bouncing_bullet_bill:
@@ -11492,7 +11494,7 @@ main_bouncing_bullet_bill:
   BMI CODE_05D8F4                           ; $05D8E9 |
   LDY $7723,x                               ; $05D8EB |
   BMI CODE_05D8F4                           ; $05D8EE |
-  JSL $03AA52                               ; $05D8F0 |
+  JSL CODE_03AA52                           ; $05D8F0 |
 
 CODE_05D8F4:
   JSR CODE_05D71D                           ; $05D8F4 |
@@ -11501,7 +11503,7 @@ CODE_05D8F4:
   STZ !s_spr_bitwise_settings_3,x           ; $05D8FC |
 
 CODE_05D8FF:
-  JSL $03AF23                               ; $05D8FF |
+  JSL CODE_03AF23                           ; $05D8FF |
   LDA #$0004                                ; $05D903 |
   STA !s_spr_draw_priority,x                ; $05D906 |
   TXY                                       ; $05D909 |
@@ -11721,7 +11723,8 @@ init_hint_block:
 
   dw $0020, $FFE0                           ; $05DABF |
 
-  JSL $03AA52                               ; $05DAC3 |
+main_hint_block:
+  JSL CODE_03AA52                           ; $05DAC3 |
   LDA !s_sprite_disable_flag                ; $05DAC7 |
   ORA $0B55                                 ; $05DACA |
   ORA !r_cur_item_used                      ; $05DACD |
@@ -11970,7 +11973,7 @@ CODE_05DC8F:
   dw $E0DC                                  ; $05DCBC |
 
 main_boo_man_bluff:
-  JSL $03AF23                               ; $05DCBE |
+  JSL CODE_03AF23                           ; $05DCBE |
   LDY !s_spr_collision_id,x                 ; $05DCC2 |
   BPL CODE_05DCFB                           ; $05DCC5 |
   JSL player_hit_sprite                     ; $05DCC7 |
@@ -12589,7 +12592,7 @@ CODE_05E130:
   dw $E2C2, $E300                           ; $05E139 |
 
 main_heading_cactus:
-  JSL $03AF23                               ; $05E13D |
+  JSL CODE_03AF23                           ; $05E13D |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $05E141 |
   BMI CODE_05E149                           ; $05E143 |
   JSL $03A5B7                               ; $05E145 |
@@ -12861,7 +12864,7 @@ main_muddy_buddy:
   JSR CODE_05E524                           ; $05E355 |
 
 CODE_05E358:
-  JSL $03AF23                               ; $05E358 |
+  JSL CODE_03AF23                           ; $05E358 |
   JSR CODE_05E6BD                           ; $05E35C |
   JSR CODE_05E6D9                           ; $05E35F |
   JSR CODE_05E44C                           ; $05E362 |
@@ -12943,7 +12946,7 @@ CODE_05E3EE:
   BNE CODE_05E447                           ; $05E3F4 |
   LDY !s_spr_draw_priority,x                ; $05E3F6 |
   BMI CODE_05E447                           ; $05E3F9 |
-  JSL $03AA52                               ; $05E3FB |
+  JSL CODE_03AA52                           ; $05E3FB |
   LDA !s_spr_cam_x_pos,x                    ; $05E3FF |
   CLC                                       ; $05E402 |
   ADC #$0004                                ; $05E403 |
@@ -13786,7 +13789,7 @@ CODE_05EAAC:
   JSR CODE_05EF9F                           ; $05EAAC |
 
 CODE_05EAAF:
-  JSL $03AF23                               ; $05EAAF |
+  JSL CODE_03AF23                           ; $05EAAF |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $05EAB3 |
   CPY #$03                                  ; $05EAB5 |
   BEQ CODE_05EAD7                           ; $05EAB7 |
@@ -13868,7 +13871,7 @@ CODE_05EB3C:
 CODE_05EB40:
   LDY !s_spr_anim_frame,x                   ; $05EB40 |
   BNE CODE_05EBA3                           ; $05EB43 |
-  JSL $03AA52                               ; $05EB45 |
+  JSL CODE_03AA52                           ; $05EB45 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $05EB49 |
   STA !gsu_r1                               ; $05EB4C |
   LDA #$0008                                ; $05EB4F |
@@ -13915,7 +13918,7 @@ CODE_05EBA3:
   RTS                                       ; $05EBA3 |
 
 CODE_05EBA4:
-  JSL $03A2C7                               ; $05EBA4 |
+  JSL CODE_03A2C7                           ; $05EBA4 |
   BCC CODE_05EBB3                           ; $05EBA8 |
   LDY !s_spr_wildcard_6_lo_dp,x             ; $05EBAA |
   BNE CODE_05EBB8                           ; $05EBAC |
@@ -14536,7 +14539,7 @@ init_arrow_wheel:
 ; brown and blue
 main_arrow_wheel:
   STZ !s_spr_facing_dir,x                   ; $05F09F |
-  JSL $03AA52                               ; $05F0A2 |
+  JSL CODE_03AA52                           ; $05F0A2 |
   JSL $05F0FA                               ; $05F0A6 |
   JSR CODE_05F0F3                           ; $05F0AA |
   JSR CODE_05F1F6                           ; $05F0AD |
@@ -14996,7 +14999,7 @@ CODE_05F428:
 
 main_double_ended_arrow_lift:
   STZ !s_spr_facing_dir,x                   ; $05F436 |
-  JSL $03AA52                               ; $05F439 |
+  JSL CODE_03AA52                           ; $05F439 |
   LDA !s_spr_state,x                        ; $05F43D |
   CMP #$0008                                ; $05F440 |
   BNE CODE_05F45B                           ; $05F443 |
@@ -15209,8 +15212,9 @@ CODE_05F5B8:
   dw $F6BF                                  ; $05F5CE |
   dw $80C2                                  ; $05F5D0 |
 
-  JSL $03AA52                               ; $05F5D2 |
-  JSL $03AF23                               ; $05F5D6 |
+main_pow_block:
+  JSL CODE_03AA52                           ; $05F5D2 |
+  JSL CODE_03AF23                           ; $05F5D6 |
   TXY                                       ; $05F5DA |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05F5DB |
   ASL A                                     ; $05F5DD |
@@ -15395,7 +15399,7 @@ CODE_05F737:
 main_flopsy_fish_jumps:
   JSR CODE_05F76D                           ; $05F74E |
   JSL $05F79A                               ; $05F751 |
-  JSL $03AF23                               ; $05F755 |
+  JSL CODE_03AF23                           ; $05F755 |
   TXY                                       ; $05F759 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05F75A |
   ASL A                                     ; $05F75C |
@@ -15414,7 +15418,7 @@ CODE_05F76D:
   BMI CODE_05F799                           ; $05F775 |
   LDY !s_spr_draw_priority,x                ; $05F777 |
   BMI CODE_05F799                           ; $05F77A |
-  JSL $03AA52                               ; $05F77C |
+  JSL CODE_03AA52                           ; $05F77C |
   REP #$10                                  ; $05F780 |
   LDY !s_spr_oam_pointer,x                  ; $05F782 |
   LDA $6000,y                               ; $05F785 |
@@ -15674,7 +15678,7 @@ init_melon_bug:
   dw $FAC7                                  ; $05F97F |
 
 main_melon_bug:
-  JSL $03AF23                               ; $05F981 |
+  JSL CODE_03AF23                           ; $05F981 |
   LDA !s_spr_x_speed_lo,x                   ; $05F985 |
   CLC                                       ; $05F988 |
   ADC #$0008                                ; $05F989 |
@@ -16321,10 +16325,10 @@ main_hit_green_egg_block:
   LDA !s_spr_dyntile_index,x                ; $05FE6E |
   ORA !s_spr_oam_pointer,x                  ; $05FE71 |
   BMI CODE_05FE7A                           ; $05FE74 |
-  JSL $03AA52                               ; $05FE76 |
+  JSL CODE_03AA52                           ; $05FE76 |
 
 CODE_05FE7A:
-  JSL $03AF23                               ; $05FE7A |
+  JSL CODE_03AF23                           ; $05FE7A |
   JSL $03D127                               ; $05FE7E |
   LDY !s_spr_collision_id,x                 ; $05FE82 |
   DEY                                       ; $05FE85 |
@@ -16472,6 +16476,7 @@ CODE_05FFC3:
   RTL                                       ; $05FFC3 |
 
 ; freespace
+junk_sprite_pointer:
   db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; $05FFC4 |
   db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; $05FFCC |
   db $FF, $FF, $FF, $FF, $FF, $FF, $FF, $FF ; $05FFD4 |

--- a/disassembly/bank05.asm
+++ b/disassembly/bank05.asm
@@ -4575,7 +4575,7 @@ CODE_05A369:
   STA $04                                   ; $05A383 |
   LDA !s_spr_wildcard_2_lo,x                ; $05A385 |
   STA $06                                   ; $05A388 |
-  JSL $049B42                               ; $05A38A |
+  JSL CODE_049B42                           ; $05A38A |
   PHA                                       ; $05A38E |
   LDA $04                                   ; $05A38F |
   STA !s_spr_wildcard_1_lo,x                ; $05A391 |
@@ -5712,6 +5712,8 @@ CODE_05AC23:
   JSR CODE_05B035                           ; $05AC8A |
   RTL                                       ; $05AC8D |
 
+; small burt phase pointers
+DATA_05AC8E:
   dw $B07C, $B0CE, $B152, $B16A             ; $05AC8E |
   dw $B182, $B18B, $80C2, $B1A9             ; $05AC96 |
   dw $B205, $B257, $B2EA, $B34F             ; $05AC9E |
@@ -5749,7 +5751,7 @@ CODE_05ACB6:
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05ACF6 |
   ASL A                                     ; $05ACF8 |
   TAX                                       ; $05ACF9 |
-  JSR ($AC8E,x)                             ; $05ACFA |
+  JSR (DATA_05AC8E,x)                      ; $05ACFA |
   JSR CODE_05B035                           ; $05ACFD |
 
 CODE_05AD00:
@@ -6673,13 +6675,16 @@ CODE_05B3D4:
   STA !s_spr_gsu_morph_1_lo,x               ; $05B3DB |
   RTS                                       ; $05B3DE |
 
-  JSL $00DEFF                               ; $05B3DF |
+DATA_05B3DF:
+  dw $FF22, $00DE                           ; $05B3DF |
+
+CODE_05B3E3:
   TYX                                       ; $05B3E3 |
   LDA !s_spr_gsu_morph_1_lo,x               ; $05B3E4 |
   CMP #$0140                                ; $05B3E7 |
   BMI CODE_05B415                           ; $05B3EA |
   LDY !s_spr_facing_dir,x                   ; $05B3EC |
-  LDA $B3DF,y                               ; $05B3EF |
+  LDA DATA_05B3DF,y                         ; $05B3EF |
   STA !s_spr_x_speed_lo,x                   ; $05B3F2 |
   LDA #$FA00                                ; $05B3F5 |
   STA !s_spr_y_speed_lo,x                   ; $05B3F8 |
@@ -16409,7 +16414,7 @@ CODE_05FF2D:
   AND #$00FF                                ; $05FF30 |
   ASL A                                     ; $05FF33 |
   TAX                                       ; $05FF34 |
-  LDA $00E9D4,x                             ; $05FF35 |
+  LDA raphael_mode7_matrix_b_c,x            ; $05FF35 |
   TAY                                       ; $05FF39 |
   STY !reg_m7a                              ; $05FF3A |
   XBA                                       ; $05FF3D |
@@ -16417,7 +16422,7 @@ CODE_05FF2D:
   STY !reg_m7a                              ; $05FF3F |
   LDY #$20                                  ; $05FF42 |
   STY !reg_m7b                              ; $05FF44 |
-  LDA $00E954,x                             ; $05FF47 |
+  LDA raphael_mode7_matrix_a_d,x            ; $05FF47 |
   PHA                                       ; $05FF4B |
   LDX $12                                   ; $05FF4C |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $05FF4E |

--- a/disassembly/bank06.asm
+++ b/disassembly/bank06.asm
@@ -2523,7 +2523,7 @@ CODE_069395:
   ASL A                                     ; $069397 |
   TAX                                       ; $069398 |
   PHX                                       ; $069399 |
-  LDA $00E954,x                             ; $06939A |
+  LDA raphael_mode7_matrix_a_d,x            ; $06939A |
   SEP #$20                                  ; $06939E |
   STA !reg_m7a                              ; $0693A0 |
   XBA                                       ; $0693A3 |
@@ -2543,7 +2543,7 @@ CODE_0693B9:
   STA $03                                   ; $0693B9 |
   REP #$20                                  ; $0693BB |
   PLX                                       ; $0693BD |
-  LDA $00E9D4,x                             ; $0693BE |
+  LDA raphael_mode7_matrix_b_c,x            ; $0693BE |
   SEP #$20                                  ; $0693C2 |
   STA !reg_m7a                              ; $0693C4 |
   XBA                                       ; $0693C7 |
@@ -4211,13 +4211,13 @@ CODE_06A174:
   LDA $10                                   ; $06A1A3 |
   AND #$007E                                ; $06A1A5 |
   TAX                                       ; $06A1A8 |
-  LDA $00E9D4,x                             ; $06A1A9 |
+  LDA raphael_mode7_matrix_b_c,x            ; $06A1A9 |
   ASL A                                     ; $06A1AD |
   ASL A                                     ; $06A1AE |
   ASL A                                     ; $06A1AF |
   ASL A                                     ; $06A1B0 |
   STA !s_spr_y_speed_lo,y                   ; $06A1B1 |
-  LDA $00E954,x                             ; $06A1B4 |
+  LDA raphael_mode7_matrix_a_d,x            ; $06A1B4 |
   ASL A                                     ; $06A1B8 |
   ASL A                                     ; $06A1B9 |
   ASL A                                     ; $06A1BA |
@@ -4306,13 +4306,13 @@ CODE_06A24D:
   ASL A                                     ; $06A25B |
   TXY                                       ; $06A25C |
   TAX                                       ; $06A25D |
-  LDA $00E9D4,x                             ; $06A25E |
+  LDA raphael_mode7_matrix_b_c,x            ; $06A25E |
   ASL A                                     ; $06A262 |
   ASL A                                     ; $06A263 |
   ASL A                                     ; $06A264 |
   ASL A                                     ; $06A265 |
   STA !s_spr_y_speed_lo,y                   ; $06A266 |
-  LDA $00E954,x                             ; $06A269 |
+  LDA raphael_mode7_matrix_a_d,x            ; $06A269 |
   ASL A                                     ; $06A26D |
   ASL A                                     ; $06A26E |
   ASL A                                     ; $06A26F |
@@ -10301,7 +10301,7 @@ CODE_06D680:
   LDA !gsu_r1                               ; $06D6A4 |
   ASL A                                     ; $06D6A7 |
   TAX                                       ; $06D6A8 |
-  LDA $00E9D4,x                             ; $06D6A9 |
+  LDA raphael_mode7_matrix_b_c,x            ; $06D6A9 |
   ASL A                                     ; $06D6AD |
   TAX                                       ; $06D6AE |
   LDA $702200,x                             ; $06D6AF |

--- a/disassembly/bank06.asm
+++ b/disassembly/bank06.asm
@@ -453,7 +453,7 @@ CODE_068395:
   LDX #$0070                                ; $06839E |
   STX $0001                                 ; $0683A1 |
   LDX #$6800                                ; $0683A4 |
-  JSL $00BEA6                               ; $0683A7 |
+  JSL CODE_00BEA6                           ; $0683A7 |
   SEP #$10                                  ; $0683AB |
   RTS                                       ; $0683AD |
 
@@ -507,7 +507,7 @@ CODE_068402:
   STA !r_reg_tm_mirror                      ; $068414 |
 
 CODE_068417:
-  JSL $03AF23                               ; $068417 |
+  JSL CODE_03AF23                           ; $068417 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $06841B |
   CPY #$0C                                  ; $06841D |
   BEQ CODE_06842B                           ; $06841F |
@@ -630,7 +630,7 @@ CODE_0684AA:
   LDA #$81C9                                ; $068512 |
   JSL r_gsu_init_3                          ; $068515 |
   REP #$10                                  ; $068519 |
-  JSL $00BE39                               ; $06851B |
+  JSL CODE_00BE39                           ; $06851B |
 
 ; args to $00BE39
   dw $5040, $727E, $7033, $0348             ; $06851F |
@@ -1660,7 +1660,7 @@ CODE_068CBF:
   LDA #$D46A                                ; $068D04 |
   JSL r_gsu_init_1                          ; $068D07 | gsu
   REP #$10                                  ; $068D0B |
-  JSL $00BE39                               ; $068D0D |
+  JSL CODE_00BE39                           ; $068D0D |
 
 ; args to $00BE39
   dw $5040, $727E, $7033, $0348             ; $068D11 |
@@ -2054,7 +2054,7 @@ CODE_068FF0:
   LDX #$08                                  ; $06902A |
   LDA #$E93B                                ; $06902C |
   JSL r_gsu_init_1                          ; $06902F |
-  JSL $00BE39                               ; $069033 |
+  JSL CODE_00BE39                           ; $069033 |
 
 ; args to $00BE39
   dw $5040, $727E, $7033, $0348             ; $069037 |
@@ -2410,7 +2410,7 @@ init_salvo_eyes:
   RTL                                       ; $0692E5 |
 
 main_salvo_eyes:
-  JSL $03AF23                               ; $0692E6 |
+  JSL CODE_03AF23                           ; $0692E6 |
   JSR CODE_069329                           ; $0692EA |
   LDA !s_spr_timer_1,x                      ; $0692ED |
   BNE CODE_069326                           ; $0692F0 |
@@ -2615,7 +2615,7 @@ CODE_069427:
   STA !s_spr_wildcard_2_lo,x                ; $06943B |
 
 CODE_06943E:
-  JSL $03AF23                               ; $06943E |
+  JSL CODE_03AF23                           ; $06943E |
   TXY                                       ; $069442 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $069443 |
   ASL A                                     ; $069445 |
@@ -3244,7 +3244,7 @@ CODE_0699ED:
   JSR ($9988,x)                             ; $0699F6 |
 
 CODE_0699F9:
-  JSL $03AF23                               ; $0699F9 |
+  JSL CODE_03AF23                           ; $0699F9 |
   LDA !s_player_state                       ; $0699FD |
   BNE CODE_069A19                           ; $069A00 |
   LDY !s_spr_gsu_morph_1_hi,x               ; $069A02 |
@@ -4877,7 +4877,7 @@ CODE_06A77F:
   LDX #$0A                                  ; $06A7B4 |
   LDA #$897A                                ; $06A7B6 |
   JSL r_gsu_init_3                          ; $06A7B9 |
-  JSL $00BE39                               ; $06A7BD |
+  JSL CODE_00BE39                           ; $06A7BD |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06A7C1 |
@@ -5282,7 +5282,7 @@ main_marching_milde:
 
 ; milde sub
   LDX $12                                   ; $06AABB |
-  JSL $03AF23                               ; $06AABD |
+  JSL CODE_03AF23                           ; $06AABD |
   LDA !s_spr_x_pixel_pos,x                  ; $06AAC1 |
   CMP #$00C0                                ; $06AAC4 |
   BCC CODE_06AAE7                           ; $06AAC7 |
@@ -5321,7 +5321,7 @@ CODE_06AAE7:
 
 ; milde sub
   LDX $12                                   ; $06AB08 |
-  JSL $03AF23                               ; $06AB0A |
+  JSL CODE_03AF23                           ; $06AB0A |
   LDA $1015                                 ; $06AB0E |
   BPL CODE_06AB19                           ; $06AB11 |
   INC $105C                                 ; $06AB13 |
@@ -5343,7 +5343,7 @@ CODE_06AB2A:
 
 ; milde sub
   LDX $12                                   ; $06AB2B |
-  JSL $03AF23                               ; $06AB2D |
+  JSL CODE_03AF23                           ; $06AB2D |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $06AB31 |
   BNE CODE_06AB63                           ; $06AB33 |
   LDA $1013                                 ; $06AB35 |
@@ -5472,7 +5472,7 @@ CODE_06ABB1:
   JSR CODE_06B223                           ; $06AC5C |
 
 CODE_06AC5F:
-  JSL $03AF23                               ; $06AC5F |
+  JSL CODE_03AF23                           ; $06AC5F |
   LDY !s_spr_wildcard_6_hi_dp,x             ; $06AC63 |
   TYX                                       ; $06AC65 |
   JMP ($AC69,x)                             ; $06AC66 |
@@ -5586,7 +5586,7 @@ CODE_06AD11:
   JSR CODE_06B0FD                           ; $06AD22 |
 
 CODE_06AD25:
-  JSL $03AF23                               ; $06AD25 |
+  JSL CODE_03AF23                           ; $06AD25 |
   JSR CODE_06AFA7                           ; $06AD29 |
   LDY !s_spr_gsu_morph_1_lo,x               ; $06AD2C |
   TYX                                       ; $06AD2F |
@@ -6290,7 +6290,7 @@ CODE_06B2DC:
   STA $105E                                 ; $06B329 |
   LDA $601C                                 ; $06B32C |
   STA $1060                                 ; $06B32F |
-  JSL $00BE39                               ; $06B332 |
+  JSL CODE_00BE39                           ; $06B332 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06B336 |
@@ -6691,7 +6691,7 @@ main_12E:
   SEC                                       ; $06B95D |
   SBC !s_spr_cam_y_pos,x                    ; $06B95E |
   STA !r_bg3_cam_y                          ; $06B961 |
-  JSL $03AF23                               ; $06B964 |
+  JSL CODE_03AF23                           ; $06B964 |
   LDA !r_reg_tm_mirror                      ; $06B968 |
   ORA !r_reg_ts_mirror                      ; $06B96B |
   AND #$001B                                ; $06B96E |
@@ -6800,7 +6800,7 @@ main_cloud_drop_vertical:
   JSL $06BB4D                               ; $06BA4C |
 
 CODE_06BA50:
-  JSL $03AF23                               ; $06BA50 |
+  JSL CODE_03AF23                           ; $06BA50 |
   JSL $06BAF3                               ; $06BA54 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $06BA58 |
   BNE CODE_06BAAE                           ; $06BA5A |
@@ -6993,7 +6993,7 @@ main_cloud_drop_horizontal:
   JSL $06BCA9                               ; $06BBEC |
 
 CODE_06BBF0:
-  JSL $03AF23                               ; $06BBF0 |
+  JSL CODE_03AF23                           ; $06BBF0 |
   JSL $06BAF3                               ; $06BBF4 |
   STZ !s_spr_facing_dir,x                   ; $06BBF8 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $06BBFB |
@@ -7552,7 +7552,7 @@ CODE_06C05F:
 CODE_06C065:
   PLA                                       ; $06C065 |
   STA $00                                   ; $06C066 |
-  JSL $03AF23                               ; $06C068 |
+  JSL CODE_03AF23                           ; $06C068 |
   LDA $00                                   ; $06C06C |
   PHA                                       ; $06C06E |
   RTS                                       ; $06C06F |
@@ -8767,7 +8767,7 @@ CODE_06CA38:
   CMP #$000A                                ; $06CA3E |
   BNE CODE_06CA4A                           ; $06CA41 |
   JSR CODE_06C9E1                           ; $06CA43 |
-  JSL $03AF23                               ; $06CA46 |
+  JSL CODE_03AF23                           ; $06CA46 |
 
 CODE_06CA4A:
   JSR CODE_06CCF8                           ; $06CA4A |
@@ -9697,7 +9697,7 @@ main_dangling_ghost:
   JSR CODE_06D307                           ; $06D1CF |
   JSR CODE_06D484                           ; $06D1D2 |
   JSR CODE_06D4FB                           ; $06D1D5 |
-  JSL $03AF23                               ; $06D1D8 |
+  JSL CODE_03AF23                           ; $06D1D8 |
   LDA !s_spr_cam_x_pos,x                    ; $06D1DC |
   CLC                                       ; $06D1DF |
   ADC #$0090                                ; $06D1E0 |
@@ -10055,7 +10055,7 @@ CODE_06D4AC:
   LDX #$08                                  ; $06D4C6 |
   LDA #$E64B                                ; $06D4C8 |
   JSL r_gsu_init_1                          ; $06D4CB |
-  JSL $00BE39                               ; $06D4CF |
+  JSL CODE_00BE39                           ; $06D4CF |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06D4D3 |
@@ -10738,7 +10738,7 @@ main_caged_ghost_sewer:
   JSR CODE_06DA01                           ; $06D9CD |
   JSR CODE_06DBA5                           ; $06D9D0 |
   JSR CODE_06DC4D                           ; $06D9D3 |
-  JSL $03AF23                               ; $06D9D6 |
+  JSL CODE_03AF23                           ; $06D9D6 |
   LDA !s_spr_cam_x_pos,x                    ; $06D9DA |
   CLC                                       ; $06D9DD |
   ADC #$0200                                ; $06D9DE |
@@ -10900,7 +10900,7 @@ CODE_06DBCE:
   LDX #$08                                  ; $06DBFE |
   LDA #$E8CA                                ; $06DC00 |
   JSL r_gsu_init_1                          ; $06DC03 |
-  JSL $00BE39                               ; $06DC07 |
+  JSL CODE_00BE39                           ; $06DC07 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06DC0B |
@@ -11455,7 +11455,7 @@ main_caged_ghost_round:
   JSR CODE_06E0A5                           ; $06E057 |
   LDA $0E                                   ; $06E05A |
   STA !s_spr_wildcard_2_lo,x                ; $06E05C |
-  JSL $03AF23                               ; $06E05F |
+  JSL CODE_03AF23                           ; $06E05F |
   LDA !s_spr_wildcard_2_lo,x                ; $06E063 |
   STA $0E                                   ; $06E066 |
   LDA !s_spr_cam_x_pos,x                    ; $06E068 |
@@ -12062,7 +12062,7 @@ CODE_06E48B:
   LDX #$08                                  ; $06E4E2 |
   LDA #$E8CA                                ; $06E4E4 |
   JSL r_gsu_init_1                          ; $06E4E7 |
-  JSL $00BE39                               ; $06E4EB | continues 8 bytes later
+  JSL CODE_00BE39                           ; $06E4EB | continues 8 bytes later
 
 ; DMA args
   db $40, $50, $7E, $72                     ; $06E4EF |
@@ -12109,7 +12109,7 @@ main_platform_ghost:
   JSR CODE_06E85A                           ; $06E541 |
   LDA $0E                                   ; $06E544 |
   STA !s_spr_wildcard_2_lo,x                ; $06E546 |
-  JSL $03AF23                               ; $06E549 |
+  JSL CODE_03AF23                           ; $06E549 |
   LDA !s_spr_wildcard_2_lo,x                ; $06E54D |
   STA $0E                                   ; $06E550 |
   LDA !s_spr_wildcard_1_lo,x                ; $06E552 |
@@ -12188,7 +12188,7 @@ CODE_06E58E:
   LDX #$08                                  ; $06E5EE |\
   LDA #$E93B                                ; $06E5F0 | | gsu
   JSL r_gsu_init_1                          ; $06E5F3 |/
-  JSL $00BE39                               ; $06E5F7 |
+  JSL CODE_00BE39                           ; $06E5F7 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06E5FB |
@@ -12662,7 +12662,7 @@ main_soft_thing:
   AND !s_spr_wildcard_4_lo_dp,x             ; $06E964 |
   STA !s_spr_wildcard_4_lo_dp,x             ; $06E966 |
   JSR CODE_06EA0A                           ; $06E968 |
-  JSL $03AF23                               ; $06E96B |
+  JSL CODE_03AF23                           ; $06E96B |
   LDA !s_spr_cam_x_pos,x                    ; $06E96F |
   CLC                                       ; $06E972 |
   ADC #$0078                                ; $06E973 |
@@ -12849,7 +12849,7 @@ CODE_06EA21:
   LDX #$08                                  ; $06EB06 |
   LDA #$E9E2                                ; $06EB08 |
   JSL r_gsu_init_1                          ; $06EB0B |
-  JSL $00BE39                               ; $06EB0F |
+  JSL CODE_00BE39                           ; $06EB0F |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06EB13 |
@@ -13644,7 +13644,7 @@ main_platform_ghost_sewer:
   JSR CODE_06F1A4                           ; $06F0CA |
   JSR CODE_06F1C6                           ; $06F0CD |
   JSR CODE_06F23F                           ; $06F0D0 |
-  JSL $03AF23                               ; $06F0D3 |
+  JSL CODE_03AF23                           ; $06F0D3 |
   LDA $0E                                   ; $06F0D7 |
   BMI .CODE_06F0E1                          ; $06F0D9 |
   JSL despawn_sprite_stage_ID               ; $06F0DB |
@@ -13718,7 +13718,7 @@ CODE_06F0EF:
   LDX #$08                                  ; $06F16A |
   LDA #$E800                                ; $06F16C |
   JSL r_gsu_init_1                          ; $06F16F |
-  JSL $00BE39                               ; $06F173 |
+  JSL CODE_00BE39                           ; $06F173 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $06F177 |

--- a/disassembly/bank07.asm
+++ b/disassembly/bank07.asm
@@ -14,7 +14,7 @@ init_bubble_plant:
   db $00, $02, $01, $02, $05, $03, $05, $04 ; $078018 |
 
 main_bubble_plant:
-  JSL $03AF23                               ; $078020 |
+  JSL CODE_03AF23                           ; $078020 |
   JSR CODE_078425                           ; $078024 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $078027 |
   BNE CODE_078055                           ; $078029 |
@@ -93,7 +93,7 @@ CODE_0780C0:
 
 ; also needlenose plant
 init_egg_plant:
-  JSL $02A007                               ; $0780C3 |
+  JSL CODE_02A007                           ; $0780C3 |
   SEP #$20                                  ; $0780C7 |
   LDA !s_spr_x_pixel_pos,x                  ; $0780C9 |
   AND #$10                                  ; $0780CC |
@@ -117,7 +117,7 @@ init_egg_plant:
 
 ; also needlenose plant
 main_egg_plant:
-  JSL $03AF23                               ; $0780F3 |
+  JSL CODE_03AF23                           ; $0780F3 |
   JSR CODE_078425                           ; $0780F7 |
   LDA !s_player_disable_flag                ; $0780FA |
   ORA !s_player_state                       ; $0780FD |
@@ -665,7 +665,7 @@ main_stilt_guy:
   JSR CODE_07874D                           ; $0785A5 |
 
 CODE_0785A8:
-  JSL $03AF23                               ; $0785A8 |
+  JSL CODE_03AF23                           ; $0785A8 |
   LDY !s_spr_collision_id,x                 ; $0785AC |
   BPL CODE_07860A                           ; $0785AF |
   LDA !s_player_ground_pound_state          ; $0785B1 |
@@ -1039,6 +1039,7 @@ CODE_0788B3:
 
   dw $FF00, $0100                           ; $0788CF |
 
+main_slugger:
   LDA !s_spr_oam_yxppccct,x                 ; $0788D3 |
   AND #$FFF1                                ; $0788D6 |
   LDY !s_spr_collision_state,x              ; $0788D9 |
@@ -1047,7 +1048,7 @@ CODE_0788B3:
 
 CODE_0788E1:
   STA !s_spr_oam_yxppccct,x                 ; $0788E1 |
-  JSL $03AF23                               ; $0788E4 |
+  JSL CODE_03AF23                           ; $0788E4 |
   LDA !s_spr_wildcard_1_lo,x                ; $0788E8 |
   BEQ CODE_0788F0                           ; $0788EB |
   JMP CODE_078EC3                           ; $0788ED |
@@ -2012,13 +2013,13 @@ CODE_0790A9:
   STZ !s_tongued_sprite_slot                ; $0790C1 |
   PLA                                       ; $0790C4 |
   PLY                                       ; $0790C5 |
-  JSL $03AF23                               ; $0790C6 |
+  JSL CODE_03AF23                           ; $0790C6 |
   JSR CODE_079377                           ; $0790CA |
   LDY #$02                                  ; $0790CD |
   BRA CODE_0790E1                           ; $0790CF |
 
 CODE_0790D1:
-  JSL $03AF23                               ; $0790D1 |
+  JSL CODE_03AF23                           ; $0790D1 |
   JSL $03A5B7                               ; $0790D5 |
   JSR CODE_079279                           ; $0790D9 |
   BPL CODE_0790E1                           ; $0790DC |
@@ -2383,7 +2384,7 @@ init_snifit:
   RTL                                       ; $07940F |
 
 main_snifit:
-  JSL $03AF23                               ; $079410 |
+  JSL CODE_03AF23                           ; $079410 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $079414 |
   TAX                                       ; $079416 |
   JSR ($941F,x)                             ; $079417 |
@@ -2568,7 +2569,7 @@ init_snifit_bullet:
   RTL                                       ; $07959A |
 
 main_snifit_bullet:
-  JSL $03AF23                               ; $07959B |
+  JSL CODE_03AF23                           ; $07959B |
   LDY !s_spr_collision_id,x                 ; $07959F |
   BPL CODE_0795A8                           ; $0795A2 |
   JSL player_hit_sprite                     ; $0795A4 |
@@ -2620,7 +2621,7 @@ CODE_079631:
   RTL                                       ; $079634 |
 
 main_poochy:
-  JSL $03AF23                               ; $079635 |
+  JSL CODE_03AF23                           ; $079635 |
   JSL $03A5B7                               ; $079639 |
   LDA !s_spr_y_pixel_pos,x                  ; $07963D |
   CMP #$0800                                ; $079640 |
@@ -3842,7 +3843,7 @@ CODE_079FE9:
   STA !s_spr_wildcard_5_lo_dp,x             ; $07A020 |
 
 CODE_07A022:
-  JSL $03AF23                               ; $07A022 |
+  JSL CODE_03AF23                           ; $07A022 |
   LDA !s_spr_oam_1,x                        ; $07A026 |
   AND #$000C                                ; $07A029 |
   BNE CODE_07A040                           ; $07A02C |
@@ -4694,7 +4695,7 @@ CODE_07A751:
   JSR CODE_07A9C6                           ; $07A751 |
 
 CODE_07A754:
-  JSL $03AF23                               ; $07A754 |
+  JSL CODE_03AF23                           ; $07A754 |
   JSR CODE_07AA37                           ; $07A758 |
   LDA !s_spr_x_player_dir,x                 ; $07A75B |
   STA !s_spr_facing_dir,x                   ; $07A75E |
@@ -5119,6 +5120,7 @@ CODE_07AAE3:
 
   dw $FFC0, $0140                           ; $07AAE8 |
 
+head_bop_lakitu:
   LDA !s_spr_cam_y_pos,x                    ; $07AAEC |
   AND #$FF00                                ; $07AAEF |
   BEQ CODE_07AB48                           ; $07AAF2 |
@@ -5196,7 +5198,7 @@ init_lava_drop_horizontal:
   dw $0008, $FFF8                           ; $07AB98 |
 
 main_lava_drop_horizontal:
-  JSL $03AF23                               ; $07AB9C |
+  JSL CODE_03AF23                           ; $07AB9C |
   LDA !s_spr_x_speed_lo,x                   ; $07ABA0 |
   BEQ CODE_07AC1C                           ; $07ABA3 |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $07ABA5 |
@@ -5336,7 +5338,7 @@ init_lava_drop_vertical:
   dw $ACC2                                  ; $07ACD0 |
 
 main_lava_drop_vertical:
-  JSL $03AF23                               ; $07ACD2 |
+  JSL CODE_03AF23                           ; $07ACD2 |
   LDA !s_spr_y_speed_lo,x                   ; $07ACD6 |
   BNE CODE_07ACDE                           ; $07ACD9 |
   JMP CODE_07AD75                           ; $07ACDB |
@@ -5528,7 +5530,7 @@ CODE_07AE0C:
 
 ; red and green
 main_fat_guy:
-  JSL $03AF23                               ; $07AE68 |
+  JSL CODE_03AF23                           ; $07AE68 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07AE6C |
   TAX                                       ; $07AE6E |
   JMP ($AE72,x)                             ; $07AE6F |
@@ -5769,7 +5771,7 @@ init_fang_dangling:
 
 main_fang_dangling:
   JSR CODE_07B253                           ; $07B059 |
-  JSL $03AF23                               ; $07B05C |
+  JSL CODE_03AF23                           ; $07B05C |
   LDY !s_spr_gsu_morph_2_lo,x               ; $07B060 |
   BEQ CODE_07B068                           ; $07B063 |
   JMP CODE_07B24F                           ; $07B065 |
@@ -5951,6 +5953,7 @@ CODE_07B1A5:
 
   dw $FF80, $0080                           ; $07B1B2 |
 
+init_fang_flying:
   LDA !s_spr_x_pixel_pos,x                  ; $07B1B6 |
   AND #$0010                                ; $07B1B9 |
   LSR A                                     ; $07B1BC |
@@ -5994,7 +5997,7 @@ main_fang_flying_wavily:
 
 CODE_07B20F:
   JSR CODE_07B253                           ; $07B20F |
-  JSL $03AF23                               ; $07B212 |
+  JSL CODE_03AF23                           ; $07B212 |
   JSL $07FC64                               ; $07B216 |
   BCC CODE_07B22B                           ; $07B21A |
   LDA !s_spr_gsu_morph_1_lo,x               ; $07B21C |
@@ -6113,7 +6116,7 @@ main_flopsy_fish:
   STA !s_spr_anim_frame,x                   ; $07B2FE |
 
 CODE_07B301:
-  JSL $03AF23                               ; $07B301 |
+  JSL CODE_03AF23                           ; $07B301 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07B305 |
   TAX                                       ; $07B307 |
   JSR ($B330,x)                             ; $07B308 |
@@ -6128,7 +6131,7 @@ main_flopsy_fish_jumping:
   STA !s_spr_anim_frame,x                   ; $07B31B |
 
 CODE_07B31E:
-  JSL $03AF23                               ; $07B31E |
+  JSL CODE_03AF23                           ; $07B31E |
   JSR CODE_07B33E                           ; $07B322 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07B325 |
   TAX                                       ; $07B327 |
@@ -6615,7 +6618,7 @@ main_sluggy:
   STA !s_spr_bitwise_settings_3,x           ; $07B701 |
 
 CODE_07B704:
-  JSL $03AF23                               ; $07B704 |
+  JSL CODE_03AF23                           ; $07B704 |
   JSL $07B853                               ; $07B708 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07B70C |
   TAX                                       ; $07B70E |
@@ -6818,6 +6821,7 @@ CODE_07B8B2:
 
   dw $0021, $0023, $0025                    ; $07B8B3 |
 
+head_bop_sluggy:
   LDA !s_spr_wildcard_6_lo,x                ; $07B8B9 |
   BNE CODE_07B938                           ; $07B8BC |
   LDA !s_spr_gsu_morph_2_lo,x               ; $07B8BE |
@@ -6995,13 +6999,13 @@ init_arrow_cloud_rotating:
 
 ; all except rotating
 main_arrow_cloud:
-  JSL $03AF23                               ; $07BA31 |
+  JSL CODE_03AF23                           ; $07BA31 |
   JSL $07BA78                               ; $07BA35 |
   JSR CODE_07BA62                           ; $07BA39 |
   RTL                                       ; $07BA3C |
 
 main_arrow_cloud_rotating:
-  JSL $03AF23                               ; $07BA3D |
+  JSL CODE_03AF23                           ; $07BA3D |
   LDA !s_spr_anim_frame,x                   ; $07BA41 |
   STA !reg_wrdivl                           ; $07BA44 |
   LDY #$03                                  ; $07BA47 |
@@ -7146,7 +7150,7 @@ main_flutter:
   STA !s_spr_bitwise_settings_1,x           ; $07BB6F |
 
 CODE_07BB72:
-  JSL $03AF23                               ; $07BB72 |
+  JSL CODE_03AF23                           ; $07BB72 |
   JSL $07BE69                               ; $07BB76 |
   JSL $07E336                               ; $07BB7A |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07BB7E |
@@ -7554,7 +7558,7 @@ main_spray_fish:
   LDX $12                                   ; $07BF21 |
 
 CODE_07BF23:
-  JSL $03AF23                               ; $07BF23 |
+  JSL CODE_03AF23                           ; $07BF23 |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $07BF27 |
   TAX                                       ; $07BF29 |
   JMP ($BF2D,x)                             ; $07BF2A |
@@ -8096,7 +8100,7 @@ CODE_07C373:
   SEP #$10                                  ; $07C39B |
 
 CODE_07C39D:
-  JSL $03AF23                               ; $07C39D |
+  JSL CODE_03AF23                           ; $07C39D |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07C3A1 |
   TAX                                       ; $07C3A3 |
   JMP ($C3A7,x)                             ; $07C3A4 |
@@ -8444,6 +8448,7 @@ CODE_07C632:
 CODE_07C688:
   RTS                                       ; $07C688 |
 
+head_bop_wall_lakitu:
   LDA !s_spr_wildcard_6_lo,x                ; $07C689 |
   BEQ CODE_07C6A1                           ; $07C68C |
   LDA #$0040                                ; $07C68E |
@@ -8491,7 +8496,7 @@ init_grunt_running:
   RTL                                       ; $07C6EB |
 
 main_grunt_walking:
-  JSL $03AF23                               ; $07C6EC |
+  JSL CODE_03AF23                           ; $07C6EC |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07C6F0 |
   TAX                                       ; $07C6F2 |
   JMP ($C6F6,x)                             ; $07C6F3 |
@@ -8503,7 +8508,7 @@ main_grunt_walking:
   dw $C83A                                  ; $07C6FE |
 
 main_grunt_running:
-  JSL $03AF23                               ; $07C700 |
+  JSL CODE_03AF23                           ; $07C700 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07C704 |
   TAX                                       ; $07C706 |
   JMP ($C70A,x)                             ; $07C707 |
@@ -8855,7 +8860,7 @@ CODE_07C9BE:
   RTL                                       ; $07C9C7 |
 
 main_spear_guy_dancing:
-  JSL $03AF23                               ; $07C9C8 |
+  JSL CODE_03AF23                           ; $07C9C8 |
   INC $0C66                                 ; $07C9CC |
   JSR CODE_07CE47                           ; $07C9CF |
   LDA $0CD8                                 ; $07C9D2 |
@@ -9469,7 +9474,7 @@ CODE_07CEE6:
   PLA                                       ; $07CEF3 |
 
 CODE_07CEF4:
-  JSL $03AF23                               ; $07CEF4 |
+  JSL CODE_03AF23                           ; $07CEF4 |
   LDA !s_spr_x_accel,x                      ; $07CEF8 |
   BEQ CODE_07CF00                           ; $07CEFB |
   JMP CODE_07D80C                           ; $07CEFD |
@@ -10084,7 +10089,7 @@ CODE_07D446:
   LDA !s_spr_y_pixel_pos,x                  ; $07D47C |
   STA !s_spr_y_pixel_pos,y                  ; $07D47F |
   TYX                                       ; $07D482 |
-  JSL $07D8D4                               ; $07D483 |
+  JSL init_zeus_guy_energy                  ; $07D483 |
 
 CODE_07D487:
   LDX $12                                   ; $07D487 |
@@ -10649,7 +10654,7 @@ init_zeus_guy_energy:
   RTL                                       ; $07D8F2 |
 
 main_zeus_guy_energy:
-  JSL $03AF23                               ; $07D8F3 |
+  JSL CODE_03AF23                           ; $07D8F3 |
   LDA !s_spr_timer_1,x                      ; $07D8F7 |
   BNE CODE_07D91E                           ; $07D8FA |
   DEC !s_spr_wildcard_4_lo_dp,x             ; $07D8FC |
@@ -10716,7 +10721,7 @@ CODE_07D971:
   BNE CODE_07D980                           ; $07D974 |
 
 CODE_07D976:
-  JSL $03AF23                               ; $07D976 |
+  JSL CODE_03AF23                           ; $07D976 |
   JSL $07E336                               ; $07D97A |
   BRA CODE_07D994                           ; $07D97E |
 
@@ -11269,7 +11274,7 @@ main_beach_koopa:
   LDA #$949D                                ; $07DDA3 |
   JSL r_gsu_init_1                          ; $07DDA6 | GSU init
   LDX $12                                   ; $07DDAA |
-  JSL $03AF23                               ; $07DDAC |
+  JSL CODE_03AF23                           ; $07DDAC |
   LDA $7860,x                               ; $07DDB0 |
   BIT #$0001                                ; $07DDB3 |
   BNE CODE_07DDC6                           ; $07DDB6 |
@@ -11303,7 +11308,7 @@ CODE_07DDE4:
   LDA #$949D                                ; $07DDE6 |
   JSL r_gsu_init_1                          ; $07DDE9 | GSU init
   LDX $12                                   ; $07DDED |
-  JSL $03AF23                               ; $07DDEF |
+  JSL CODE_03AF23                           ; $07DDEF |
   JSL $07E35B                               ; $07DDF3 |
   JSL $03A5B7                               ; $07DDF7 |
   JSL $07E2A1                               ; $07DDFB |
@@ -12012,6 +12017,8 @@ CODE_07E3AC:
   ORA #$0800                                ; $07E3B5 |
   STA !s_spr_oam_1,x                        ; $07E3B8 |
   BRA CODE_07E3C8                           ; $07E3BB |
+
+CODE_07E3BD:
   LDX #$08                                  ; $07E3BD |
   LDA #$949D                                ; $07E3BF |
   JSL r_gsu_init_1                          ; $07E3C2 | GSU init
@@ -12028,6 +12035,7 @@ CODE_07E3C8:
 
   dw $0400, $FC00                           ; $07E3DB |
 
+CODE_07E3DF:
   LDA !s_spr_wildcard_1_lo,x                ; $07E3DF |
   BNE CODE_07E399                           ; $07E3E2 |
   LDX #$08                                  ; $07E3E4 |
@@ -12038,6 +12046,8 @@ CODE_07E3C8:
   STA $00                                   ; $07E3F2 |
   LDA #$0169                                ; $07E3F4 |
   BRA CODE_07E411                           ; $07E3F7 |
+
+CODE_07E3F9:
   LDA !s_spr_wildcard_1_lo,x                ; $07E3F9 |
   BNE CODE_07E399                           ; $07E3FC |
   LDX #$08                                  ; $07E3FE |
@@ -12196,7 +12206,7 @@ CODE_07E56A:
   LDA #$949D                                ; $07E56C |
   JSL r_gsu_init_1                          ; $07E56F | GSU init
   LDX $12                                   ; $07E573 |
-  JSL $03AF23                               ; $07E575 |
+  JSL CODE_03AF23                           ; $07E575 |
   JSL $07E35B                               ; $07E579 |
   JSL $03A5B7                               ; $07E57D |
   JSL $07E6B7                               ; $07E581 |
@@ -12260,7 +12270,7 @@ CODE_07E5E9:
   LDA #$949D                                ; $07E5EB |
   JSL r_gsu_init_1                          ; $07E5EE | GSU init
   LDX $12                                   ; $07E5F2 |
-  JSL $03AF23                               ; $07E5F4 |
+  JSL CODE_03AF23                           ; $07E5F4 |
   JSL $07E35B                               ; $07E5F8 |
   JSL $03A5B7                               ; $07E5FC |
   JSL $07E6B7                               ; $07E600 |
@@ -12320,7 +12330,7 @@ CODE_07E65F:
   LDA #$949D                                ; $07E661 |
   JSL r_gsu_init_1                          ; $07E664 | GSU init
   LDX $12                                   ; $07E668 |
-  JSL $03AF23                               ; $07E66A |
+  JSL CODE_03AF23                           ; $07E66A |
   JSL $07E35B                               ; $07E66E |
   JSL $03A5B7                               ; $07E672 |
   JSL $07E6B7                               ; $07E676 |
@@ -12423,6 +12433,7 @@ CODE_07E6E9:
 CODE_07E72F:
   RTS                                       ; $07E72F |
 
+CODE_07E730:
   LDA !s_spr_timer_4,x                      ; $07E730 |
   BNE CODE_07E740                           ; $07E733 |
   STZ $00                                   ; $07E735 |
@@ -12438,6 +12449,8 @@ CODE_07E740:
 CODE_07E748:
   LDA #$016B                                ; $07E748 |
   BRA CODE_07E768                           ; $07E74B |
+
+CODE_07E74D:
   LDA !s_spr_timer_4,x                      ; $07E74D |
   BNE CODE_07E75D                           ; $07E750 |
   STZ $00                                   ; $07E752 |
@@ -12531,7 +12544,7 @@ CODE_07E7E9:
   SEP #$10                                  ; $07E811 |
 
 CODE_07E813:
-  JSL $03AF23                               ; $07E813 |
+  JSL CODE_03AF23                           ; $07E813 |
   JSR CODE_07EADE                           ; $07E817 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $07E81A |
   TYX                                       ; $07E81C |
@@ -12892,6 +12905,7 @@ CODE_07EB1D:
 CODE_07EB44:
   RTS                                       ; $07EB44 |
 
+CODE_07EB45:
   LDA #$0012                                ; $07EB45 |
   STA !s_spr_anim_frame,x                   ; $07EB48 |
   RTL                                       ; $07EB4B |
@@ -12914,7 +12928,7 @@ init_thunder_lakitu:
   LDY !r_cam_moving_dir_x                   ; $07EB71 |
   LDA !r_bg1_cam_x                          ; $07EB74 |
   CLC                                       ; $07EB77 |
-  ADC $F0C3,y                               ; $07EB78 |
+  ADC DATA_07F0C3,y                         ; $07EB78 |
   STA $00                                   ; $07EB7B |
   LDA #$0166                                ; $07EB7D |
   JSL spawn_sprite_active                   ; $07EB80 |
@@ -12988,7 +13002,7 @@ CODE_07EC0F:
   PLY                                       ; $07EC13 |
 
 CODE_07EC14:
-  JSL $03AF23                               ; $07EC14 |
+  JSL CODE_03AF23                           ; $07EC14 |
   JSL $07EF98                               ; $07EC18 |
   LDA !s_spr_x_player_dir,x                 ; $07EC1C |
   AND #$00FF                                ; $07EC1F |
@@ -13498,14 +13512,17 @@ CODE_07F027:
 CODE_07F03D:
   RTS                                       ; $07F03D |
 
+head_bop_thunder_lakitu:
   LDA !s_spr_gsu_morph_1_lo,x               ; $07F03E |
   TAX                                       ; $07F041 |
-  JMP ($F045,x)                             ; $07F042 |
+  JMP (DATA_07F045,x)                       ; $07F042 |
 
-  dw $F04B                                  ; $07F045 |
-  dw $F08D                                  ; $07F047 |
-  dw $F0C7                                  ; $07F049 |
+DATA_07F045:
+  dw CODE_07F04B                            ; $07F045 |
+  dw CODE_07F08D                            ; $07F047 |
+  dw CODE_07F0C7                            ; $07F049 |
 
+CODE_07F04B:
   LDX $12                                   ; $07F04B |
   LDA #$011C                                ; $07F04D |
   JSL spawn_sprite_init                     ; $07F050 |
@@ -13534,6 +13551,7 @@ CODE_07F06B:
   INC !s_spr_gsu_morph_1_lo,x               ; $07F089 |
   RTL                                       ; $07F08C |
 
+CODE_07F08D:
   LDX $12                                   ; $07F08D |
   LDA !s_spr_cam_x_pos,x                    ; $07F08F |
   CLC                                       ; $07F092 |
@@ -13560,15 +13578,17 @@ CODE_07F0A7:
 CODE_07F0C2:
   RTL                                       ; $07F0C2 |
 
+DATA_07F0C3:
   dw $FFD0, $0110                           ; $07F0C3 |
 
+CODE_07F0C7:
   LDX $12                                   ; $07F0C7 |
   LDA !s_spr_timer_1,x                      ; $07F0C9 |
   BNE CODE_07F10B                           ; $07F0CC |
   LDY !r_cam_moving_dir_x                   ; $07F0CE |
   LDA !r_bg1_cam_x                          ; $07F0D1 |
   CLC                                       ; $07F0D4 |
-  ADC $F0C3,y                               ; $07F0D5 |
+  ADC DATA_07F0C3,y                         ; $07F0D5 |
   STA !s_spr_x_pixel_pos,x                  ; $07F0D8 |
   LDA !r_bg1_cam_y                          ; $07F0DB |
   SEC                                       ; $07F0DE |
@@ -13597,16 +13617,16 @@ CODE_07F10B:
 
   dw $FF80, $0080                           ; $07F114 |
 
-init_baron_von_zeppelin_5_coins:
+init_bvz_5_coins:
   LDA #$000E                                ; $07F118 |
   BRA CODE_07F12B                           ; $07F11B |
 
-init_baron_von_zeppelin_key:
+init_bvz_key:
   JSR CODE_07F28B                           ; $07F11D |
   LDA #$000C                                ; $07F120 |
   BRA CODE_07F12B                           ; $07F123 |
 
-init_baron_von_zeppelin_1_up:
+init_bvz_1_up:
   JSR CODE_07F28B                           ; $07F125 |
   LDA #$000A                                ; $07F128 |
 
@@ -13618,7 +13638,7 @@ CODE_07F12B:
   STZ !s_spr_facing_dir,x                   ; $07F134 |
   BRA CODE_07F1AA                           ; $07F137 |
 
-init_baron_von_zeppelin_large_spring_ball:
+init_bvz_large_spring_ball:
   JSL $03AE60                               ; $07F139 |
   LDA #$0100                                ; $07F13D |
   STA !gsu_r6                               ; $07F140 |
@@ -13643,31 +13663,31 @@ init_baron_von_zeppelin_large_spring_ball:
   LDA #$0008                                ; $07F178 |
   BRA CODE_07F19E                           ; $07F17B |
 
-init_baron_von_zeppelin_icy_watermelon:
+init_bvz_icy_watermelon:
   LDA #$0014                                ; $07F17D |
   BRA CODE_07F19E                           ; $07F180 |
 
-init_baron_von_zeppelin_fire_watermelon:
+init_bvz_fire_watermelon:
   LDA #$0012                                ; $07F182 |
   BRA CODE_07F19E                           ; $07F185 |
 
-init_baron_von_zeppelin_watermelon:
+init_bvz_watermelon:
   LDA #$0010                                ; $07F187 |
   BRA CODE_07F19E                           ; $07F18A |
 
-init_baron_von_zeppelin_bandit:
+init_bvz_bandit:
   LDA #$0006                                ; $07F18C |
   BRA CODE_07F19E                           ; $07F18F |
 
-init_baron_von_zeppelin_bomb:
+init_bvz_bomb:
   LDA #$0004                                ; $07F191 |
   BRA CODE_07F19E                           ; $07F194 |
 
-init_baron_von_zeppelin_needlenose:
+init_bvz_needlenose:
   LDA #$0002                                ; $07F196 |
   BRA CODE_07F19E                           ; $07F199 |
 
-init_baron_von_zeppelin_red_shy_guy:
+init_bvz_red_shy_guy:
   LDA #$0000                                ; $07F19B |
 
 CODE_07F19E:
@@ -13693,7 +13713,7 @@ CODE_07F1AA:
   STA !s_spr_y_accel,x                      ; $07F1C7 |
   RTL                                       ; $07F1CA |
 
-init_baron_von_zeppelin_giant_egg:
+init_bvz_giant_egg:
   LDA #$0018                                ; $07F1CB |
   STA !s_spr_gsu_morph_1_lo,x               ; $07F1CE |
   LDA #$FFFF                                ; $07F1D1 |
@@ -13715,7 +13735,7 @@ init_baron_von_zeppelin_giant_egg:
   STA !s_spr_y_accel,x                      ; $07F1F7 |
   RTL                                       ; $07F1FA |
 
-init_baron_von_zeppelin_crate_with_6_stars:
+init_bvz_crate_with_6_stars:
   JSL $03AE60                               ; $07F1FB |
   LDA #$0100                                ; $07F1FF |
   STA !gsu_r6                               ; $07F202 |
@@ -13804,55 +13824,54 @@ CODE_07F296:
   RTS                                       ; $07F2B1 |
 
 ; bandit, bomb, needlenose, and red shy guy
-main_baron_von_zeppelin_enemies:
+main_bvz_enemies:
   STZ !gsu_r4                               ; $07F2B2 |
   LDX #$08                                  ; $07F2B5 |
   LDA #$95B9                                ; $07F2B7 |
   JSL r_gsu_init_1                          ; $07F2BA | GSU init
   LDX $12                                   ; $07F2BE |
   JSR CODE_07F9C9                           ; $07F2C0 |
-  JSL $03AF23                               ; $07F2C3 |
+  JSL CODE_03AF23                           ; $07F2C3 |
   JSR CODE_07F412                           ; $07F2C7 |
   JSR CODE_07F746                           ; $07F2CA |
   JSR CODE_07F3DB                           ; $07F2CD |
   RTL                                       ; $07F2D0 |
 
-;
-main_baron_von_zeppelin_large_spring_ball:
-  JSL $03AA52                               ; $07F2D1 |
+main_bvz_large_spring_ball:
+  JSL CODE_03AA52                           ; $07F2D1 |
   STZ !gsu_r4                               ; $07F2D5 |
   LDX #$08                                  ; $07F2D8 |
   LDA #$95B9                                ; $07F2DA |
   JSL r_gsu_init_1                          ; $07F2DD | GSU init
   LDX $12                                   ; $07F2E1 |
-  JSL $03AF23                               ; $07F2E3 |
+  JSL CODE_03AF23                           ; $07F2E3 |
   JSR CODE_07F538                           ; $07F2E7 |
   JSR CODE_07F497                           ; $07F2EA |
   JSR CODE_07F3DB                           ; $07F2ED |
   RTL                                       ; $07F2F0 |
 
 ;regular and fire watermelons, and giant egg
-main_baron_von_zeppelin_melon_and_giant_egg:
+main_bvz_melon_and_giant_egg:
   STZ !gsu_r4                               ; $07F2F1 |
   LDX #$08                                  ; $07F2F4 |
   LDA #$95B9                                ; $07F2F6 |
   JSL r_gsu_init_1                          ; $07F2F9 | GSU init
   LDX $12                                   ; $07F2FD |
   JSR CODE_07F9C9                           ; $07F2FF |
-  JSL $03AF23                               ; $07F302 |
+  JSL CODE_03AF23                           ; $07F302 |
   JSR CODE_07F538                           ; $07F306 |
   JSR CODE_07F497                           ; $07F309 |
   JSR CODE_07F3DB                           ; $07F30C |
   RTL                                       ; $07F30F |
 
-main_baron_von_zeppelin_icy_watermelon:
+main_bvz_icy_watermelon:
   STZ !gsu_r4                               ; $07F310 |
   LDX #$08                                  ; $07F313 |
   LDA #$95B9                                ; $07F315 |
   JSL r_gsu_init_1                          ; $07F318 | GSU init
   LDX $12                                   ; $07F31C |
   JSR CODE_07F9C9                           ; $07F31E |
-  JSL $03AF23                               ; $07F321 |
+  JSL CODE_03AF23                           ; $07F321 |
   JSR CODE_07F538                           ; $07F325 |
   JSR CODE_07F497                           ; $07F328 |
   JSR CODE_07F3DB                           ; $07F32B |
@@ -13860,7 +13879,7 @@ main_baron_von_zeppelin_icy_watermelon:
   RTL                                       ; $07F332 |
 
 ; 5 coins, key, and 1-up
-main_baron_von_zeppelin_consumables:
+main_bvz_consumables:
   LDA !s_spr_wildcard_6_lo_dp,x             ; $07F333 |
   LSR A                                     ; $07F335 |
   LSR A                                     ; $07F336 |
@@ -13872,7 +13891,7 @@ main_baron_von_zeppelin_consumables:
   JSL r_gsu_init_1                          ; $07F341 | GSU init
   LDX $12                                   ; $07F345 |
   JSR CODE_07F9C9                           ; $07F347 |
-  JSL $03AF23                               ; $07F34A |
+  JSL CODE_03AF23                           ; $07F34A |
   LDA !s_spr_facing_dir,x                   ; $07F34E |
   BEQ CODE_07F35A                           ; $07F351 |
   LDA !s_spr_wildcard_6_lo_dp,x             ; $07F353 |
@@ -13910,8 +13929,8 @@ CODE_07F35A:
   dw $F384                                  ; $07F38D |
   dw $F378                                  ; $07F38F |
 
-main_baron_von_zeppelin_crate_with_6_stars:
-  JSL $03AA52                               ; $07F391 |
+main_bvz_crate_with_6_stars:
+  JSL CODE_03AA52                           ; $07F391 |
   LDA #$0007                                ; $07F395 |
   STA !gsu_r0                               ; $07F398 |
   LDA !s_spr_wildcard_5_hi_dp,x             ; $07F39B |
@@ -13930,7 +13949,7 @@ main_baron_von_zeppelin_crate_with_6_stars:
   LDA #$95F4                                ; $07F3B1 |
   JSL r_gsu_init_1                          ; $07F3B4 | GSU init
   LDX $12                                   ; $07F3B8 |
-  JSL $03AF23                               ; $07F3BA |
+  JSL CODE_03AF23                           ; $07F3BA |
   LDA !s_spr_facing_dir,x                   ; $07F3BE |
   BEQ CODE_07F3CA                           ; $07F3C1 |
   LDA !s_spr_wildcard_6_lo_dp,x             ; $07F3C3 |
@@ -14877,7 +14896,7 @@ CODE_07FB0A:
   JSL $03D3F3                               ; $07FB1F |
   RTS                                       ; $07FB23 |
 
-init_baron_von_zeppelin:
+init_bvz:
   LDA !s_spr_facing_dir,x                   ; $07FB24 |
   TAY                                       ; $07FB27 |
   LDA $F110,y                               ; $07FB28 |
@@ -14891,13 +14910,13 @@ init_baron_von_zeppelin:
   REP #$20                                  ; $07FB3A |
   RTL                                       ; $07FB3C |
 
-main_baron_von_zeppelin:
+main_bvz:
   STZ !gsu_r4                               ; $07FB3D |
   LDX #$08                                  ; $07FB40 |
   LDA #$95B9                                ; $07FB42 |
   JSL r_gsu_init_1                          ; $07FB45 | GSU init
   LDX $12                                   ; $07FB49 |
-  JSL $03AF23                               ; $07FB4B |
+  JSL CODE_03AF23                           ; $07FB4B |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $07FB4F |
   TAX                                       ; $07FB51 |
   JMP ($FB55,x)                             ; $07FB52 |
@@ -15253,7 +15272,7 @@ CODE_07FDE0:
   db $10, $10, $20                          ; $07FDE1 |
 
 main_cork:
-  JSL $03AF23                               ; $07FDE4 |
+  JSL CODE_03AF23                           ; $07FDE4 |
   JSL $03D127                               ; $07FDE8 |
   JSL $03D291                               ; $07FDEC |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $07FDF0 |
@@ -15325,7 +15344,7 @@ CODE_07FE73:
   CMP #$0027                                ; $07FE7F |
   BNE CODE_07FEE4                           ; $07FE82 |
   TYX                                       ; $07FE84 |
-  JSL $03BF87                               ; $07FE85 |
+  JSL CODE_03BF87                           ; $07FE85 |
   JSL despawn_sprite_stage_ID               ; $07FE89 |
   LDX $12                                   ; $07FE8D |
   JSL $03D3EB                               ; $07FE8F |

--- a/disassembly/bank07.asm
+++ b/disassembly/bank07.asm
@@ -5925,9 +5925,9 @@ CODE_07B177:
   REP #$10                                  ; $07B177 |
   TXY                                       ; $07B179 |
   TAX                                       ; $07B17A |
-  LDA $00E9D4,x                             ; $07B17B |
+  LDA raphael_mode7_matrix_b_c,x            ; $07B17B |
   STA !s_spr_y_speed_lo,y                   ; $07B17F |
-  LDA $00E954,x                             ; $07B182 |
+  LDA raphael_mode7_matrix_a_d,x            ; $07B182 |
   LDX !s_spr_facing_dir,y                   ; $07B186 |
   EOR $B07C,x                               ; $07B189 |
   INC A                                     ; $07B18C |

--- a/disassembly/bank08.asm
+++ b/disassembly/bank08.asm
@@ -14470,14 +14470,15 @@ CODE_08DA03:
 
 ; pointers to icon sets for each world
 map_icon_gfx_ptrs:
-  dw $DA2E, $DA52                           ; $08DA16 |
-  dw $DA76, $DA9A                           ; $08DA1A |
-  dw $DABE, $DAE2                           ; $08DA1E |
-  dw $DB06, $DB2A                           ; $08DA22 |
-  dw $DB4E, $DB72                           ; $08DA26 |
-  dw $DB96, $DBBA                           ; $08DA2A |
+  dw w1_map_icon_gfx_t, w1_map_icon_gfx_b   ; $08DA16 |
+  dw w2_map_icon_gfx_t, w2_map_icon_gfx_b   ; $08DA1A |
+  dw w3_map_icon_gfx_t, w3_map_icon_gfx_b   ; $08DA1E |
+  dw w4_map_icon_gfx_t, w4_map_icon_gfx_b   ; $08DA22 |
+  dw w5_map_icon_gfx_t, w5_map_icon_gfx_b   ; $08DA26 |
+  dw w6_map_icon_gfx_t, w6_map_icon_gfx_b   ; $08DA2A |
 
 ; icon GFX pointers (super FX)
+w1_map_icon_gfx_t:
   dl hirom_mirror($268404)                  ; $08DA2E |
   dl hirom_mirror($268420)                  ; $08DA31 |
   dl hirom_mirror($26843C)                  ; $08DA34 |
@@ -14490,6 +14491,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26C4C8)                  ; $08DA49 |
   dl hirom_mirror($26E420)                  ; $08DA4C |
   dl hirom_mirror($26E490)                  ; $08DA4F |
+w1_map_icon_gfx_b:
   dl hirom_mirror($26A404)                  ; $08DA52 |
   dl hirom_mirror($26A420)                  ; $08DA55 |
   dl hirom_mirror($26A43C)                  ; $08DA58 |
@@ -14502,6 +14504,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26C4E4)                  ; $08DA6D |
   dl hirom_mirror($26E420)                  ; $08DA70 |
   dl hirom_mirror($26E490)                  ; $08DA73 |
+w2_map_icon_gfx_t:
   dl hirom_mirror($26C404)                  ; $08DA76 |
   dl hirom_mirror($26C420)                  ; $08DA79 |
   dl hirom_mirror($26C43C)                  ; $08DA7C |
@@ -14514,6 +14517,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26E404)                  ; $08DA91 |
   dl hirom_mirror($26E420)                  ; $08DA94 |
   dl hirom_mirror($26E490)                  ; $08DA97 |
+w2_map_icon_gfx_b:
   dl hirom_mirror($26E404)                  ; $08DA9A |
   dl hirom_mirror($26E420)                  ; $08DA9D |
   dl hirom_mirror($26E43C)                  ; $08DAA0 |
@@ -14526,6 +14530,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26E4AC)                  ; $08DAB5 |
   dl hirom_mirror($26E420)                  ; $08DAB8 |
   dl hirom_mirror($26E490)                  ; $08DABB |
+w3_map_icon_gfx_t:
   dl hirom_mirror($268404)                  ; $08DABE |
   dl hirom_mirror($268420)                  ; $08DAC1 |
   dl hirom_mirror($26843C)                  ; $08DAC4 |
@@ -14538,6 +14543,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26E4C8)                  ; $08DAD9 |
   dl hirom_mirror($26E420)                  ; $08DADC |
   dl hirom_mirror($26E490)                  ; $08DADF |
+w3_map_icon_gfx_b:
   dl hirom_mirror($26A404)                  ; $08DAE2 |
   dl hirom_mirror($26A420)                  ; $08DAE5 |
   dl hirom_mirror($26A43C)                  ; $08DAE8 |
@@ -14550,6 +14556,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26E4E4)                  ; $08DAFD |
   dl hirom_mirror($26E420)                  ; $08DB00 |
   dl hirom_mirror($26E490)                  ; $08DB03 |
+w4_map_icon_gfx_t:
   dl hirom_mirror($26E43C)                  ; $08DB06 |
   dl hirom_mirror($26E458)                  ; $08DB09 |
   dl hirom_mirror($26E474)                  ; $08DB0C |
@@ -14562,6 +14569,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26E458)                  ; $08DB21 |
   dl hirom_mirror($27C43C)                  ; $08DB24 |
   dl hirom_mirror($26C404)                  ; $08DB27 |
+w4_map_icon_gfx_b:
   dl hirom_mirror($278404)                  ; $08DB2A |
   dl hirom_mirror($278420)                  ; $08DB2D |
   dl hirom_mirror($27843C)                  ; $08DB30 |
@@ -14574,6 +14582,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($27A4AC)                  ; $08DB45 |
   dl hirom_mirror($27A4C8)                  ; $08DB48 |
   dl hirom_mirror($27A4E4)                  ; $08DB4B |
+w5_map_icon_gfx_t:
   dl hirom_mirror($26C404)                  ; $08DB4E |
   dl hirom_mirror($26C420)                  ; $08DB51 |
   dl hirom_mirror($26C43C)                  ; $08DB54 |
@@ -14586,6 +14595,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($26E420)                  ; $08DB69 |
   dl hirom_mirror($26E420)                  ; $08DB6C |
   dl hirom_mirror($26E490)                  ; $08DB6F |
+w5_map_icon_gfx_b:
   dl hirom_mirror($278404)                  ; $08DB72 |
   dl hirom_mirror($278420)                  ; $08DB75 |
   dl hirom_mirror($27843C)                  ; $08DB78 |
@@ -14598,6 +14608,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($27A404)                  ; $08DB8D |
   dl hirom_mirror($27A420)                  ; $08DB90 |
   dl hirom_mirror($27A43C)                  ; $08DB93 |
+w6_map_icon_gfx_t:
   dl hirom_mirror($27A458)                  ; $08DB96 |
   dl hirom_mirror($27A474)                  ; $08DB99 |
   dl hirom_mirror($27A490)                  ; $08DB9C |
@@ -14610,6 +14621,7 @@ map_icon_gfx_ptrs:
   dl hirom_mirror($27A458)                  ; $08DBB1 |
   dl hirom_mirror($27A474)                  ; $08DBB4 |
   dl hirom_mirror($27A490)                  ; $08DBB7 |
+w6_map_icon_gfx_b:
   dl hirom_mirror($27A43C)                  ; $08DBBA |
   dl hirom_mirror($278420)                  ; $08DBBD |
   dl hirom_mirror($27843C)                  ; $08DBC0 |

--- a/disassembly/bank0C.asm
+++ b/disassembly/bank0C.asm
@@ -13,7 +13,7 @@ init_falling_icicle:
   RTL                                       ; $0C8015 |
 
 main_falling_icicle:
-  JSL $03AF23                               ; $0C8016 |
+  JSL CODE_03AF23                           ; $0C8016 |
   LDA !s_spr_anim_frame,x                   ; $0C801A |
   ASL A                                     ; $0C801D |
   TAY                                       ; $0C801E |
@@ -395,7 +395,7 @@ init_goomba:
   RTL                                       ; $0C8368 |
 
 main_goomba:
-  JSL $03AF23                               ; $0C8369 |
+  JSL CODE_03AF23                           ; $0C8369 |
   JSL $07E336                               ; $0C836D |
   JSL $03A5B7                               ; $0C8371 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0C8375 |
@@ -665,6 +665,8 @@ CODE_0C858A:
 
 CODE_0C858B:
   BRA CODE_0C8606                           ; $0C858B |
+
+head_bop_goomba:
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0C858D |
   TAX                                       ; $0C858F |
   JMP ($8630,x)                             ; $0C8590 |
@@ -800,8 +802,9 @@ CODE_0C86B1:
 
   dw $0000, $FFF0, $FFE0                    ; $0C86B7 |
 
-  JSL $03AA52                               ; $0C86BD |
-  JSL $03AF23                               ; $0C86C1 |
+main_unknown:
+  JSL CODE_03AA52                           ; $0C86BD |
+  JSL CODE_03AF23                           ; $0C86C1 |
   JSR CODE_0C878D                           ; $0C86C5 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0C86C8 |
   STA $603E                                 ; $0C86CA |
@@ -928,7 +931,7 @@ CODE_0C878D:
 
 main_unbalanced_snowy_playform:
   JSL $03AB1C                               ; $0C87D1 |
-  JSL $03AF23                               ; $0C87D5 |
+  JSL CODE_03AF23                           ; $0C87D5 |
   JSR CODE_0C88A2                           ; $0C87D9 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0C87DC |
   STA $603E                                 ; $0C87DE |
@@ -1054,6 +1057,7 @@ CODE_0C88A2:
   LDX $12                                   ; $0C88E3 |
   RTS                                       ; $0C88E5 |
 
+init_dizzy_dandy:
   LDA #$0001                                ; $0C88E6 |
   STA !s_spr_wildcard_5_lo_dp,x             ; $0C88E9 |
   LDA #$0100                                ; $0C88EB |
@@ -1065,8 +1069,9 @@ CODE_0C88A2:
 
   dw $0055, $0055, $0055, $0055, $0055      ; $0C8901 |
 
-  JSL $03AA52                               ; $0C890B |
-  JSL $03AF23                               ; $0C890F |
+main_dizzy_dandy:
+  JSL CODE_03AA52                           ; $0C890B |
+  JSL CODE_03AF23                           ; $0C890F |
   JSR CODE_0C8A80                           ; $0C8913 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $0C8916 |
   TYX                                       ; $0C8918 |
@@ -1407,7 +1412,7 @@ CODE_0C8BB7:
   JMP CODE_0C8D2F                           ; $0C8BD0 |
 
 CODE_0C8BD3:
-  JSL $03AF23                               ; $0C8BD3 |
+  JSL CODE_03AF23                           ; $0C8BD3 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0C8BD7 |
   CPY #$04                                  ; $0C8BD9 |
   BEQ CODE_0C8BE5                           ; $0C8BDB |
@@ -1864,7 +1869,7 @@ CODE_0C8F3F:
   JML despawn_sprite_free_slot              ; $0C8F59 |
 
 CODE_0C8F5D:
-  JSL $03AF23                               ; $0C8F5D |
+  JSL CODE_03AF23                           ; $0C8F5D |
   LDA !s_spr_timer_1,x                      ; $0C8F61 |
   BNE CODE_0C8FE2                           ; $0C8F64 |
   LDX #$09                                  ; $0C8F66 |
@@ -1920,6 +1925,7 @@ CODE_0C8FDC:
 CODE_0C8FE2:
   RTL                                       ; $0C8FE2 |
 
+head_bop_boo_guy:
   LDA !s_spr_bitwise_settings_1,x           ; $0C8FE3 |
   AND #$F9FF                                ; $0C8FE6 |
   STA !s_spr_bitwise_settings_1,x           ; $0C8FE9 |
@@ -1980,7 +1986,7 @@ init_blargg:
   RTL                                       ; $0C907F |
 
 main_blargg:
-  JSL $03AF23                               ; $0C9080 |
+  JSL CODE_03AF23                           ; $0C9080 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0C9084 |
   TAX                                       ; $0C9086 |
   JMP ($908A,x)                             ; $0C9087 |
@@ -2282,12 +2288,12 @@ CODE_0C9305:
   RTL                                       ; $0C9305 |
 
 init_bumpty:
-  JSL $02A007                               ; $0C9306 |
+  JSL CODE_02A007                           ; $0C9306 |
   JSR CODE_0C9497                           ; $0C930A |
   RTL                                       ; $0C930D |
 
 main_bumpty:
-  JSL $03AF23                               ; $0C930E |
+  JSL CODE_03AF23                           ; $0C930E |
   JSR CODE_0C9613                           ; $0C9312 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0C9315 |
   TAX                                       ; $0C9317 |
@@ -2849,7 +2855,7 @@ init_bumpty_tackling:
   RTL                                       ; $0C971C |
 
 main_bumpty_tackling:
-  JSL $03AF23                               ; $0C971D |
+  JSL CODE_03AF23                           ; $0C971D |
   JSL $0C9926                               ; $0C9721 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0C9725 |
   TAX                                       ; $0C9727 |
@@ -3241,7 +3247,7 @@ main_bumpty_flying:
   JML spawn_sprite                          ; $0C9A1F |
 
 CODE_0C9A23:
-  JSL $03AF23                               ; $0C9A23 |
+  JSL CODE_03AF23                           ; $0C9A23 |
   JSL $0C9B02                               ; $0C9A27 |
   LDY #$00                                  ; $0C9A2B |
   LDA !s_spr_y_pixel_pos,x                  ; $0C9A2D |
@@ -3450,7 +3456,7 @@ main_skeleton_goonie:
   JML spawn_sprite                          ; $0C9BA2 |
 
 CODE_0C9BA6:
-  JSL $03AF23                               ; $0C9BA6 |
+  JSL CODE_03AF23                           ; $0C9BA6 |
   JSL $07E336                               ; $0C9BAA |
   JSL $03A5B7                               ; $0C9BAE |
   JSR CODE_0C9C23                           ; $0C9BB2 |
@@ -3527,6 +3533,7 @@ CODE_0C9C23:
 CODE_0C9C47:
   RTS                                       ; $0C9C47 |
 
+head_bop_skeleton_goonie:
   JSL $0C9C7B                               ; $0C9C48 |
   LDA #$019E                                ; $0C9C4C |
   TXY                                       ; $0C9C4F |
@@ -3600,7 +3607,7 @@ init_skeleton_goonie_flightless:
   dw $FE00, $0200                           ; $0C9CF9 |
 
 main_skeleton_goonie_flightless:
-  JSL $03AF23                               ; $0C9CFD |
+  JSL CODE_03AF23                           ; $0C9CFD |
   JSL $03A5B7                               ; $0C9D01 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0C9D05 |
   TYX                                       ; $0C9D07 |
@@ -3767,7 +3774,7 @@ CODE_0C9E3E:
   RTL                                       ; $0C9E73 |
 
 CODE_0C9E74:
-  JSL $03AF23                               ; $0C9E74 |
+  JSL CODE_03AF23                           ; $0C9E74 |
   JSR CODE_0C9F76                           ; $0C9E78 |
   LDY !s_spr_collision_id,x                 ; $0C9E7B |
   BPL CODE_0C9EC2                           ; $0C9E7E |
@@ -3935,6 +3942,7 @@ CODE_0C9FB4:
   PLA                                       ; $0C9FDC |
   RTL                                       ; $0C9FDD |
 
+head_bop_skeleton_goonie_bomb:
   LDY !s_spr_gsu_morph_1_lo,x               ; $0C9FDE |
   LDA !s_spr_bitwise_settings_3,y           ; $0C9FE1 |
   ORA #$001B                                ; $0C9FE4 |
@@ -3986,7 +3994,7 @@ main_firebar:
   LDA #$96DF                                ; $0CA04A |
   JSL r_gsu_init_1                          ; $0CA04D | GSU init
   LDX $12                                   ; $0CA051 |
-  JSL $03AF23                               ; $0CA053 |
+  JSL CODE_03AF23                           ; $0CA053 |
   LDY !s_spr_collision_id,x                 ; $0CA057 |
   BPL CODE_0CA060                           ; $0CA05A |
   JSL player_hit_sprite                     ; $0CA05C |
@@ -4017,7 +4025,7 @@ init_little_mouser_nest:
   RTL                                       ; $0CA081 |
 
 main_little_mouser_nest:
-  JSL $03AF23                               ; $0CA082 |
+  JSL CODE_03AF23                           ; $0CA082 |
   RTL                                       ; $0CA086 |
 
 init_little_mouser_in_nest:
@@ -4045,7 +4053,7 @@ init_little_mouser_in_nest:
   JMP CODE_0CA20F                           ; $0CA0B1 |
 
 main_little_mouser_in_nest:
-  JSL $03AF23                               ; $0CA0B4 |
+  JSL CODE_03AF23                           ; $0CA0B4 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0CA0B8 |
   TAX                                       ; $0CA0BA |
   JMP ($A0BE,x)                             ; $0CA0BB |
@@ -4331,7 +4339,7 @@ main_little_mouser:
   STA !s_spr_oam_1,y                        ; $0CA2F4 |
 
 CODE_0CA2F7:
-  JSL $03AF23                               ; $0CA2F7 |
+  JSL CODE_03AF23                           ; $0CA2F7 |
   JSL despawn_sprite_threshold_B            ; $0CA2FB |
   BCC CODE_0CA322                           ; $0CA2FF |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0CA301 |
@@ -4788,7 +4796,7 @@ CODE_0CA68E:
 
 CODE_0CA692:
   TYX                                       ; $0CA692 |
-  JSL $03BF87                               ; $0CA693 |
+  JSL CODE_03BF87                           ; $0CA693 |
   TXY                                       ; $0CA697 |
   LDX $12                                   ; $0CA698 |
   LDA #$000C                                ; $0CA69A |
@@ -5179,7 +5187,7 @@ CODE_0CA9A8:
   STA !s_spr_bitwise_settings_3,x           ; $0CA9B8 |
 
 CODE_0CA9BB:
-  JSL $03AF23                               ; $0CA9BB |
+  JSL CODE_03AF23                           ; $0CA9BB |
   JSR CODE_0CB29D                           ; $0CA9BF |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0CA9C2 |
   TAX                                       ; $0CA9C4 |
@@ -6466,7 +6474,7 @@ main_little_skull_mouser:
   LDX $12                                   ; $0CB375 |
   LDA !s_spr_collision_state,x              ; $0CB377 |
   BNE CODE_0CB311                           ; $0CB37A |
-  JSL $03AF23                               ; $0CB37C |
+  JSL CODE_03AF23                           ; $0CB37C |
   JSL $07FD6C                               ; $0CB380 |
   BCC CODE_0CB394                           ; $0CB384 |
   JSL $03B20B                               ; $0CB386 |
@@ -6588,7 +6596,7 @@ CODE_0CB43E:
 
 CODE_0CB471:
   STZ !s_spr_collision_state,x              ; $0CB471 |
-  JSL $03AF23                               ; $0CB474 |
+  JSL CODE_03AF23                           ; $0CB474 |
   JSL $07FD6C                               ; $0CB478 |
   BCC CODE_0CB49A                           ; $0CB47C |
   JSL $03B20B                               ; $0CB47E |
@@ -6841,8 +6849,8 @@ CODE_0CB671:
   RTL                                       ; $0CB6AB |
 
 main_jean_de_fillet:
-  JSL $03AA52                               ; $0CB6AC |
-  JSL $03AF23                               ; $0CB6B0 |
+  JSL CODE_03AA52                           ; $0CB6AC |
+  JSL CODE_03AF23                           ; $0CB6B0 |
   SEP #$20                                  ; $0CB6B4 |
   LDA #$FF                                  ; $0CB6B6 |
   STA $7863,x                               ; $0CB6B8 |
@@ -7223,7 +7231,7 @@ main_hot_lips:
   LDX $12                                   ; $0CBA6F |
 
 CODE_0CBA71:
-  JSL $03AF23                               ; $0CBA71 |
+  JSL CODE_03AF23                           ; $0CBA71 |
   JSR CODE_0CBDFC                           ; $0CBA75 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0CBA78 |
   TYX                                       ; $0CBA7A |
@@ -7790,7 +7798,7 @@ main_boo_balloon:
   PLY                                       ; $0CBF2D |
 
 CODE_0CBF2E:
-  JSL $03AF23                               ; $0CBF2E |
+  JSL CODE_03AF23                           ; $0CBF2E |
   JSR CODE_0CC01F                           ; $0CBF32 |
   JSR CODE_0CC220                           ; $0CBF35 |
   LDA !s_spr_x_player_dir,x                 ; $0CBF38 |
@@ -8261,6 +8269,7 @@ CODE_0CC293:
   JSR CODE_0CC0AF                           ; $0CC2A0 |
   RTL                                       ; $0CC2A3 |
 
+head_bop_boo_balloon:
   LDY !s_spr_draw_priority,x                ; $0CC2A4 |
   BMI CODE_0CC2EF                           ; $0CC2A7 |
   LDA !s_spr_anim_frame,x                   ; $0CC2A9 |
@@ -8369,10 +8378,10 @@ CODE_0CC39A:
 main_kamek_shoots_magic:
   LDA !s_spr_anim_frame,x                   ; $0CC39B |
   BNE CODE_0CC3A4                           ; $0CC39E |
-  JSL $03AA52                               ; $0CC3A0 |
+  JSL CODE_03AA52                           ; $0CC3A0 |
 
 CODE_0CC3A4:
-  JSL $03AF23                               ; $0CC3A4 |
+  JSL CODE_03AF23                           ; $0CC3A4 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $0CC3A8 |
   TYX                                       ; $0CC3AA |
   JMP ($C3AE,x)                             ; $0CC3AB |
@@ -8854,13 +8863,14 @@ CODE_0CC793:
   PLA                                       ; $0CC793 |
   RTL                                       ; $0CC794 |
 
-main_kamek_magic:
+head_bop_kamek_magic:
   RTL                                       ; $0CC795 |
 
 init_kamek_magic:
   RTL                                       ; $0CC796 |
 
-  JSL $03AF23                               ; $0CC797 |
+main_kamek_magic:
+  JSL CODE_03AF23                           ; $0CC797 |
   JSR CODE_0CC844                           ; $0CC79B |
   JSR CODE_0CC8D4                           ; $0CC79E |
   LDA !s_spr_timer_1,x                      ; $0CC7A1 |
@@ -9037,7 +9047,7 @@ CODE_0CC8ED:
 
 main_tulip:
   JSR CODE_0CCBD3                           ; $0CC91D |
-  JSL $03AF23                               ; $0CC920 |
+  JSL CODE_03AF23                           ; $0CC920 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0CC924 |
   TYX                                       ; $0CC926 |
   JMP ($C92A,x)                             ; $0CC927 |
@@ -9685,7 +9695,8 @@ init_piscatory_pete:
   REP #$20                                  ; $0CCE80 |
   RTL                                       ; $0CCE82 |
 
-  JSL $03AF23                               ; $0CCE83 |
+main_piscatory_pete:
+  JSL CODE_03AF23                           ; $0CCE83 |
   JSL $0CD017                               ; $0CCE87 |
   JSL $0CD053                               ; $0CCE8B |
   JSR CODE_0CD00D                           ; $0CCE8F |
@@ -9976,7 +9987,7 @@ init_preying_mantas:
   db $08, $00, $04, $00, $04, $00, $08, $00 ; $0CD08B |
 
 main_preying_mantas:
-  JSL $03AF23                               ; $0CD093 |
+  JSL CODE_03AF23                           ; $0CD093 |
   JSR CODE_0CD00D                           ; $0CD097 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0CD09A |
   TYX                                       ; $0CD09C |
@@ -10099,7 +10110,7 @@ main_loch_nestor:
   LDX $12                                   ; $0CD18C |
 
 CODE_0CD18E:
-  JSL $03AF23                               ; $0CD18E |
+  JSL CODE_03AF23                           ; $0CD18E |
   JSR CODE_0CD3DC                           ; $0CD192 |
   LDA !s_spr_timer_1,x                      ; $0CD195 |
   BNE CODE_0CD1A9                           ; $0CD198 |
@@ -10571,7 +10582,7 @@ main_boo:
 
   LDX $12                                   ; $0CD54F |
   JSR CODE_0CD6CE                           ; $0CD551 |
-  JSL $03AF23                               ; $0CD554 |
+  JSL CODE_03AF23                           ; $0CD554 |
   JSL $0CD8FC                               ; $0CD558 |
   JSR CODE_0CD6A2                           ; $0CD55C |
   JSL $0CD77C                               ; $0CD55F |
@@ -11062,7 +11073,7 @@ CODE_0CD925:
   RTL                                       ; $0CD925 |
 
   LDX $12                                   ; $0CD926 |
-  JSL $03AF23                               ; $0CD928 |
+  JSL CODE_03AF23                           ; $0CD928 |
   JSL $0CDA0C                               ; $0CD92C |
   LDY !s_spr_wildcard_5_hi_dp,x             ; $0CD930 |
   TYX                                       ; $0CD932 |
@@ -11299,7 +11310,7 @@ CODE_0CDB4D:
   db $D9, $88, $53, $D9, $3A, $54, $00      ; $0CDB65 |
 
 main_boss_kamek:
-  JSL $03AF23                               ; $0CDB6C |
+  JSL CODE_03AF23                           ; $0CDB6C |
   JSR CODE_0CE526                           ; $0CDB70 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0CDB73 |
   TYX                                       ; $0CDB75 |
@@ -11748,7 +11759,7 @@ CODE_0CDF2F:
   LDX #$0070                                ; $0CDF87 |
   STX $01                                   ; $0CDF8A |
   LDX #$6800                                ; $0CDF8C |
-  JSL $00BEA6                               ; $0CDF8F |
+  JSL CODE_00BEA6                           ; $0CDF8F |
   SEP #$10                                  ; $0CDF93 |
   PLD                                       ; $0CDF95 |
   LDX $12                                   ; $0CDF96 |
@@ -11942,7 +11953,7 @@ CODE_0CE14E:
   JSL r_gsu_init_1                          ; $0CE17C | GSU init
   NOP                                       ; $0CE180 |
   NOP                                       ; $0CE181 |
-  JSL $00BE39                               ; $0CE182 |
+  JSL CODE_00BE39                           ; $0CE182 |
 
 ; DMA args
   dl $7E56D0, $703A02                       ; $0CE186 |
@@ -11959,13 +11970,13 @@ CODE_0CE190:
   JSL r_gsu_init_1                          ; $0CE19D | GSU init
   NOP                                       ; $0CE1A1 |
   NOP                                       ; $0CE1A2 |
-  JSL $00BE39                               ; $0CE1A3 |
+  JSL CODE_00BE39                           ; $0CE1A3 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $0CE1A7 |
   dw $01A4                                  ; $0CE1AD |
 
-  JSL $00BE39                               ; $0CE1AF |
+  JSL CODE_00BE39                           ; $0CE1AF |
 
 ; DMA args
   dl $7E5388, $7036BA                       ; $0CE1B3 |
@@ -12064,7 +12075,7 @@ CODE_0CE250:
   JSL r_gsu_init_1                          ; $0CE27E | GSU init
   NOP                                       ; $0CE282 |
   NOP                                       ; $0CE283 |
-  JSL $00BE39                               ; $0CE284 |
+  JSL CODE_00BE39                           ; $0CE284 |
 
 ; DMA args
   dl $7E56D0, $703A02                       ; $0CE288 |
@@ -12080,13 +12091,13 @@ CODE_0CE292:
   JSL r_gsu_init_1                          ; $0CE29C | GSU init
   NOP                                       ; $0CE2A0 |
   NOP                                       ; $0CE2A1 |
-  JSL $00BE39                               ; $0CE2A2 |
+  JSL CODE_00BE39                           ; $0CE2A2 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $0CE2A6 |
   dw $01A4                                  ; $0CE2AC |
 
-  JSL $00BE39                               ; $0CE2AE |
+  JSL CODE_00BE39                           ; $0CE2AE |
 
 ; DMA args
   dl $7E5388, $7036BA                       ; $0CE2B2 |
@@ -12213,7 +12224,7 @@ CODE_0CE38F:
   JSL r_gsu_init_1                          ; $0CE3AE | GSU init
   NOP                                       ; $0CE3B2 |
   NOP                                       ; $0CE3B3 |
-  JSL $00BE39                               ; $0CE3B4 |
+  JSL CODE_00BE39                           ; $0CE3B4 |
 
 ; DMA args
   dl $7E56D0, $703A02                       ; $0CE3B8 |
@@ -12225,13 +12236,13 @@ CODE_0CE38F:
   JSL r_gsu_init_1                          ; $0CE3C7 | GSU init
   NOP                                       ; $0CE3CB |
   NOP                                       ; $0CE3CC |
-  JSL $00BE39                               ; $0CE3CD |
+  JSL CODE_00BE39                           ; $0CE3CD |
 
 ; DMA args
   dl $7E5040, $703372                       ; $0CE3D1 |
   dw $01A4                                  ; $0CE3D7 |
 
-  JSL $00BE39                               ; $0CE3D9 |
+  JSL CODE_00BE39                           ; $0CE3D9 |
 
 ; DMA args
   dl $7E5388, $7036BA                       ; $0CE3DD |
@@ -12295,7 +12306,7 @@ CODE_0CE432:
   JSL r_gsu_init_1                          ; $0CE451 | GSU init
   NOP                                       ; $0CE455 |
   NOP                                       ; $0CE456 |
-  JSL $00BE39                               ; $0CE457 |
+  JSL CODE_00BE39                           ; $0CE457 |
 
 ; DMA args
   dl $7E56D0, $703A02                       ; $0CE45B |
@@ -12307,13 +12318,13 @@ CODE_0CE432:
   JSL r_gsu_init_1                          ; $0CE46A | GSU init
   NOP                                       ; $0CE46E |
   NOP                                       ; $0CE46F |
-  JSL $00BE39                               ; $0CE470 |
+  JSL CODE_00BE39                           ; $0CE470 |
 
 ; DMA args
   dl $7E5040, $703372                       ; $0CE474 |
   dw $01A4                                  ; $0CE47A |
 
-  JSL $00BE39                               ; $0CE47C |
+  JSL CODE_00BE39                           ; $0CE47C |
 
 ; DMA args
   dl $7E5388, $7036BA                       ; $0CE480 |
@@ -12562,7 +12573,7 @@ CODE_0CE657:
   RTL                                       ; $0CE657 |
 
 main_roger_shy_guy:
-  JSL $03AF23                               ; $0CE658 |
+  JSL CODE_03AF23                           ; $0CE658 |
   JSR CODE_0CE94F                           ; $0CE65C |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0CE65F |
   TYX                                       ; $0CE661 |
@@ -13294,7 +13305,7 @@ main_balloon_bg3:
   LDA #$8390                                ; $0CEBE4 |
   JSL r_gsu_init_1                          ; $0CEBE7 | GSU init
   LDX $12                                   ; $0CEBEB |
-  JSL $03AF23                               ; $0CEBED |
+  JSL CODE_03AF23                           ; $0CEBED |
   LDA $601A                                 ; $0CEBF1 |
   BNE CODE_0CEBF9                           ; $0CEBF4 |
   JMP CODE_0CEC71                           ; $0CEBF6 |
@@ -13589,7 +13600,7 @@ CODE_0CEDE1:
   LDX #$08                                  ; $0CEE33 |
   LDA #$E865                                ; $0CEE35 |
   JSL r_gsu_init_1                          ; $0CEE38 | GSU init
-  JSL $00BE39                               ; $0CEE3C |
+  JSL CODE_00BE39                           ; $0CEE3C |
 
 ; DMA args
   dl $7E5040, $703372                       ; $0CEE40 |
@@ -13657,7 +13668,7 @@ CODE_0CEE58:
   dw $0001, $0004, $0000, $0003             ; $0CEFB4 |
   dw $0000, $0002, $0000, $0001             ; $0CEFBC |
 
-init_balloon_pumper_with_red_balloon_bg3:
+init_balloon_pumper_red_bg3:
   JSL $03AE60                               ; $0CEFC4 |
   LDA $0CB2                                 ; $0CEFC8 |
   BNE CODE_0CEFD6                           ; $0CEFCB |
@@ -13687,7 +13698,7 @@ CODE_0CEFDA:
   STA !s_spr_wildcard_3_lo_dp,x             ; $0CEFFF |
   JML $028048                               ; $0CF001 |
 
-main_balloon_pumper_with_red_balloon_bg3:
+main_balloon_pumper_red_bg3:
   LDA !s_spr_oam_pointer,x                  ; $0CF005 |
   INC A                                     ; $0CF008 |
   INC A                                     ; $0CF009 |
@@ -13709,7 +13720,7 @@ main_balloon_pumper_with_red_balloon_bg3:
   JSL $028048                               ; $0CF032 |
 
 CODE_0CF036:
-  JSL $03AF23                               ; $0CF036 |
+  JSL CODE_03AF23                           ; $0CF036 |
   JSR CODE_0CF147                           ; $0CF03A |
   STZ $0E                                   ; $0CF03D |
   LDA !s_spr_y_player_delta,x               ; $0CF03F |
@@ -13917,7 +13928,7 @@ init_train_bandit:
   db $9E                                    ; $0CF1D4 |
 
 main_train_bandit:
-  JSL $03AF23                               ; $0CF1D5 |
+  JSL CODE_03AF23                           ; $0CF1D5 |
   LDA !s_player_form                        ; $0CF1D9 |
   CMP #$0008                                ; $0CF1DC |
   BNE CODE_0CF1EB                           ; $0CF1DF |
@@ -14257,7 +14268,7 @@ CODE_0CF45B:
   JSR CODE_0CF477                           ; $0CF461 |
 
 CODE_0CF464:
-  JSL $03AF23                               ; $0CF464 |
+  JSL CODE_03AF23                           ; $0CF464 |
   JSR CODE_0CF6D0                           ; $0CF468 |
   LDY !s_spr_wildcard_1_lo,x                ; $0CF46B |
   DEY                                       ; $0CF46E |
@@ -14735,6 +14746,8 @@ CODE_0CF82C:
   ORA !s_spr_oam_yxppccct,x                 ; $0CF840 |
   STA !s_spr_oam_yxppccct,x                 ; $0CF843 |
   BRA CODE_0CF82C                           ; $0CF846 |
+
+head_bop_fly_guy:
   LDY !s_spr_draw_priority,x                ; $0CF848 |
   BMI CODE_0CF868                           ; $0CF84B |
   LDY !s_spr_wildcard_1_lo,x                ; $0CF84D |
@@ -15114,7 +15127,7 @@ CODE_0CFC48:
   JSR CODE_0CFD41                           ; $0CFC48 |
   JSL $0CFEDD                               ; $0CFC4B |
   JSR CODE_0CFD69                           ; $0CFC4F |
-  JSL $03AF23                               ; $0CFC52 |
+  JSL CODE_03AF23                           ; $0CFC52 |
   JSR CODE_0CFDFC                           ; $0CFC56 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0CFC59 |
   TYX                                       ; $0CFC5B |

--- a/disassembly/bank0C.asm
+++ b/disassembly/bank0C.asm
@@ -7663,7 +7663,7 @@ CODE_0CBDBA:
 
 CODE_0CBDF2:
   REP #$10                                  ; $0CBDF2 |
-  JSL $04AC9C                               ; $0CBDF4 |
+  JSL player_death_spike                    ; $0CBDF4 |
   SEP #$10                                  ; $0CBDF8 |
   PLA                                       ; $0CBDFA |
   RTL                                       ; $0CBDFB |
@@ -10162,7 +10162,7 @@ CODE_0CD1D5:
   REP #$10                                  ; $0CD1FC |
   TXY                                       ; $0CD1FE |
   TAX                                       ; $0CD1FF |
-  LDA $00E9D4,x                             ; $0CD200 |
+  LDA raphael_mode7_matrix_b_c,x            ; $0CD200 |
   CMP #$8000                                ; $0CD204 |
   ROR A                                     ; $0CD207 |
   CMP #$8000                                ; $0CD208 |
@@ -10172,7 +10172,7 @@ CODE_0CD1D5:
   CLC                                       ; $0CD210 |
   ADC !s_spr_gsu_morph_1_lo,y               ; $0CD211 |
   STA !s_spr_x_pixel_pos,y                  ; $0CD214 |
-  LDA $00E954,x                             ; $0CD217 |
+  LDA raphael_mode7_matrix_a_d,x            ; $0CD217 |
   AND #$8000                                ; $0CD21B |
   ASL A                                     ; $0CD21E |
   ROL A                                     ; $0CD21F |
@@ -12388,7 +12388,7 @@ CODE_0CE4ED:
   REP #$10                                  ; $0CE4ED |
   TXY                                       ; $0CE4EF |
   LDX !s_spr_wildcard_6_lo_dp,y             ; $0CE4F0 |
-  LDA $00E9D4,x                             ; $0CE4F2 |
+  LDA raphael_mode7_matrix_b_c,x            ; $0CE4F2 |
   CMP #$8000                                ; $0CE4F6 |
   ROR A                                     ; $0CE4F9 |
   CMP #$8000                                ; $0CE4FA |
@@ -13054,7 +13054,7 @@ CODE_0CE9C0:
   STA $0000                                 ; $0CE9C3 |
   LDA !s_spr_y_pixel_pos,x                  ; $0CE9C6 |
   STA $0002                                 ; $0CE9C9 |
-  JSL $03A520                               ; $0CE9CC |
+  JSL CODE_03A520                           ; $0CE9CC |
   LDA #$0009                                ; $0CE9D0 |\ play sound #$09
   JSL push_sound_queue                      ; $0CE9D3 |/
   JSL $03D3EB                               ; $0CE9D7 |
@@ -13147,6 +13147,8 @@ CODE_0CEA89:
 CODE_0CEA8A:
   JSL $0CEAA5                               ; $0CEA8A |
   JML despawn_sprite_free_slot              ; $0CEA8E |
+
+CODE_0CEA92:
   PHB                                       ; $0CEA92 |
   PHK                                       ; $0CEA93 |
   PLB                                       ; $0CEA94 |

--- a/disassembly/bank0D.asm
+++ b/disassembly/bank0D.asm
@@ -6811,7 +6811,7 @@ CODE_0DB528:
 
 CODE_0DB534:
   STA $06                                   ; $0DB534 |
-  JSL $049B42                               ; $0DB536 |
+  JSL CODE_049B42                           ; $0DB536 |
   PHA                                       ; $0DB53A |
   LDY $04                                   ; $0DB53B |
   TYA                                       ; $0DB53D |

--- a/disassembly/bank0D.asm
+++ b/disassembly/bank0D.asm
@@ -31,7 +31,7 @@ CODE_0D801C:
 main_spiky_mace:
   STZ !s_spr_facing_dir,x                   ; $0D8031 |
   JSR CODE_0D8065                           ; $0D8034 |
-  JSL $03AF23                               ; $0D8037 |
+  JSL CODE_03AF23                           ; $0D8037 |
   JSL despawn_sprite                        ; $0D803B |
   BCC CODE_0D804C                           ; $0D803F |
   LDA !s_spr_wildcard_2_lo,x                ; $0D8041 |
@@ -53,7 +53,7 @@ CODE_0D8064:
   RTL                                       ; $0D8064 |
 
 CODE_0D8065:
-  JSL $03AA52                               ; $0D8065 |
+  JSL CODE_03AA52                           ; $0D8065 |
   LDA !s_spr_dyntile_index,x                ; $0D8069 |
   PHA                                       ; $0D806C |
   LDA !s_spr_wildcard_2_lo,x                ; $0D806D |
@@ -600,7 +600,7 @@ CODE_0D84A0:
 
 main_boo_guys_carrying_bombs:
   JSR CODE_0D85B8                           ; $0D84AB |
-  JSL $03AF23                               ; $0D84AE |
+  JSL CODE_03AF23                           ; $0D84AE |
   JSR CODE_0D8729                           ; $0D84B2 |
   TXY                                       ; $0D84B5 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0D84B6 |
@@ -1412,7 +1412,7 @@ CODE_0D8AE0:
 main_chained_spike_ball:
   JSR CODE_0D8B3B                           ; $0D8AF1 |
   JSR CODE_0D8B8B                           ; $0D8AF4 |
-  JSL $03AF23                               ; $0D8AF7 |
+  JSL CODE_03AF23                           ; $0D8AF7 |
   LDY !s_spr_collision_id,x                 ; $0D8AFB |
   BPL CODE_0D8B06                           ; $0D8AFE |
   JSL player_hit_sprite                     ; $0D8B00 |
@@ -1422,7 +1422,7 @@ CODE_0D8B06:
   JSL $03A5B7                               ; $0D8B06 |
 
 CODE_0D8B0A:
-  JSL $03A2C7                               ; $0D8B0A |
+  JSL CODE_03A2C7                           ; $0D8B0A |
   BCC CODE_0D8B2F                           ; $0D8B0E |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $0D8B10 |
   TAX                                       ; $0D8B12 |
@@ -1913,7 +1913,7 @@ crate_ptr:
 
 main_crate:
   JSR CODE_0D8F27                           ; $0D8EBE |
-  JSL $03AF23                               ; $0D8EC1 |
+  JSL CODE_03AF23                           ; $0D8EC1 |
   STZ !s_spr_x_speed_lo,x                   ; $0D8EC5 |
   JSR CODE_0D8F38                           ; $0D8EC8 |
   TXY                                       ; $0D8ECB |
@@ -1970,7 +1970,7 @@ CODE_0D8F23:
 CODE_0D8F27:
   LDY !s_spr_wildcard_6_lo_dp,x             ; $0D8F27 |
   BNE CODE_0D8F2F                           ; $0D8F29 |
-  JSL $03AA52                               ; $0D8F2B |
+  JSL CODE_03AA52                           ; $0D8F2B |
 
 CODE_0D8F2F:
   RTS                                       ; $0D8F2F |
@@ -2746,8 +2746,9 @@ CODE_0D94E9:
   dw $96BC                                  ; $0D94F1 |
   dw $96DF                                  ; $0D94F3 |
 
+main_chained_pulley_log:
   JSR CODE_0D9560                           ; $0D94F5 |
-  JSL $03AF23                               ; $0D94F8 |
+  JSL CODE_03AF23                           ; $0D94F8 |
   JSR CODE_0D95EE                           ; $0D94FC |
   JSL $03A299                               ; $0D94FF |
   BCC CODE_0D9512                           ; $0D9503 |
@@ -3078,8 +3079,8 @@ init_pulley:
   RTL                                       ; $0D9770 |
 
 main_pulley:
-  JSL $03AA52                               ; $0D9771 |
-  JSL $03AF23                               ; $0D9775 |
+  JSL CODE_03AA52                           ; $0D9771 |
+  JSL CODE_03AF23                           ; $0D9775 |
   LDY !s_spr_collision_id,x                 ; $0D9779 |
   BEQ CODE_0D97C3                           ; $0D977C |
   DEY                                       ; $0D977E |
@@ -3199,8 +3200,8 @@ CODE_0D9871:
   dw $99EF                                  ; $0D9877 |
 
 main_small_raven:
-  JSL $03AA52                               ; $0D9879 |
-  JSL $03AF23                               ; $0D987D |
+  JSL CODE_03AA52                           ; $0D9879 |
+  JSL CODE_03AF23                           ; $0D987D |
   JSR CODE_0D98CA                           ; $0D9881 |
   JSR CODE_0D98FB                           ; $0D9884 |
   JSR CODE_0D994E                           ; $0D9887 |
@@ -3427,7 +3428,7 @@ init_flipper_downwards:
 
 main_flipper_downwards:
   JSR CODE_0D9A40                           ; $0D9A25 |
-  JSL $03AF23                               ; $0D9A28 |
+  JSL CODE_03AF23                           ; $0D9A28 |
   JSR CODE_0D9B13                           ; $0D9A2C |
   JSR CODE_0D9C93                           ; $0D9A2F |
   LDA #$04B4                                ; $0D9A32 |
@@ -3440,7 +3441,7 @@ CODE_0D9A3C:
   RTL                                       ; $0D9A3F |
 
 CODE_0D9A40:
-  JSL $03AA52                               ; $0D9A40 |
+  JSL CODE_03AA52                           ; $0D9A40 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $0D9A44 |
   AND #$01FE                                ; $0D9A47 |
   STA !gsu_r1                               ; $0D9A4A |
@@ -3824,7 +3825,7 @@ init_flipper_left_and_right:
 
 main_flipped_left_and_right:
   JSR CODE_0D9D64                           ; $0D9D49 |
-  JSL $03AF23                               ; $0D9D4C |
+  JSL CODE_03AF23                           ; $0D9D4C |
   JSR CODE_0D9E70                           ; $0D9D50 |
   JSR CODE_0D9C93                           ; $0D9D53 |
   LDA #$04B5                                ; $0D9D56 |
@@ -3837,7 +3838,7 @@ CODE_0D9D60:
   RTL                                       ; $0D9D63 |
 
 CODE_0D9D64:
-  JSL $03AA52                               ; $0D9D64 |
+  JSL CODE_03AA52                           ; $0D9D64 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $0D9D68 |
   AND #$01FE                                ; $0D9D6B |
   STA !gsu_r1                               ; $0D9D6E |
@@ -4296,7 +4297,7 @@ main_shark_chomp:
   RTL                                       ; $0DA112 |
 
 CODE_0DA113:
-  JSL $03AF23                               ; $0DA113 |
+  JSL CODE_03AF23                           ; $0DA113 |
   TXY                                       ; $0DA117 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0DA118 |
   ASL A                                     ; $0DA11A |
@@ -4815,7 +4816,7 @@ init_spiked_platform_switch:
 
 ; both green and red switches
 main_spiked_platform_switch:
-  JSL $03AF23                               ; $0DA527 |
+  JSL CODE_03AF23                           ; $0DA527 |
   LDY !s_spr_wildcard_6_lo_dp,x             ; $0DA52B |
   LDA $0FD1,y                               ; $0DA52D |
   CMP $0FD5,y                               ; $0DA530 |
@@ -4886,7 +4887,7 @@ CODE_0DA5A1:
 ; both green and red platforms
 main_spiked_platform:
   JSR CODE_0DA5D7                           ; $0DA5BA |
-  JSL $03AF23                               ; $0DA5BD |
+  JSL CODE_03AF23                           ; $0DA5BD |
   JSR CODE_0DA69C                           ; $0DA5C1 |
   JSR CODE_0DA7E6                           ; $0DA5C4 |
   JSR CODE_0DA8B8                           ; $0DA5C7 |
@@ -4908,7 +4909,7 @@ CODE_0DA5DD:
   LDA $0FC1,y                               ; $0DA5DF |
   DEC A                                     ; $0DA5E2 |
   STA !s_spr_dyntile_index,x                ; $0DA5E3 |
-  JSL $03AA52                               ; $0DA5E6 |
+  JSL CODE_03AA52                           ; $0DA5E6 |
   LDY !s_spr_wildcard_6_lo_dp,x             ; $0DA5EA |
   LDA $0FC5,y                               ; $0DA5EC |
   DEC A                                     ; $0DA5EF |
@@ -4991,7 +4992,7 @@ CODE_0DA69B:
   RTS                                       ; $0DA69B |
 
 CODE_0DA69C:
-  JSL $03A2C7                               ; $0DA69C |
+  JSL CODE_03A2C7                           ; $0DA69C |
   BCC CODE_0DA69B                           ; $0DA6A0 |
   LDY !s_spr_wildcard_6_lo_dp,x             ; $0DA6A2 |
   LDA $0FCD,y                               ; $0DA6A4 |
@@ -5262,7 +5263,7 @@ CODE_0DA8E1:
 
 main_two_spiked_platforms_with_switch:
   JSR CODE_0DA911                           ; $0DA8F1 |
-  JSL $03AF23                               ; $0DA8F4 |
+  JSL CODE_03AF23                           ; $0DA8F4 |
   JSR CODE_0DAC2D                           ; $0DA8F8 |
   JSR CODE_0DAA52                           ; $0DA8FB |
   JSR CODE_0DAC43                           ; $0DA8FE |
@@ -5287,7 +5288,7 @@ CODE_0DA917:
   BEQ CODE_0DA916                           ; $0DA920 |
 
 CODE_0DA922:
-  JSL $03AA52                               ; $0DA922 |
+  JSL CODE_03AA52                           ; $0DA922 |
   REP #$10                                  ; $0DA926 |
   LDA !s_spr_oam_pointer,x                  ; $0DA928 |
   CLC                                       ; $0DA92B |
@@ -6124,7 +6125,7 @@ CODE_0DAFC9:
   SEP #$10                                  ; $0DAFE7 |
 
 CODE_0DAFE9:
-  JSL $03AF23                               ; $0DAFE9 |
+  JSL CODE_03AF23                           ; $0DAFE9 |
   LDY !s_spr_wildcard_1_lo,x                ; $0DAFED |
   BEQ CODE_0DAFF6                           ; $0DAFF0 |
   JSL $03A5B7                               ; $0DAFF2 |
@@ -6573,7 +6574,7 @@ CODE_0DB35A:
   STZ $611A                                 ; $0DB35A |
 
 CODE_0DB35D:
-  JSL $03AF23                               ; $0DB35D |
+  JSL CODE_03AF23                           ; $0DB35D |
   TXY                                       ; $0DB361 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0DB362 |
   ASL A                                     ; $0DB364 |
@@ -6620,7 +6621,7 @@ CODE_0DB3B8:
   RTL                                       ; $0DB3B8 |
 
 CODE_0DB3B9:
-  JSL $03AA52                               ; $0DB3B9 |
+  JSL CODE_03AA52                           ; $0DB3B9 |
   LDA #$FFF8                                ; $0DB3BD |
   LDY !s_spr_wildcard_6_hi_dp,x             ; $0DB3C0 |
   BEQ CODE_0DB3C7                           ; $0DB3C2 |
@@ -7312,7 +7313,7 @@ CODE_0DB945:
   STA !s_spr_y_pixel_pos,x                  ; $0DB956 |
 
 CODE_0DB959:
-  JSL $03AF23                               ; $0DB959 |
+  JSL CODE_03AF23                           ; $0DB959 |
   TXY                                       ; $0DB95D |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0DB95E |
   ASL A                                     ; $0DB960 |
@@ -7416,8 +7417,8 @@ init_spinning_log:
   dw $BB2E                                  ; $0DBA24 |
 
 main_spinning_log:
-  JSL $03AA52                               ; $0DBA26 |
-  JSL $03AF23                               ; $0DBA2A |
+  JSL CODE_03AA52                           ; $0DBA26 |
+  JSL CODE_03AF23                           ; $0DBA2A |
   TXY                                       ; $0DBA2E |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0DBA2F |
   ASL A                                     ; $0DBA31 |
@@ -7589,7 +7590,8 @@ CODE_0DBB68:
   dw $8000                                  ; $0DBB7C |
   dw $BD11                                  ; $0DBB7E |
 
-  JSL $03AF23                               ; $0DBB80 |
+main_flower_pot:
+  JSL CODE_03AF23                           ; $0DBB80 |
   LDY !s_spr_wildcard_6_lo_dp,x             ; $0DBB84 |
   BNE CODE_0DBB8B                           ; $0DBB86 |
   STZ !s_spr_x_speed_lo,x                   ; $0DBB88 |
@@ -7838,7 +7840,7 @@ CODE_0DBD10:
 
 CODE_0DBD2D:
   DEC !s_spr_anim_frame,x                   ; $0DBD2D |
-  JSL $03A2C7                               ; $0DBD30 |
+  JSL CODE_03A2C7                           ; $0DBD30 |
   BCC CODE_0DBD3A                           ; $0DBD34 |
   JSL despawn_sprite_free_slot              ; $0DBD36 |
 
@@ -7937,7 +7939,7 @@ CODE_0DBDC1:
   BRA CODE_0DBDF3                           ; $0DBDE7 |
 
 CODE_0DBDE9:
-  JSL $03A2C7                               ; $0DBDE9 |
+  JSL CODE_03A2C7                           ; $0DBDE9 |
   BCC CODE_0DBDF3                           ; $0DBDED |
   JML despawn_sprite_stage_ID               ; $0DBDEF |
 
@@ -7989,7 +7991,7 @@ CODE_0DBE22:
   REP #$20                                  ; $0DBE51 |
 
 CODE_0DBE53:
-  JSL $03AF23                               ; $0DBE53 |
+  JSL CODE_03AF23                           ; $0DBE53 |
   JSR CODE_0DBF4A                           ; $0DBE57 |
   LDA !s_spr_x_accel_ceiling,x              ; $0DBE5A |
   BNE CODE_0DBE71                           ; $0DBE5D |
@@ -8499,7 +8501,7 @@ main_tap_tap:
   RTL                                       ; $0DC272 | Return
 
 .check_collision
-  JSL $03AF23                               ; $0DC273 | handles frozen and projectile state
+  JSL CODE_03AF23                           ; $0DC273 | handles frozen and projectile state
   LDY !s_spr_collision_id,x                 ; $0DC277 |\
   BNE .check_collision_type                 ; $0DC27A |/ If collision with sprite/player
 
@@ -8852,7 +8854,7 @@ CODE_0DC504:
   BNE CODE_0DC4D4                           ; $0DC509 |
   RTS                                       ; $0DC50B |
 
-; .init_baby_bowser
+init_baby_bowser:
   RTL                                       ; $0DC50C |
 
 ; baby bowser states
@@ -8958,7 +8960,7 @@ CODE_0DC5BC:
   STA !r_reg_tm_mirror                      ; $0DC5BC |
 
 CODE_0DC5BF:
-  JSL $03AF23                               ; $0DC5BF |
+  JSL CODE_03AF23                           ; $0DC5BF |
   BRA CODE_0DC5D8                           ; $0DC5C3 |
 
 CODE_0DC5C5:
@@ -8981,7 +8983,7 @@ CODE_0DC5D8:
 CODE_0DC5E6:
   LDA #$0011                                ; $0DC5E6 |
   STA $0B83                                 ; $0DC5E9 |
-  JSL $03AF23                               ; $0DC5EC |
+  JSL CODE_03AF23                           ; $0DC5EC |
 
 CODE_0DC5F0:
   TXY                                       ; $0DC5F0 |
@@ -10233,7 +10235,7 @@ CODE_0DD0AC:
   LDX #$08                                  ; $0DD299 |
   LDA #$BD37                                ; $0DD29B |
   JSL r_gsu_init_1                          ; $0DD29E | GSU init
-  JSL $00BE39                               ; $0DD2A2 | return address + 8
+  JSL CODE_00BE39                           ; $0DD2A2 | return address + 8
 
   dw $56D0, $027E, $703A, $0348             ; $0DD2A6 |
 
@@ -10342,15 +10344,15 @@ CODE_0DD375:
   LDX #$09                                  ; $0DD39C |
   LDA #$F572                                ; $0DD39E |
   JSL r_gsu_init_1                          ; $0DD3A1 | GSU init
-  JSL $00BE39                               ; $0DD3A5 | return address + 8
+  JSL CODE_00BE39                           ; $0DD3A5 | return address + 8
 
   dw $56DE, $007F, $7058, $00D2             ; $0DD3A9 |
 
-  JSL $00BE39                               ; $0DD3B1 | return address + 8
+  JSL CODE_00BE39                           ; $0DD3B1 | return address + 8
 
   dw $5894, $D27F, $7058, $01A4             ; $0DD3B5 |
 
-  JSL $00BE39                               ; $0DD3BD | return address + 8
+  JSL CODE_00BE39                           ; $0DD3BD | return address + 8
 
   dw $5388, $5E7E, $7038, $01A4             ; $0DD3C1 |
 
@@ -10421,11 +10423,11 @@ CODE_0DD43B:
   LDA $00                                   ; $0DD451 |
   CPY #$4000                                ; $0DD453 |
   BCS CODE_0DD45E                           ; $0DD456 |
-  JSL $00BF86                               ; $0DD458 |
+  JSL CODE_00BF86                           ; $0DD458 |
   BRA CODE_0DD464                           ; $0DD45C |
 
 CODE_0DD45E:
-  JSL $00BEA6                               ; $0DD45E |
+  JSL CODE_00BEA6                           ; $0DD45E |
   LSR $00                                   ; $0DD462 |
 
 CODE_0DD464:
@@ -10468,7 +10470,7 @@ CODE_0DD464:
   STA $0C18                                 ; $0DD4BA |
   LDA #$0800                                ; $0DD4BD |
   LDX #$00FF                                ; $0DD4C0 |
-  JSL $00BF4A                               ; $0DD4C3 |
+  JSL CODE_00BF4A                           ; $0DD4C3 |
   SEP #$10                                  ; $0DD4C7 |
   LDX $12                                   ; $0DD4C9 |
   RTS                                       ; $0DD4CB |
@@ -11369,7 +11371,7 @@ CODE_0DDECD:
   ADC #$0080                                ; $0DDEDA |
   STA $02                                   ; $0DDEDD |
   LDA #$000E                                ; $0DDEDF |
-  JSL $00BF16                               ; $0DDEE2 |
+  JSL CODE_00BF16                           ; $0DDEE2 |
   DEC $04                                   ; $0DDEE6 |
   BNE CODE_0DDECD                           ; $0DDEE8 |
   SEP #$10                                  ; $0DDEEA |
@@ -11900,6 +11902,7 @@ CODE_0DEAA8:
 CODE_0DEAD2:
   RTL                                       ; $0DEAD2 |
 
+init_bowser_room_kamek:
   LDA #$0080                                ; $0DEAD3 |
   STA !s_cam_x_right_boundary               ; $0DEAD6 |
   LDA #$0134                                ; $0DEAD9 |
@@ -11956,9 +11959,10 @@ CODE_0DEB58:
   dw $ED47, $EDAC, $EE00, $EEAB             ; $0DEB64 |
   dw $EEEC, $EFF1                           ; $0DEB6C |
 
+main_bower_room_kamek:
   LDY !s_spr_anim_frame,x                   ; $0DEB70 |
   BNE CODE_0DEB8E                           ; $0DEB73 |
-  JSL $03AA52                               ; $0DEB75 |
+  JSL CODE_03AA52                           ; $0DEB75 |
   REP #$10                                  ; $0DEB79 |
   LDA !s_spr_oam_pointer,x                  ; $0DEB7B |
   CLC                                       ; $0DEB7E |
@@ -12452,7 +12456,7 @@ CODE_0DEFA2:
   dw $0001, $FFFF                           ; $0DEFED |
 
   TYX                                       ; $0DEFF1 |
-  JSL $03A2C7                               ; $0DEFF2 |
+  JSL CODE_03A2C7                           ; $0DEFF2 |
   BCC CODE_0DF000                           ; $0DEFF6 |
   INC $105C                                 ; $0DEFF8 |
   PLA                                       ; $0DEFFB |
@@ -12485,10 +12489,12 @@ CODE_0DF022:
 
 CODE_0DF034:
   JMP CODE_0DEFA2                           ; $0DF034 |
+Return_0DF037:
   RTL                                       ; $0DF037 |
 
+main_ground_shake:
   JSR CODE_0DF058                           ; $0DF038 |
-  JSL $03AF23                               ; $0DF03B |
+  JSL CODE_03AF23                           ; $0DF03B |
   JSR CODE_0DF082                           ; $0DF03F |
   JSR CODE_0DF0A3                           ; $0DF042 |
   JSR CODE_0DF0B9                           ; $0DF045 |
@@ -12769,7 +12775,7 @@ CODE_0DF286:
   LDY #$0070                                ; $0DF288 |
   STY $0001                                 ; $0DF28B |
   LDY $0C18                                 ; $0DF28E |
-  JSL $00BEA6                               ; $0DF291 |
+  JSL CODE_00BEA6                           ; $0DF291 |
   SEP #$10                                  ; $0DF295 |
   LDX $12                                   ; $0DF297 |
   LDA $00                                   ; $0DF299 |
@@ -12888,7 +12894,7 @@ CODE_0DF382:
   STA $0001                                 ; $0DF393 |
   LDY #$5800                                ; $0DF396 |
   LDA #$0800                                ; $0DF399 |
-  JSL $00BEA6                               ; $0DF39C |
+  JSL CODE_00BEA6                           ; $0DF39C |
   SEP #$10                                  ; $0DF3A0 |
   LDX #$1C                                  ; $0DF3A2 |
 
@@ -13082,9 +13088,11 @@ CODE_0DF608:
 
   dw $0000, $0020, $0040                    ; $0DF631 |
 
-  db $22, $EB, $AE, $03, $A0, $04           ; $0DF637 |
+init_bowser_quake:
+  JSL $03AEEB                               ; $0DF637 |
+  LDY #$04                                  ; $0DF63B |
 
-CODE_0DF63D:
+.loop
   PHY                                       ; $0DF63D |
   LDA $F625,y                               ; $0DF63E |
   STA !gsu_r5                               ; $0DF641 |
@@ -13103,7 +13111,7 @@ CODE_0DF63D:
   PLY                                       ; $0DF668 |
   DEY                                       ; $0DF669 |
   DEY                                       ; $0DF66A |
-  BPL CODE_0DF63D                           ; $0DF66B |
+  BPL .loop                                 ; $0DF66B |
   INC $0CF9                                 ; $0DF66D |
   LDY #$1C                                  ; $0DF670 |
   LDX !r_interrupt_mode                     ; $0DF672 |
@@ -13161,9 +13169,13 @@ CODE_0DF6AA:
 
   dw $D000, $3000                           ; $0DF6F6 |
 
-  db $40, $10, $50, $20, $22, $23, $AF, $03 ; $0DF6FA |
-  db $AD, $72, $10, $D0, $03, $4C, $C1, $F7 ; $0DF702 |
-
+  db $40, $10, $50, $20                     ; $0DF6FA |
+main_bowser_quake:
+  JSL CODE_03AF23                           ; $0DF6FE |
+  LDA $1072                                 ; $0DF702 |
+  BNE .skip                                 ; $0DF705 |
+  JMP CODE_0DF7C1                           ; $0DF707 |
+.skip
   LDA $14                                   ; $0DF70A |
   AND #$000F                                ; $0DF70C |
   ORA #$0040                                ; $0DF70F |
@@ -13252,6 +13264,7 @@ CODE_0DF7A5:
 CODE_0DF7C0:
   RTL                                       ; $0DF7C0 |
 
+CODE_0DF7C1:
   LDA !s_spr_wildcard_4_lo_dp,x             ; $0DF7C1 |
   BNE CODE_0DF7F1                           ; $0DF7C3 |
   LDY !s_spr_wildcard_2_lo,x                ; $0DF7C5 |
@@ -13580,7 +13593,7 @@ main_baby_bowser_egg:
   RTL                                       ; $0DFA73 |
 
 .CODE_0DFA74
-  JSL $03B9DD                               ; $0DFA74 |
+  JSL CODE_03B9DD                           ; $0DFA74 |
   LDA !s_spr_wildcard_6_lo_dp,x             ; $0DFA78 |
   BEQ .CODE_0DFA7F                          ; $0DFA7A |
   JMP .CODE_0DFA8F                          ; $0DFA7C |
@@ -13683,7 +13696,7 @@ CODE_0DFB4B:
 
 CODE_0DFB4F:
   STA !s_spr_wildcard_5_lo_dp,x             ; $0DFB4F |
-  JSL $03AF23                               ; $0DFB51 |
+  JSL CODE_03AF23                           ; $0DFB51 |
   JSL $0DFAD2                               ; $0DFB55 |
   LDA !s_spr_wildcard_4_lo_dp,x             ; $0DFB59 |
   CLC                                       ; $0DFB5B |
@@ -13724,7 +13737,7 @@ main_rubble:
   LSR A                                     ; $0DFB9B |
   LSR A                                     ; $0DFB9C |
   JSR update_bowser_distant_spr             ; $0DFB9D |
-  JSL $03AF23                               ; $0DFBA0 |
+  JSL CODE_03AF23                           ; $0DFBA0 |
   LDA !s_spr_y_speed_lo,x                   ; $0DFBA4 |
   BPL CODE_0DFBB2                           ; $0DFBA7 |
   LDA !s_spr_cam_y_pos,x                    ; $0DFBA9 |
@@ -13742,8 +13755,10 @@ CODE_0DFBB2:
 CODE_0DFBBA:
   DEC $1072                                 ; $0DFBBA |
   JML despawn_sprite_stage_ID               ; $0DFBBD |
+Return_0DFBC1:
   RTL                                       ; $0DFBC1 |
 
+CODE_0DFBC2:
   LDY !s_spr_draw_priority,x                ; $0DFBC2 |
   BPL CODE_0DFBD5                           ; $0DFBC5 |
   LDA !r_frame_counter_global               ; $0DFBC7 |
@@ -13753,7 +13768,7 @@ CODE_0DFBBA:
   JSL $02D995                               ; $0DFBD1 |
 
 CODE_0DFBD5:
-  JSL $03AF23                               ; $0DFBD5 |
+  JSL CODE_03AF23                           ; $0DFBD5 |
   LDA !s_spr_timer_1,x                      ; $0DFBD9 |
   BNE CODE_0DFBE2                           ; $0DFBDC |
   JML despawn_sprite_stage_ID               ; $0DFBDE |

--- a/disassembly/bank0E.asm
+++ b/disassembly/bank0E.asm
@@ -4947,7 +4947,7 @@ CODE_0EA824:
   STA !s_spr_wildcard_1_lo,x                ; $0EA824 |
   TYX                                       ; $0EA827 |
   LDY #$0000                                ; $0EA828 |
-  LDA $00E9D4,x                             ; $0EA82B |
+  LDA raphael_mode7_matrix_b_c,x            ; $0EA82B |
   ASL A                                     ; $0EA82F |
   ASL A                                     ; $0EA830 |
   BMI CODE_0EA836                           ; $0EA831 |
@@ -4956,7 +4956,7 @@ CODE_0EA824:
 CODE_0EA836:
   STA $02                                   ; $0EA836 |
   STY $04                                   ; $0EA838 |
-  LDA $00E954,x                             ; $0EA83A |
+  LDA raphael_mode7_matrix_a_d,x            ; $0EA83A |
   ASL A                                     ; $0EA83E |
   ASL A                                     ; $0EA83F |
   SEP #$10                                  ; $0EA840 |
@@ -6618,9 +6618,10 @@ CODE_0EB47F:
   JSL $03B25B                               ; $0EB490 |
 
 CODE_0EB494:
-  JSL $0EB4AE                               ; $0EB494 |
+  JSL CODE_0EB4AE                           ; $0EB494 |
   RTS                                       ; $0EB498 |
 
+CODE_0EB499:
   PHB                                       ; $0EB499 |
   PHK                                       ; $0EB49A |
   PLB                                       ; $0EB49B |
@@ -6630,13 +6631,14 @@ CODE_0EB494:
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0EB4A1 |
   CPY #$02                                  ; $0EB4A3 |
   BNE CODE_0EB4AB                           ; $0EB4A5 |
-  JSL $0EB4AE                               ; $0EB4A7 |
+  JSL CODE_0EB4AE                           ; $0EB4A7 |
 
 CODE_0EB4AB:
   PLD                                       ; $0EB4AB |
   PLB                                       ; $0EB4AC |
   RTL                                       ; $0EB4AD |
 
+CODE_0EB4AE:
   LDA #$0020                                ; $0EB4AE |
   STA !s_spr_timer_3,x                      ; $0EB4B1 |
   LDA #$00FF                                ; $0EB4B4 |

--- a/disassembly/bank0E.asm
+++ b/disassembly/bank0E.asm
@@ -23,7 +23,7 @@ main_cannonball:
   BMI CODE_0E809E                           ; $0E8021 |
 
 CODE_0E8023:
-  JSL $03AF23                               ; $0E8023 |
+  JSL CODE_03AF23                           ; $0E8023 |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0E8027 |
   BEQ CODE_0E802F                           ; $0E8029 |
   JSR CODE_0E814D                           ; $0E802B |
@@ -346,7 +346,7 @@ CODE_0E828E:
   STA $600A,y                               ; $0E8291 |
   STA $6012,y                               ; $0E8294 |
   SEP #$10                                  ; $0E8297 |
-  JSL $03AF23                               ; $0E8299 |
+  JSL CODE_03AF23                           ; $0E8299 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $0E829D |
   INC A                                     ; $0E82A0 |
   INC A                                     ; $0E82A1 |
@@ -590,7 +590,7 @@ main_incoming_chomp:
   JSL $03ABFA                               ; $0E8460 |
 
 CODE_0E8464:
-  JSL $03AF23                               ; $0E8464 |
+  JSL CODE_03AF23                           ; $0E8464 |
   TXY                                       ; $0E8468 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0E8469 |
   ASL A                                     ; $0E846B |
@@ -1497,7 +1497,7 @@ main_incoming_chomp_flock:
   JSR CODE_0E8C1C                           ; $0E8BE8 |
 
 CODE_0E8BEB:
-  JSL $03AF23                               ; $0E8BEB |
+  JSL CODE_03AF23                           ; $0E8BEB |
   LDA !s_spr_cam_x_pos,x                    ; $0E8BEF |
   CLC                                       ; $0E8BF2 |
   ADC #$00A0                                ; $0E8BF3 |
@@ -1814,7 +1814,7 @@ main_incoming_chomp_falling_shadow:
   JSL $03ABFA                               ; $0E8E0D |
 
 CODE_0E8E11:
-  JSL $03AF23                               ; $0E8E11 |
+  JSL CODE_03AF23                           ; $0E8E11 |
   LDA !r_frame_counter_global               ; $0E8E15 |
   CMP !s_spr_wildcard_4_lo_dp,x             ; $0E8E18 |
   BEQ CODE_0E8E22                           ; $0E8E1A |
@@ -2002,7 +2002,7 @@ CODE_0E8FAB:
   AND #$FFF0                                ; $0E8FC1 |
   ORA $8F75,y                               ; $0E8FC4 |
   STA !s_spr_y_pixel_pos,x                  ; $0E8FC7 |
-  JSL $03AF23                               ; $0E8FCA |
+  JSL CODE_03AF23                           ; $0E8FCA |
   JSL despawn_sprite_threshold_B            ; $0E8FCE |
   BCC CODE_0E8FE5                           ; $0E8FD2 |
   LDY !s_spr_id,x                           ; $0E8FD4 |
@@ -2668,12 +2668,12 @@ CODE_0E952B:
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0E952B |
   CPY #$05                                  ; $0E952D |
   BNE CODE_0E9537                           ; $0E952F |
-  JSL $03AF23                               ; $0E9531 |
+  JSL CODE_03AF23                           ; $0E9531 |
   BRA CODE_0E9541                           ; $0E9535 |
 
 CODE_0E9537:
   JSR CODE_0E95AE                           ; $0E9537 |
-  JSL $03AF23                               ; $0E953A |
+  JSL CODE_03AF23                           ; $0E953A |
   JSR CODE_0E971F                           ; $0E953E |
 
 CODE_0E9541:
@@ -2699,7 +2699,7 @@ CODE_0E9560:
   RTL                                       ; $0E9560 |
 
 CODE_0E9561:
-  JSL $03AF23                               ; $0E9561 |
+  JSL CODE_03AF23                           ; $0E9561 |
   LDY $0C7C                                 ; $0E9565 |
   BEQ CODE_0E9576                           ; $0E9568 |
   LDA !s_spr_cam_y_pos,x                    ; $0E956A |
@@ -3371,6 +3371,7 @@ init_fat_goonie:
   LDA !s_spr_wildcard_1_lo,x                ; $0E9A9B |
   INC A                                     ; $0E9A9E |
   BNE CODE_0E9ACD                           ; $0E9A9F |
+init_bowling_goonie:
   INC !s_spr_wildcard_4_lo_dp,x             ; $0E9AA1 |
   INC !s_spr_anim_frame,x                   ; $0E9AA3 |
   LDY #$0A                                  ; $0E9AA6 |
@@ -3449,7 +3450,7 @@ main_fat_goonie:
   STZ !s_spr_bitwise_settings_3,x           ; $0E9B43 |
 
 CODE_0E9B46:
-  JSL $03AF23                               ; $0E9B46 |
+  JSL CODE_03AF23                           ; $0E9B46 |
   TXY                                       ; $0E9B4A |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0E9B4B |
   ASL A                                     ; $0E9B4D |
@@ -3606,7 +3607,7 @@ CODE_0E9D3E:
   RTS                                       ; $0E9D8A |
 
 CODE_0E9D8B:
-  JSL $03AA52                               ; $0E9D8B |
+  JSL CODE_03AA52                           ; $0E9D8B |
   REP #$10                                  ; $0E9D8F |
   LDY !s_spr_oam_pointer,x                  ; $0E9D91 |
   LDA #$8000                                ; $0E9D94 |
@@ -4128,7 +4129,7 @@ CODE_0EA1B4:
   SEP #$10                                  ; $0EA1B7 |
 
 CODE_0EA1B9:
-  JSL $03AF23                               ; $0EA1B9 |
+  JSL CODE_03AF23                           ; $0EA1B9 |
   JSR CODE_0EA1CF                           ; $0EA1BD |
   TXY                                       ; $0EA1C0 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0EA1C1 |
@@ -4529,7 +4530,7 @@ CODE_0EA4E3:
 
 main_parent_huffin_puffin:
   JSR CODE_0EA519                           ; $0EA4F5 |
-  JSL $03AF23                               ; $0EA4F8 |
+  JSL CODE_03AF23                           ; $0EA4F8 |
   JSR CODE_0EA533                           ; $0EA4FC |
   STZ $0E                                   ; $0EA4FF |
   TXY                                       ; $0EA501 |
@@ -5010,7 +5011,7 @@ CODE_0EA88E:
   STA !s_spr_y_speed_lo,x                   ; $0EA895 |
 
 CODE_0EA898:
-  JSL $03B9DD                               ; $0EA898 |
+  JSL CODE_03B9DD                           ; $0EA898 |
   LDA !s_spr_wildcard_6_lo_dp,x             ; $0EA89C |
   BEQ CODE_0EA8A3                           ; $0EA89E |
   JMP CODE_0EAA25                           ; $0EA8A0 |
@@ -5354,7 +5355,7 @@ main_blow_hard:
   STZ !s_spr_bitwise_settings_3,x           ; $0EAB00 |
 
 CODE_0EAB03:
-  JSL $03AF23                               ; $0EAB03 |
+  JSL CODE_03AF23                           ; $0EAB03 |
   JSR CODE_0EABC0                           ; $0EAB07 |
   JSR CODE_0EABAC                           ; $0EAB0A |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0EAB0D |
@@ -5383,7 +5384,7 @@ CODE_0EAB30:
   RTS                                       ; $0EAB35 |
 
 CODE_0EAB36:
-  JSL $03AA52                               ; $0EAB36 |
+  JSL CODE_03AA52                           ; $0EAB36 |
   LDA !s_spr_x_hitbox_center,x              ; $0EAB3A |
   SEC                                       ; $0EAB3D |
   SBC !s_bg1_cam_x                          ; $0EAB3E |
@@ -6245,7 +6246,7 @@ main_green_needlenose:
   JSR CODE_0EB27C                           ; $0EB1BB |
 
 CODE_0EB1BE:
-  JSL $03AF23                               ; $0EB1BE |
+  JSL CODE_03AF23                           ; $0EB1BE |
   LDA !s_spr_id,x                           ; $0EB1C2 |
   CMP #$00A2                                ; $0EB1C5 |
   BNE CODE_0EB1CD                           ; $0EB1C8 |
@@ -6478,10 +6479,10 @@ CODE_0EB383:
   BRA CODE_0EB39B                           ; $0EB395 |
 
 CODE_0EB397:
-  JSL $03AA52                               ; $0EB397 |
+  JSL CODE_03AA52                           ; $0EB397 |
 
 CODE_0EB39B:
-  JSL $02A007                               ; $0EB39B |
+  JSL CODE_02A007                           ; $0EB39B |
   RTL                                       ; $0EB39F |
 
   dw $B41A, $B42A, $B457, $B525             ; $0EB3A0 |
@@ -6489,8 +6490,8 @@ CODE_0EB39B:
   dw $4010, $4020                           ; $0EB3A8 |
 
 main_flower:
-  JSL $03AA52                               ; $0EB3AC |
-  JSL $03AF23                               ; $0EB3B0 |
+  JSL CODE_03AA52                           ; $0EB3AC |
+  JSL CODE_03AF23                           ; $0EB3B0 |
   TXY                                       ; $0EB3B4 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0EB3B5 |
   ASL A                                     ; $0EB3B7 |
@@ -6709,7 +6710,7 @@ CODE_0EB54D:
 ; this flower is spriteset-specific
 init_flower_2:
   JSL $03D406                               ; $0EB54E |
-  JSL $02A007                               ; $0EB552 |
+  JSL CODE_02A007                           ; $0EB552 |
   RTL                                       ; $0EB556 |
 
   dw $B56C                                  ; $0EB557 |
@@ -6719,7 +6720,7 @@ init_flower_2:
 
 ; this flower is spriteset-specific
 main_flower_2:
-  JSL $03AF23                               ; $0EB55F |
+  JSL CODE_03AF23                           ; $0EB55F |
   TXY                                       ; $0EB563 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0EB564 |
   ASL A                                     ; $0EB566 |
@@ -6812,7 +6813,7 @@ main_red_pow_switch:
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0EB601 |
   CPY #$03                                  ; $0EB603 |
   BEQ CODE_0EB60E                           ; $0EB605 |
-  JSL $03AA52                               ; $0EB607 |
+  JSL CODE_03AA52                           ; $0EB607 |
   JSR CODE_0EB61A                           ; $0EB60B |
 
 CODE_0EB60E:
@@ -7204,7 +7205,7 @@ CODE_0EB91B:
 
 main_cactus_jack:
   STZ !s_spr_facing_dir,x                   ; $0EB92E |
-  JSL $03AA52                               ; $0EB931 |
+  JSL CODE_03AA52                           ; $0EB931 |
   LDA !s_spr_state,x                        ; $0EB935 |
   CMP #$0010                                ; $0EB938 |
   BEQ CODE_0EB958                           ; $0EB93B |
@@ -7240,7 +7241,7 @@ CODE_0EB962:
   BEQ CODE_0EB979                           ; $0EB973 |
 
 CODE_0EB975:
-  JSL $03AF23                               ; $0EB975 |
+  JSL CODE_03AF23                           ; $0EB975 |
 
 CODE_0EB979:
   JSR CODE_0EB998                           ; $0EB979 |
@@ -7263,7 +7264,7 @@ CODE_0EB997:
   RTL                                       ; $0EB997 |
 
 CODE_0EB998:
-  JSL $03A2C7                               ; $0EB998 |
+  JSL CODE_03A2C7                           ; $0EB998 |
   BCS CODE_0EB9CB                           ; $0EB99C |
 
 CODE_0EB99E:
@@ -7927,7 +7928,7 @@ CODE_0EBEC8:
   RTL                                       ; $0EBED4 |
 
 main_chomp_rock:
-  JSL $03A2C7                               ; $0EBED5 |
+  JSL CODE_03A2C7                           ; $0EBED5 |
   BCC CODE_0EBEE8                           ; $0EBED9 |
   JSR CODE_0EBF49                           ; $0EBEDB |
   JSR CODE_0EC54A                           ; $0EBEDE |
@@ -7936,8 +7937,8 @@ main_chomp_rock:
   RTL                                       ; $0EBEE7 |
 
 CODE_0EBEE8:
-  JSL $03AA52                               ; $0EBEE8 |
-  JSL $03AF23                               ; $0EBEEC |
+  JSL CODE_03AA52                           ; $0EBEE8 |
+  JSL CODE_03AF23                           ; $0EBEEC |
   STZ !s_spr_facing_dir,x                   ; $0EBEF0 |
   JSR CODE_0EBF49                           ; $0EBEF3 |
   JSL $0EC365                               ; $0EBEF6 |
@@ -9225,6 +9226,7 @@ CODE_0EC8D3:
   STA !s_spr_bitwise_settings_1,x           ; $0EC8D3 |
   RTS                                       ; $0EC8D6 |
 
+init_snowball:
   JSL $03AEEB                               ; $0EC8D7 |
   LDY !r_cur_stage                          ; $0EC8DB |
   CPY #$31                                  ; $0EC8DE |
@@ -9238,8 +9240,9 @@ CODE_0EC8E8:
   STA !s_spr_gsu_morph_1_lo,x               ; $0EC8EE |
   RTL                                       ; $0EC8F1 |
 
+main_snowball:
   JSL $03AB1C                               ; $0EC8F2 |
-  JSL $03AF23                               ; $0EC8F6 |
+  JSL CODE_03AF23                           ; $0EC8F6 |
   STZ !s_spr_facing_dir,x                   ; $0EC8FA |
   JSL $0EC365                               ; $0EC8FD |
   JSR CODE_0EBFBB                           ; $0EC901 |
@@ -9398,7 +9401,7 @@ CODE_0ECA1E:
   JSR CODE_0ECAF8                           ; $0ECA29 |
 
 CODE_0ECA2C:
-  JSL $03A2C7                               ; $0ECA2C |
+  JSL CODE_03A2C7                           ; $0ECA2C |
   BCS CODE_0ECA35                           ; $0ECA30 |
   JMP CODE_0ECA8D                           ; $0ECA32 |
 
@@ -9409,13 +9412,13 @@ CODE_0ECA35:
 
 CODE_0ECA3A:
   JSR CODE_0ECCC7                           ; $0ECA3A |
-  JSL $03A2C7                               ; $0ECA3D |
+  JSL CODE_03A2C7                           ; $0ECA3D |
   BCC CODE_0ECA47                           ; $0ECA41 |
   JSL despawn_sprite_stage_ID               ; $0ECA43 |
 
 CODE_0ECA47:
   PLA                                       ; $0ECA47 |
-  JSL $03AF23                               ; $0ECA48 |
+  JSL CODE_03AF23                           ; $0ECA48 |
   LDA !s_spr_id,x                           ; $0ECA4C |
   CMP #$0020                                ; $0ECA4F |
   BEQ CODE_0ECA66                           ; $0ECA52 |
@@ -9445,7 +9448,7 @@ CODE_0ECA77:
   BNE CODE_0ECA8C                           ; $0ECA86 |
 
 CODE_0ECA88:
-  JSL $03AF23                               ; $0ECA88 |
+  JSL CODE_03AF23                           ; $0ECA88 |
 
 CODE_0ECA8C:
   RTL                                       ; $0ECA8C |
@@ -9453,7 +9456,7 @@ CODE_0ECA8C:
 CODE_0ECA8D:
   PLA                                       ; $0ECA8D |
   STA $00                                   ; $0ECA8E |
-  JSL $03AF23                               ; $0ECA90 |
+  JSL CODE_03AF23                           ; $0ECA90 |
   LDA $00                                   ; $0ECA94 |
   PHA                                       ; $0ECA96 |
   RTS                                       ; $0ECA97 |
@@ -9789,7 +9792,7 @@ CODE_0ECCF3:
 CODE_0ECCF9:
   LDY !s_spr_wildcard_2_lo,x                ; $0ECCF9 |
   BEQ CODE_0ECD12                           ; $0ECCFC |
-  JSL $03A2C7                               ; $0ECCFE |
+  JSL CODE_03A2C7                           ; $0ECCFE |
   BCC CODE_0ECD30                           ; $0ECD02 |
   STZ !s_spr_x_speed_lo,x                   ; $0ECD04 |
   STZ !s_spr_x_accel,x                      ; $0ECD07 |
@@ -9798,7 +9801,7 @@ CODE_0ECCF9:
   BRA CODE_0ECD30                           ; $0ECD10 |
 
 CODE_0ECD12:
-  JSL $03A2C7                               ; $0ECD12 |
+  JSL CODE_03A2C7                           ; $0ECD12 |
   BCS CODE_0ECD4F                           ; $0ECD16 |
   RTS                                       ; $0ECD18 |
 
@@ -9835,14 +9838,14 @@ CODE_0ECD4F:
   JML despawn_sprite_stage_ID               ; $0ECD50 |
   LDY !s_spr_wildcard_2_lo,x                ; $0ECD54 |
   BEQ CODE_0ECD67                           ; $0ECD57 |
-  JSL $03A2C7                               ; $0ECD59 |
+  JSL CODE_03A2C7                           ; $0ECD59 |
   BCC CODE_0ECD30                           ; $0ECD5D |
   STZ !s_spr_x_speed_lo,x                   ; $0ECD5F |
   STZ !s_spr_x_accel,x                      ; $0ECD62 |
   BRA CODE_0ECD30                           ; $0ECD65 |
 
 CODE_0ECD67:
-  JSL $03A2C7                               ; $0ECD67 |
+  JSL CODE_03A2C7                           ; $0ECD67 |
   BCS CODE_0ECD4F                           ; $0ECD6B |
   RTS                                       ; $0ECD6D |
 
@@ -11284,7 +11287,7 @@ CODE_0ED830:
 CODE_0ED83C:
   RTS                                       ; $0ED83C |
 
-headbop_bandit:
+head_bop_bandit:
   JSR CODE_0ECCC7                           ; $0ED83D |
   JML $039F9F                               ; $0ED840 |
   TXY                                       ; $0ED844 |
@@ -11351,7 +11354,7 @@ main_coin_bandit:
   CMP #$0010                                ; $0ED8BC |
   BNE CODE_0ED8D9                           ; $0ED8BF |
   JSR CODE_0ED956                           ; $0ED8C1 |
-  JSL $03A2C7                               ; $0ED8C4 |
+  JSL CODE_03A2C7                           ; $0ED8C4 |
   BCC CODE_0ED8E8                           ; $0ED8C8 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $0ED8CA |
   BMI CODE_0ED8D3                           ; $0ED8CC |
@@ -11373,7 +11376,7 @@ CODE_0ED8E5:
   JSR CODE_0ED9C2                           ; $0ED8E5 |
 
 CODE_0ED8E8:
-  JSL $03AF23                               ; $0ED8E8 |
+  JSL CODE_03AF23                           ; $0ED8E8 |
   LDA #$0040                                ; $0ED8EC |
   STA !s_spr_y_accel,x                      ; $0ED8EF |
   TXY                                       ; $0ED8F2 |
@@ -11702,7 +11705,7 @@ CODE_0EDB5B:
   BRA CODE_0EDBBE                           ; $0EDB74 |
 
 CODE_0EDB76:
-  JSL $03A2C7                               ; $0EDB76 |
+  JSL CODE_03A2C7                           ; $0EDB76 |
   BCC CODE_0EDBBE                           ; $0EDB7A |
   LDY !s_spr_wildcard_5_lo_dp,x             ; $0EDB7C |
   CPY #$F001                                ; $0EDB7E |
@@ -11782,7 +11785,7 @@ CODE_0EDBBE:
   RTL                                       ; $0EDC31 |
 
 CODE_0EDC32:
-  JSL $03AF23                               ; $0EDC32 |
+  JSL CODE_03AF23                           ; $0EDC32 |
   TXY                                       ; $0EDC36 |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0EDC37 |
   ASL A                                     ; $0EDC39 |
@@ -12380,7 +12383,7 @@ main_frog_pirate:
 
 CODE_0EE046:
   JSR CODE_0EE1B3                           ; $0EE046 |
-  JSL $03AF23                               ; $0EE049 |
+  JSL CODE_03AF23                           ; $0EE049 |
 
 CODE_0EE04D:
   JSR CODE_0EE1D9                           ; $0EE04D |
@@ -12450,7 +12453,7 @@ CODE_0EE0D2:
   RTL                                       ; $0EE0D2 |
 
 CODE_0EE0D3:
-  JSL $03AF23                               ; $0EE0D3 |
+  JSL CODE_03AF23                           ; $0EE0D3 |
   JSR CODE_0EE1D9                           ; $0EE0D7 |
   JSR CODE_0EE519                           ; $0EE0DA |
   RTL                                       ; $0EE0DD |
@@ -12605,7 +12608,7 @@ CODE_0EE1E4:
   RTS                                       ; $0EE20B |
 
 CODE_0EE20C:
-  JSL $03A2C7                               ; $0EE20C |
+  JSL CODE_03A2C7                           ; $0EE20C |
   BCC CODE_0EE230                           ; $0EE210 |
   LDY !s_spr_wildcard_2_lo,x                ; $0EE212 |
   BNE CODE_0EE21C                           ; $0EE215 |
@@ -14881,7 +14884,7 @@ CODE_0EF847:
 main_fishin_lakitu:
   JSR CODE_0EF9FE                           ; $0EF86F |
   JSR CODE_0EF98E                           ; $0EF872 |
-  JSL $03AF23                               ; $0EF875 |
+  JSL CODE_03AF23                           ; $0EF875 |
   JSR CODE_0EFBC0                           ; $0EF879 |
   TXY                                       ; $0EF87C |
   LDA !s_spr_wildcard_5_lo_dp,x             ; $0EF87D |
@@ -15678,8 +15681,9 @@ CODE_0EFE78:
 CODE_0EFF1F:
   RTS                                       ; $0EFF1F |
 
+headbop_fishin_lakitu:
   JSR CODE_0EF9FE                           ; $0EFF20 |
-  JSL $03A2C7                               ; $0EFF23 |
+  JSL CODE_03A2C7                           ; $0EFF23 |
   BCC CODE_0EFF62                           ; $0EFF27 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $0EFF29 |
   BEQ CODE_0EFF3D                           ; $0EFF2B |

--- a/disassembly/bank0F.asm
+++ b/disassembly/bank0F.asm
@@ -1059,7 +1059,7 @@ CODE_0F88A4:
   TXY                                       ; $0F88A8 |
   REP #$10                                  ; $0F88A9 |
   TAX                                       ; $0F88AB |
-  LDA $00E954,x                             ; $0F88AC |
+  LDA raphael_mode7_matrix_a_d,x            ; $0F88AC |
   CMP #$8000                                ; $0F88B0 |
   ROR A                                     ; $0F88B3 |
   CMP #$8000                                ; $0F88B4 |
@@ -1069,7 +1069,7 @@ CODE_0F88A4:
   CLC                                       ; $0F88BC |
   ADC !s_spr_gsu_morph_1_lo,y               ; $0F88BD |
   STA !s_spr_x_pixel_pos,y                  ; $0F88C0 |
-  LDA $00E9D4,x                             ; $0F88C3 |
+  LDA raphael_mode7_matrix_b_c,x            ; $0F88C3 |
   CMP #$8000                                ; $0F88C7 |
   ROR A                                     ; $0F88CA |
   CMP #$8000                                ; $0F88CB |

--- a/disassembly/bank0F.asm
+++ b/disassembly/bank0F.asm
@@ -1,6 +1,6 @@
 org $0F8000
 
-init_GOAL:
+init_GOAL_text:
   LDY #$05                                  ; $0F8000 |
   STY !s_spr_wildcard_4_lo_dp,x             ; $0F8002 |
   LDX #$1C                                  ; $0F8004 |
@@ -15,7 +15,7 @@ CODE_0F8006:
   LDX $12                                   ; $0F8016 |
   RTL                                       ; $0F8018 |
 
-main_GOAL:
+main_GOAL_text:
   LDY !s_spr_draw_priority,x                ; $0F8019 |
   BMI CODE_0F805B                           ; $0F801C |
   LDA #$00E0                                ; $0F801E |
@@ -431,7 +431,7 @@ CODE_0F83AE:
 
 CODE_0F83B1:
   STA !s_spr_bitwise_settings_1,x           ; $0F83B1 |
-  JSL $03AF23                               ; $0F83B4 |
+  JSL CODE_03AF23                           ; $0F83B4 |
   JSL $03A5B7                               ; $0F83B8 |
   JSR CODE_0F85CB                           ; $0F83BC |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0F83BF |
@@ -726,6 +726,7 @@ CODE_0F85FC:
   STA $7782,y                               ; $0F8632 |
   RTS                                       ; $0F8635 |
 
+head_bop_crazee_daisy:
   LDA #$0039                                ; $0F8636 |\ play sound #$39
   JSL push_sound_queue                      ; $0F8639 |/
   LDA !s_spr_wildcard_2_lo,x                ; $0F863D |
@@ -744,7 +745,8 @@ init_stork:
 
   db $02, $03, $02, $01                     ; $0F865B |
 
-  JSL $03AF23                               ; $0F865F |
+main_stork:
+  JSL CODE_03AF23                           ; $0F865F |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0F8663 |
   TYX                                       ; $0F8665 |
   JMP ($8669,x)                             ; $0F8666 |
@@ -969,7 +971,7 @@ rotating_door_state_ptr:
 
 ; rotating door state $00: spinning
   LDX $12                                   ; $0F87FD |
-  JSL $03AF23                               ; $0F87FF |
+  JSL CODE_03AF23                           ; $0F87FF |
   LDY !s_spr_wildcard_1_lo,x                ; $0F8803 |
   LDA $105C,y                               ; $0F8806 |
   BEQ CODE_0F8813                           ; $0F8809 |
@@ -991,7 +993,7 @@ CODE_0F8813:
 
 ; rotating door state $02: falling
   LDX $12                                   ; $0F8825 |
-  JSL $03AF23                               ; $0F8827 |
+  JSL CODE_03AF23                           ; $0F8827 |
   LDA $7860,x                               ; $0F882B |
   AND #$0001                                ; $0F882E |
   BEQ CODE_0F8855                           ; $0F8831 |
@@ -1241,7 +1243,7 @@ init_dragonfly:
   RTL                                       ; $0F8A16 |
 
 main_dragonfly:
-  JSL $03AF23                               ; $0F8A17 | handle freeze/projectile
+  JSL CODE_03AF23                           ; $0F8A17 | handle freeze/projectile
   JSR CODE_0F8A33                           ; $0F8A1B |
   LDA !s_spr_timer_1,x                      ; $0F8A1E |
   BNE CODE_0F8A32                           ; $0F8A21 |
@@ -1347,7 +1349,7 @@ init_butterfly:
   RTL                                       ; $0F8AE8 |
 
 main_butterfly:
-  JSL $03AF23                               ; $0F8AE9 |
+  JSL CODE_03AF23                           ; $0F8AE9 |
   LDA !s_spr_timer_1,x                      ; $0F8AED |
   BNE CODE_0F8B01                           ; $0F8AF0 |
   LDA #$0004                                ; $0F8AF2 |
@@ -1438,7 +1440,7 @@ main_nipper_spore:
   JSL $0F8B5B                               ; $0F8BA5 |
 
 main_nipper_plant:
-  JSL $03AF23                               ; $0F8BA9 |
+  JSL CODE_03AF23                           ; $0F8BA9 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0F8BAD |
   TAX                                       ; $0F8BAF |
   JSR ($8BB8,x)                             ; $0F8BB0 |
@@ -1657,9 +1659,10 @@ CODE_0F8D44:
   db $02, $00, $04, $00, $02, $00, $04, $00 ; $0F8DA3 |
   db $02, $00, $04, $00, $02, $00           ; $0F8DAB |
 
+main_baby_luigi:
   JSR CODE_0F8E20                           ; $0F8DB1 |
   JSR CODE_0F8E49                           ; $0F8DB4 |
-  JSL $03AF23                               ; $0F8DB7 |
+  JSL CODE_03AF23                           ; $0F8DB7 |
   LDY !s_spr_wildcard_4_lo_dp,x             ; $0F8DBB |
   TYX                                       ; $0F8DBD |
   JMP ($8DC1,x)                             ; $0F8DBE |
@@ -1717,7 +1720,7 @@ CODE_0F8E1F:
 CODE_0F8E20:
   LDA !s_spr_anim_frame,x                   ; $0F8E20 |
   BNE CODE_0F8E2A                           ; $0F8E23 |
-  JSL $03AA52                               ; $0F8E25 |
+  JSL CODE_03AA52                           ; $0F8E25 |
   RTS                                       ; $0F8E29 |
 
 CODE_0F8E2A:
@@ -1809,7 +1812,7 @@ CODE_0F8EEA:
   RTL                                       ; $0F8EEA |
 
 main_hidden_winged_cloud_A:
-  JSL $03AF23                               ; $0F8EEB |
+  JSL CODE_03AF23                           ; $0F8EEB |
   TXA                                       ; $0F8EEF |
   STA !gsu_r1                               ; $0F8EF0 |
   LDX #$09                                  ; $0F8EF3 |
@@ -1865,7 +1868,7 @@ init_sparrow:
   RTL                                       ; $0F8F63 |
 
 main_sparrow:
-  JSL $03AF23                               ; $0F8F64 |
+  JSL CODE_03AF23                           ; $0F8F64 |
   LDA !s_spr_wildcard_3_lo_dp,x             ; $0F8F68 |
   TAX                                       ; $0F8F6A |
   JMP ($8F6E,x)                             ; $0F8F6B |
@@ -2033,7 +2036,7 @@ init_red_1up_egg:
   RTL                                       ; $0F90BF |
 
 main_red_1up_egg:
-  JSL $03AF23                               ; $0F90C0 |
+  JSL CODE_03AF23                           ; $0F90C0 |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0F90C4 |
   TYX                                       ; $0F90C6 |
   JMP ($90CA,x)                             ; $0F90C7 |
@@ -2087,7 +2090,7 @@ main_bouncing_green_needlenose:
   STA !s_spr_bitwise_settings_3,x           ; $0F912A |
 
 CODE_0F912D:
-  JSL $03AF23                               ; $0F912D |
+  JSL CODE_03AF23                           ; $0F912D |
   LDA !s_spr_bitwise_settings_3,x           ; $0F9131 |
   BIT #$001F                                ; $0F9134 |
   BEQ CODE_0F9173                           ; $0F9137 |
@@ -2131,7 +2134,7 @@ init_frog:
   RTL                                       ; $0F918B |
 
 main_frog:
-  JSL $03AF23                               ; $0F918C |
+  JSL CODE_03AF23                           ; $0F918C |
   LDY !s_spr_wildcard_3_lo_dp,x             ; $0F9190 |
   TYX                                       ; $0F9192 |
   JMP ($9197,x)                             ; $0F9193 |
@@ -2288,7 +2291,7 @@ CODE_0F9286:
 ; falls when all enemies on screen are dead (red coin, key, flower, door)
 ; Enemy = sprite with #$6000 flags
 main_bonus_sprite:
-  JSL $03AF23                               ; $0F92A1 |
+  JSL CODE_03AF23                           ; $0F92A1 |
   LDX #$09                                  ; $0F92A5 |
   LDA #$AF4A                                ; $0F92A7 | Test if enemies currently spawned
   JSL r_gsu_init_1                          ; $0F92AA | GSU init
@@ -2391,7 +2394,7 @@ CODE_0F935F:
   JSR CODE_0F97EE                           ; $0F9374 |
 
 CODE_0F9377:
-  JSL $03AF23                               ; $0F9377 |
+  JSL CODE_03AF23                           ; $0F9377 |
   JSR CODE_0F94BF                           ; $0F937B |
   JSR CODE_0F93EA                           ; $0F937E |
   JSR CODE_0F9391                           ; $0F9381 |
@@ -2983,7 +2986,7 @@ main_large_milde:
   CMP #$0003                                ; $0F98C2 |
   BNE CODE_0F98D5                           ; $0F98C5 |
   JSR CODE_0F9BB6                           ; $0F98C7 |
-  JSL $03AF23                               ; $0F98CA |
+  JSL CODE_03AF23                           ; $0F98CA |
   JSR CODE_0F993B                           ; $0F98CE |
   JSR CODE_0F9BC9                           ; $0F98D1 |
   RTL                                       ; $0F98D4 |
@@ -2996,7 +2999,7 @@ CODE_0F98D5:
   JSR CODE_0F98F2                           ; $0F98E1 |
 
 CODE_0F98E4:
-  JSL $03AF23                               ; $0F98E4 |
+  JSL CODE_03AF23                           ; $0F98E4 |
   JSR CODE_0F993B                           ; $0F98E8 |
   JSR CODE_0F93EA                           ; $0F98EB |
   JSR CODE_0F9391                           ; $0F98EE |
@@ -3310,7 +3313,7 @@ CODE_0F9BB5:
   RTL                                       ; $0F9BB5 |
 
 CODE_0F9BB6:
-  JSL $03AA52                               ; $0F9BB6 |
+  JSL CODE_03AA52                           ; $0F9BB6 |
   REP #$10                                  ; $0F9BBA |
   LDA !s_spr_oam_pointer,x                  ; $0F9BBC |
   CLC                                       ; $0F9BBF |
@@ -3379,7 +3382,7 @@ main_tap_tap_the_red_nose:
   SEP #$20                                  ; $0F9C58 |
   JSR CODE_0FA8E9                           ; $0F9C5A |
   REP #$20                                  ; $0F9C5D |
-  JSL $03AF23                               ; $0F9C5F |
+  JSL CODE_03AF23                           ; $0F9C5F |
   JSR CODE_0FA6DB                           ; $0F9C63 |
   SEP #$20                                  ; $0F9C66 |
   JSR CODE_0F9CA2                           ; $0F9C68 |
@@ -5179,7 +5182,7 @@ init_raph_spark:
   db $FF                                    ; $0FABE4 |
 
 main_raph_spark:
-  JSL $03AF23                               ; $0FABE5 |
+  JSL CODE_03AF23                           ; $0FABE5 |
   SEP #$20                                  ; $0FABE9 |
   LDA #$47                                  ; $0FABEB |
   STA $000051                               ; $0FABED |
@@ -5345,7 +5348,7 @@ CODE_0FAD33:
   AND #$07FF                                ; $0FAD3B |
   ORA #$2000                                ; $0FAD3E |
   STA !s_spr_oam_1,x                        ; $0FAD41 |
-  JSL $03AA52                               ; $0FAD44 |
+  JSL CODE_03AA52                           ; $0FAD44 |
   BRA CODE_0FAD4E                           ; $0FAD48 |
 
 CODE_0FAD4A:
@@ -5393,7 +5396,7 @@ CODE_0FADA9:
   JSR CODE_0FADC4                           ; $0FADA9 |
 
 CODE_0FADAC:
-  JSL $03AF23                               ; $0FADAC |
+  JSL CODE_03AF23                           ; $0FADAC |
   LDA !r_header_level_mode                  ; $0FADB0 |
   CMP #$0009                                ; $0FADB3 |
   BNE CODE_0FADBC                           ; $0FADB6 |
@@ -7291,7 +7294,7 @@ CODE_0FBA88:
   dw $2406, $2AFF, $2004, $1004             ; $0FBB6A |
   dw $1E04, $1003, $1004, $1E04             ; $0FBB72 |
 
-gamemode13:
+gm13_prepare_retry_screen:
   JSL init_oam_and_bg3_tilemap              ; $0FBB7A |
   JSL clear_basic_states                    ; $0FBB7E |
   JSL clear_all_sprites                     ; $0FBB82 |
@@ -7302,7 +7305,7 @@ gamemode13:
   LDA #$0000                                ; $0FBB91 |
   STA !s_cgram_mirror                       ; $0FBB94 |
   LDX #$004A                                ; $0FBB98 |
-  JSL $00BB05                               ; $0FBB9B | load palettes
+  JSL CODE_00BB05                           ; $0FBB9B | load palettes
   LDX #$02                                  ; $0FBB9F |
   JSL init_scene_regs                       ; $0FBBA1 |
   LDA #$10                                  ; $0FBBA5 |
@@ -7373,10 +7376,10 @@ gamemode13:
   PHK                                       ; $0FBC64 |
   PLB                                       ; $0FBC65 |
 
-gamemode15:
-  JSL $008259                               ; $0FBC66 |
+gm15_retry_screen_cutscene:
+  JSL init_oam_buffer                       ; $0FBC66 |
   JSL spr_edge_despawn_draw                 ; $0FBC6A |
-  JSL $0FBF39                               ; $0FBC6E |
+  JSL CODE_0FBF39                           ; $0FBC6E |
   REP #$20                                  ; $0FBC72 |
   LDX #$08                                  ; $0FBC74 |
   LDA #$B1EF                                ; $0FBC76 |
@@ -7473,8 +7476,8 @@ CODE_0FBC9A:
 
   dw $0243, $0080, $0070, $0000             ; $0FBDB6 |
 
-gamemod05:
-  JSL $0082D0                               ; $0FBDBE |
+gm05_load_cutscene:
+  JSL CODE_0082D0                           ; $0FBDBE |
   JSL init_oam_and_bg3_tilemap              ; $0FBDC2 |
   JSL clear_basic_states                    ; $0FBDC6 |
   JSL clear_all_sprites                     ; $0FBDCA |
@@ -7486,7 +7489,7 @@ gamemod05:
   JSL prepare_tilemap_dma_queue_l           ; $0FBDDC |
   REP #$30                                  ; $0FBDE0 |
   LDX #$0050                                ; $0FBDE2 |
-  JSL $00BB05                               ; $0FBDE5 |
+  JSL CODE_00BB05                           ; $0FBDE5 |
   LDX #$24                                  ; $0FBDE9 |
   JSL init_scene_regs                       ; $0FBDEB |
   LDA #$7C                                  ; $0FBDEF |
@@ -7549,7 +7552,7 @@ CODE_0FBE34:
   REP #$30                                  ; $0FBE84 |
   LDX #$BD0A                                ; $0FBE86 |
   JSR CODE_0FBF14                           ; $0FBE89 |
-  JSL $0FBEB2                               ; $0FBE8C |
+  JSL CODE_0FBEB2                           ; $0FBE8C |
   LDA #$02                                  ; $0FBE90 |
   STA !r_irq_count                          ; $0FBE92 |
   LDA #$50                                  ; $0FBE95 |
@@ -7562,14 +7565,16 @@ CODE_0FBE34:
   LDA #$3100                                ; $0FBEA6 |
   STA $1405                                 ; $0FBEA9 |
   SEP #$20                                  ; $0FBEAC |
-  JML $1083E2                               ; $0FBEAE |
+  JML increment_gamemode                    ; $0FBEAE |
+
+CODE_0FBEB2:
   PHB                                       ; $0FBEB2 |
   PHK                                       ; $0FBEB3 |
   PLB                                       ; $0FBEB4 |
   JSR CODE_0FCB8A                           ; $0FBEB5 |
   BRA CODE_0FBEE5                           ; $0FBEB8 |
 
-gamemode07:
+gm07_cutscene:
   REP #$20                                  ; $0FBEBA |
   DEC $1405                                 ; $0FBEBC |
   SEP #$20                                  ; $0FBEBF |
@@ -7592,9 +7597,9 @@ CODE_0FBED3:
   BRA CODE_0FBF12                           ; $0FBEE3 |
 
 CODE_0FBEE5:
-  JSL $008259                               ; $0FBEE5 | init OAM buffer
+  JSL init_oam_buffer                       ; $0FBEE5 | init OAM buffer
   JSR CODE_0FCC6F                           ; $0FBEE9 |
-  JSL $0FBF39                               ; $0FBEEC |
+  JSL CODE_0FBF39                           ; $0FBEEC |
   JSL spr_edge_despawn_draw                 ; $0FBEF0 |
   REP #$20                                  ; $0FBEF4 |
   LDA !r_reg_obsel_mirror                   ; $0FBEF6 |
@@ -7636,6 +7641,7 @@ CODE_0FBF36:
   SEP #$30                                  ; $0FBF36 |
   RTS                                       ; $0FBF38 |
 
+CODE_0FBF39:
   PHB                                       ; $0FBF39 |
   PHK                                       ; $0FBF3A |
   PLB                                       ; $0FBF3B |
@@ -9111,7 +9117,7 @@ CODE_0FCB3D:
   LDA #$9083                                ; $0FCB72 |
   JSL r_gsu_init_1                          ; $0FCB75 | GSU init
   REP #$10                                  ; $0FCB79 |
-  JSL $00BE39                               ; $0FCB7B |
+  JSL CODE_00BE39                           ; $0FCB7B |
 
   dw $51EC, $727E, $7033, $01C0             ; $0FCB7F |
 
@@ -9391,7 +9397,7 @@ CODE_0FCDAA:
   LDA $CE38,x                               ; $0FCDBF |
   TAX                                       ; $0FCDC2 |
   LDA #$0080                                ; $0FCDC3 |
-  JSL $00BEA6                               ; $0FCDC6 |
+  JSL CODE_00BEA6                           ; $0FCDC6 |
   JSR CODE_0FCE40                           ; $0FCDCA |
   JSR CODE_0FCE4D                           ; $0FCDCD |
   BRA CODE_0FCDF9                           ; $0FCDD0 |
@@ -9402,13 +9408,13 @@ CODE_0FCDD2:
   LDA $CE38,x                               ; $0FCDD8 |
   TAX                                       ; $0FCDDB |
   LDA #$0080                                ; $0FCDDC |
-  JSL $00BEA6                               ; $0FCDDF |
+  JSL CODE_00BEA6                           ; $0FCDDF |
   JSR CODE_0FCE40                           ; $0FCDE3 |
   JSR CODE_0FCE4D                           ; $0FCDE6 |
   LDY $11BC                                 ; $0FCDE9 |
   LDX #$13BE                                ; $0FCDEC |
   LDA #$0040                                ; $0FCDEF |
-  JSL $00BEA6                               ; $0FCDF2 |
+  JSL CODE_00BEA6                           ; $0FCDF2 |
   JSR CODE_0FCE4D                           ; $0FCDF6 |
 
 CODE_0FCDF9:
@@ -9417,20 +9423,20 @@ CODE_0FCDF9:
   LDA $CE38,x                               ; $0FCDFF |
   TAX                                       ; $0FCE02 |
   LDA #$0080                                ; $0FCE03 |
-  JSL $00BEA6                               ; $0FCE06 |
+  JSL CODE_00BEA6                           ; $0FCE06 |
   JSR CODE_0FCE40                           ; $0FCE0A |
   JSR CODE_0FCE4D                           ; $0FCE0D |
   LDY $11BC                                 ; $0FCE10 |
   LDX #$13BE                                ; $0FCE13 |
   LDA #$0040                                ; $0FCE16 |
-  JSL $00BEA6                               ; $0FCE19 |
+  JSL CODE_00BEA6                           ; $0FCE19 |
   JSR CODE_0FCE4D                           ; $0FCE1D |
   LDA !s_player_x_cam_rel                   ; $0FCE20 |
   BEQ CODE_0FCE35                           ; $0FCE23 |
   LDY $11BC                                 ; $0FCE25 |
   LDX #$13BE                                ; $0FCE28 |
   LDA #$0040                                ; $0FCE2B |
-  JSL $00BEA6                               ; $0FCE2E |
+  JSL CODE_00BEA6                           ; $0FCE2E |
   JSR CODE_0FCE4D                           ; $0FCE32 |
 
 CODE_0FCE35:
@@ -9527,23 +9533,23 @@ CODE_0FCF2D:
   LDY #$7E60                                ; $0FCF34 |
   LDX #$13BE                                ; $0FCF37 |
   LDA #$0040                                ; $0FCF3A |
-  JSL $00BEA6                               ; $0FCF3D |
+  JSL CODE_00BEA6                           ; $0FCF3D |
   LDY #$7E80                                ; $0FCF41 |
   LDX #$13BE                                ; $0FCF44 |
   LDA #$0040                                ; $0FCF47 |
-  JSL $00BEA6                               ; $0FCF4A |
+  JSL CODE_00BEA6                           ; $0FCF4A |
   LDY #$7EA0                                ; $0FCF4E |
   LDX #$13BE                                ; $0FCF51 |
   LDA #$0040                                ; $0FCF54 |
-  JSL $00BEA6                               ; $0FCF57 |
+  JSL CODE_00BEA6                           ; $0FCF57 |
   LDY #$7EC0                                ; $0FCF5B |
   LDX #$13BE                                ; $0FCF5E |
   LDA #$0040                                ; $0FCF61 |
-  JSL $00BEA6                               ; $0FCF64 |
+  JSL CODE_00BEA6                           ; $0FCF64 |
   LDY #$7EE0                                ; $0FCF68 |
   LDX #$13BE                                ; $0FCF6B |
   LDA #$0040                                ; $0FCF6E |
-  JSL $00BEA6                               ; $0FCF71 |
+  JSL CODE_00BEA6                           ; $0FCF71 |
   SEP #$10                                  ; $0FCF75 |
   RTS                                       ; $0FCF77 |
 

--- a/disassembly/bank10.asm
+++ b/disassembly/bank10.asm
@@ -1,5 +1,6 @@
 org $108000
 
+CODE_108000:
   PHB                                       ; $108000 |
   PHK                                       ; $108001 |
   PLB                                       ; $108002 |
@@ -376,8 +377,8 @@ save_game:
   db $60, $60, $00, $00, $70, $60, $02, $00 ; $10837B |
   db $80, $60, $04, $00, $90, $60, $06, $00 ; $108383 |
 
-gamemode00:
-  JSL $0082D0                               ; $10838B |
+gm00_ninpresents_prep:
+  JSL CODE_0082D0                           ; $10838B |
   JSL init_oam_and_bg3_tilemap              ; $10838F |
   LDX #$02                                  ; $108393 |
   JSL init_scene_regs                       ; $108395 |
@@ -395,7 +396,7 @@ CODE_1083AB:
   JSL load_compressed_gfx_files_l           ; $1083B0 |
   REP #$30                                  ; $1083B4 |
   LDX #$0040                                ; $1083B6 |
-  JSL $00BB05                               ; $1083B9 |
+  JSL CODE_00BB05                           ; $1083B9 |
   JSR CODE_108A6D                           ; $1083BD |
   LDX #$0F                                  ; $1083C0 |
 
@@ -406,21 +407,22 @@ CODE_1083C2:
   BPL CODE_1083C2                           ; $1083CA |
   LDA #$AA                                  ; $1083CC |
   STA $006C00                               ; $1083CE |
-  JSL $108000                               ; $1083D2 |
+  JSL CODE_108000                           ; $1083D2 |
   STZ $0202                                 ; $1083D6 |
   LDA #$80                                  ; $1083D9 |
   STA $011A                                 ; $1083DB |
-  JSL $008245                               ; $1083DE |
+  JSL enable_nmi                            ; $1083DE |
+increment_gamemode:
   INC !r_game_mode                          ; $1083E2 |
 
 CODE_1083E5:
   PLB                                       ; $1083E5 |
   RTL                                       ; $1083E6 |
 
-gamemode03:
+gm03_ninpresents_show:
   DEC $011A                                 ; $1083E7 |
   BNE CODE_1083E5                           ; $1083EA |
-  JML $1083E2                               ; $1083EC |
+  JML increment_gamemode                    ; $1083EC |
 
 ; gsu table
   db $FE, $00, $FD, $00, $FC, $30, $BD, $B1 ; $1083F0 |
@@ -598,7 +600,7 @@ CODE_1086EC:
   SEP #$20                                  ; $1087B8 |
   LDA #$43                                  ; $1087BA |
   STA !r_game_mode                          ; $1087BC |
-  JSL $008245                               ; $1087BF |
+  JSL enable_nmi                            ; $1087BF |
   RTS                                       ; $1087C3 |
 
 CODE_1087C4:
@@ -709,6 +711,7 @@ CODE_1087C4:
   SEP #$20                                  ; $1088F8 |
   RTS                                       ; $1088FA |
 
+gm44_unknown:
   REP #$20                                  ; $1088FB |
   LDA $702002                               ; $1088FD |
   INC A                                     ; $108901 |
@@ -725,7 +728,7 @@ CODE_10890A:
   PLB                                       ; $10891C |
   RTL                                       ; $10891D |
 
-gamemode01:
+gm01_ninpresents_load:
   JSR CODE_108987                           ; $10891E |
   LDA $00                                   ; $108921 |
   CMP #$FF                                  ; $108923 |
@@ -758,7 +761,7 @@ CODE_108939:
 
 CODE_108953:
   JSL clear_all_sprites                     ; $108953 |
-  JSL $008259                               ; $108957 |  init OAM buffer
+  JSL init_oam_buffer                       ; $108957 |  init OAM buffer
   REP #$20                                  ; $10895B |
   PHB                                       ; $10895D |
   LDX #$70                                  ; $10895E |
@@ -877,7 +880,7 @@ CODE_108A6D:
   JSR CODE_1087C4                           ; $108A96 |
   RTS                                       ; $108A99 |
 
-gamemode42:
+gm42_controller_error:
   REP #$20                                  ; $108A9A |
   LDA $702002                               ; $108A9C |
   INC A                                     ; $108AA0 |
@@ -1305,7 +1308,7 @@ check_cross_section_spawn:
   PLB                                       ; $108D4A |
   RTL                                       ; $108D4B |
 
-gamemode0E:
+gm0e_level_fadein_to_control:
   LDA $8D                                   ; $108D4C |
   BEQ CODE_108D75                           ; $108D4E |
   REP #$30                                  ; $108D50 |
@@ -1487,7 +1490,7 @@ CODE_108E80:
   REP #$20                                  ; $108E80 |
   JML $108F5D                               ; $108E82 |
 
-gamemode11:
+gm11_level_death:
   REP #$20                                  ; $108E86 |
   LDA $0B4C                                 ; $108E88 |
   BNE CODE_108EDE                           ; $108E8B |
@@ -1596,7 +1599,7 @@ CODE_108F45:
   LDX #$08                                  ; $108F54 |
   LDA #$8EF3                                ; $108F56 |
   JSL r_gsu_init_1                          ; $108F59 |  GSU init routines
-  JSL $00BE39                               ; $108F5D |
+  JSL CODE_00BE39                           ; $108F5D |
 
   dw $56D0, $027E, $703A, $0348             ; $108F61 |
 
@@ -3115,11 +3118,11 @@ CODE_109A85:
   dw $2644, $5B18, $E97E, $56D0             ; $109ADC |
   dw $74E9, $0058                           ; $109AE4 |
 
-gamemode2A:
+gm2a_load_bonus_game:
   JSL init_oam_and_bg3_tilemap              ; $109AE8 |
   JSL clear_basic_states                    ; $109AEC |
   JSL clear_all_sprites                     ; $109AF0 |
-  JSL $008259                               ; $109AF4 |
+  JSL init_oam_buffer                       ; $109AF4 |
   JSL copy_division_lookup_to_sram          ; $109AF8 |
   REP #$10                                  ; $109AFC |
   LDY !r_bonus_game_type                    ; $109AFE |
@@ -3147,7 +3150,7 @@ gamemode2A:
   LDA $00BA14,x                             ; $109B35 |
   STA $18                                   ; $109B39 |
   LDX #$0094                                ; $109B3B |
-  JSL $00BB05                               ; $109B3E |
+  JSL CODE_00BB05                           ; $109B3E |
   LDX #$2A                                  ; $109B42 |
   JSL init_scene_regs                       ; $109B44 |
   LDX #$04                                  ; $109B48 |
@@ -3366,7 +3369,7 @@ CODE_109CC7:
   REP #$10                                  ; $109D25 |
 
 CODE_109D27:
-  JSL $00BE39                               ; $109D27 |
+  JSL CODE_00BE39                           ; $109D27 |
 
   dw $56D0, $027E, $703A, $0348             ; $109D2B |
 
@@ -3772,8 +3775,8 @@ CODE_10A034:
   JSR CODE_10D205                           ; $10A137 |
   RTS                                       ; $10A13A |
 
-gamemode2C:
-  JSL $008259                               ; $10A13B |
+gm2c_bonus_game:
+  JSL init_oam_buffer                       ; $10A13B |
   JSL spr_edge_despawn_draw                 ; $10A13F |
   REP #$30                                  ; $10A143 |
   JSR CODE_10A175                           ; $10A145 |
@@ -4883,7 +4886,7 @@ CODE_10AB50:
   LDX #$AB12                                ; $10AB55 |
   LDA #$0006                                ; $10AB58 |
   PHY                                       ; $10AB5B |
-  JSL $00BEA6                               ; $10AB5C |
+  JSL CODE_00BEA6                           ; $10AB5C |
   PLA                                       ; $10AB60 |
   CLC                                       ; $10AB61 |
   ADC #$0020                                ; $10AB62 |
@@ -4976,7 +4979,7 @@ CODE_10AC06:
   LDA #$0006                                ; $10AC0B |
   PHX                                       ; $10AC0E |
   PHY                                       ; $10AC0F |
-  JSL $00BEA6                               ; $10AC10 |
+  JSL CODE_00BEA6                           ; $10AC10 |
   PLA                                       ; $10AC14 |
   CLC                                       ; $10AC15 |
   ADC #$0020                                ; $10AC16 |
@@ -5113,19 +5116,19 @@ CODE_10AD19:
   LDY #$5E80                                ; $10AD1E |
   LDX #$5800                                ; $10AD21 |
   LDA #$0080                                ; $10AD24 |
-  JSL $00BEA6                               ; $10AD27 |
+  JSL CODE_00BEA6                           ; $10AD27 |
   LDY #$5F80                                ; $10AD2B |
   LDX #$5A00                                ; $10AD2E |
   LDA #$0080                                ; $10AD31 |
-  JSL $00BEA6                               ; $10AD34 |
+  JSL CODE_00BEA6                           ; $10AD34 |
   LDY #$5EC0                                ; $10AD38 |
   LDX #$5C00                                ; $10AD3B |
   LDA #$0080                                ; $10AD3E |
-  JSL $00BEA6                               ; $10AD41 |
+  JSL CODE_00BEA6                           ; $10AD41 |
   LDY #$5FC0                                ; $10AD45 |
   LDX #$5E00                                ; $10AD48 |
   LDA #$0080                                ; $10AD4B |
-  JSL $00BEA6                               ; $10AD4E |
+  JSL CODE_00BEA6                           ; $10AD4E |
   RTS                                       ; $10AD52 |
 
   dw $0007, $000D, $000C, $000A             ; $10AD53 |
@@ -6089,7 +6092,7 @@ CODE_10B577:
   LDX #$AB12                                ; $10B57C |
   LDA #$0006                                ; $10B57F |
   PHY                                       ; $10B582 |
-  JSL $00BEA6                               ; $10B583 |
+  JSL CODE_00BEA6                           ; $10B583 |
   PLA                                       ; $10B587 |
   CLC                                       ; $10B588 |
   ADC #$0020                                ; $10B589 |
@@ -6114,7 +6117,7 @@ CODE_10B5AF:
   LDA #$0006                                ; $10B5B4 |
   PHX                                       ; $10B5B7 |
   PHY                                       ; $10B5B8 |
-  JSL $00BEA6                               ; $10B5B9 |
+  JSL CODE_00BEA6                           ; $10B5B9 |
   PLA                                       ; $10B5BD |
   CLC                                       ; $10B5BE |
   ADC #$0020                                ; $10B5BF |
@@ -6266,7 +6269,7 @@ CODE_10B7CA:
   PHY                                       ; $10B7CA |
   PHX                                       ; $10B7CB |
   LDA #$0006                                ; $10B7CC |
-  JSL $00BEA6                               ; $10B7CF |
+  JSL CODE_00BEA6                           ; $10B7CF |
   PLA                                       ; $10B7D3 |
   CLC                                       ; $10B7D4 |
   ADC #$0006                                ; $10B7D5 |
@@ -6430,7 +6433,7 @@ CODE_10B927:
   LDA #$0060                                ; $10B927 |
   PHX                                       ; $10B92A |
   PHY                                       ; $10B92B |
-  JSL $00BEA6                               ; $10B92C |
+  JSL CODE_00BEA6                           ; $10B92C |
   PLA                                       ; $10B930 |
   CLC                                       ; $10B931 |
   ADC #$0030                                ; $10B932 |
@@ -6918,7 +6921,7 @@ CODE_10BCDD:
   LDA #$000E                                ; $10BCE9 |
   PHX                                       ; $10BCEC |
   PHY                                       ; $10BCED |
-  JSL $00BEA6                               ; $10BCEE |
+  JSL CODE_00BEA6                           ; $10BCEE |
   PLA                                       ; $10BCF2 |
   CLC                                       ; $10BCF3 |
   ADC #$0020                                ; $10BCF4 |
@@ -6928,7 +6931,7 @@ CODE_10BCDD:
   ADC #$000E                                ; $10BCFA |
   TAX                                       ; $10BCFD |
   LDA #$000E                                ; $10BCFE |
-  JSL $00BEA6                               ; $10BD01 |
+  JSL CODE_00BEA6                           ; $10BD01 |
   RTS                                       ; $10BD05 |
 
   LDA #$0010                                ; $10BD06 |
@@ -6938,14 +6941,14 @@ CODE_10BCDD:
   LDY $A9A8,x                               ; $10BD10 |
   ASL $DA00                                 ; $10BD13 |
   PHY                                       ; $10BD16 |
-  JSL $00BEA6                               ; $10BD17 |
+  JSL CODE_00BEA6                           ; $10BD17 |
   PLA                                       ; $10BD1B |
   CLC                                       ; $10BD1C |
   ADC #$0020                                ; $10BD1D |
   TAY                                       ; $10BD20 |
   PLX                                       ; $10BD21 |
   LDA #$000E                                ; $10BD22 |
-  JSL $00BEA6                               ; $10BD25 |
+  JSL CODE_00BEA6                           ; $10BD25 |
   RTS                                       ; $10BD29 |
 
 ; random list generation without dupes
@@ -9127,7 +9130,7 @@ CODE_10CF1F:
   LDA #$0006                                ; $10CF1F |
   PHY                                       ; $10CF22 |
   PHX                                       ; $10CF23 |
-  JSL $00BEA6                               ; $10CF24 |
+  JSL CODE_00BEA6                           ; $10CF24 |
   PLA                                       ; $10CF28 |
   CLC                                       ; $10CF29 |
   ADC #$0006                                ; $10CF2A |
@@ -9282,7 +9285,7 @@ CODE_10D048:
   LDA #$0060                                ; $10D048 |
   PHX                                       ; $10D04B |
   PHY                                       ; $10D04C |
-  JSL $00BEA6                               ; $10D04D |
+  JSL CODE_00BEA6                           ; $10D04D |
   PLA                                       ; $10D051 |
   CLC                                       ; $10D052 |
   ADC #$0030                                ; $10D053 |
@@ -9373,7 +9376,7 @@ CODE_10D0F1:
   LDX #$5800                                ; $10D101 |
   LDA #$0060                                ; $10D104 |
   PHY                                       ; $10D107 |
-  JSL $00BEA6                               ; $10D108 |
+  JSL CODE_00BEA6                           ; $10D108 |
   PLA                                       ; $10D10C |
   CLC                                       ; $10D10D |
   ADC #$0030                                ; $10D10E |
@@ -9381,14 +9384,14 @@ CODE_10D0F1:
   LDX #$5A00                                ; $10D112 |
   LDA #$0060                                ; $10D115 |
   PHY                                       ; $10D118 |
-  JSL $00BEA6                               ; $10D119 |
+  JSL CODE_00BEA6                           ; $10D119 |
   PLA                                       ; $10D11D |
   CLC                                       ; $10D11E |
   ADC #$0030                                ; $10D11F |
   TAY                                       ; $10D122 |
   LDX #$5C00                                ; $10D123 |
   LDA #$0060                                ; $10D126 |
-  JSL $00BEA6                               ; $10D129 |
+  JSL CODE_00BEA6                           ; $10D129 |
   PLX                                       ; $10D12D |
 
 CODE_10D12E:
@@ -9948,7 +9951,7 @@ CODE_10D598:
   STA $01                                   ; $10D59C |
   LDX #$AB12                                ; $10D59E |
   LDA #$0006                                ; $10D5A1 |
-  JSL $00BEA6                               ; $10D5A4 |
+  JSL CODE_00BEA6                           ; $10D5A4 |
   PLA                                       ; $10D5A8 |
   CLC                                       ; $10D5A9 |
   ADC #$0020                                ; $10D5AA |
@@ -10030,7 +10033,7 @@ CODE_10D643:
   LDA #$0006                                ; $10D643 |
   PHX                                       ; $10D646 |
   PHY                                       ; $10D647 |
-  JSL $00BEA6                               ; $10D648 |
+  JSL CODE_00BEA6                           ; $10D648 |
   PLA                                       ; $10D64C |
   CLC                                       ; $10D64D |
   ADC #$0020                                ; $10D64E |
@@ -10237,7 +10240,7 @@ CODE_10D7EC:
   STA $01                                   ; $10D7F0 |
   LDX #$AB12                                ; $10D7F2 |
   LDA #$0006                                ; $10D7F5 |
-  JSL $00BEA6                               ; $10D7F8 |
+  JSL CODE_00BEA6                           ; $10D7F8 |
   PLA                                       ; $10D7FC |
   CLC                                       ; $10D7FD |
   ADC #$0020                                ; $10D7FE |
@@ -10345,7 +10348,7 @@ CODE_10D8CE:
   LDA #$0006                                ; $10D8D3 |
   PHX                                       ; $10D8D6 |
   PHY                                       ; $10D8D7 |
-  JSL $00BEA6                               ; $10D8D8 |
+  JSL CODE_00BEA6                           ; $10D8D8 |
   PLA                                       ; $10D8DC |
   CLC                                       ; $10D8DD |
   ADC #$0020                                ; $10D8DE |
@@ -10443,7 +10446,7 @@ CODE_10D98A:
   STA $01                                   ; $10D98E |
   LDX #$AB12                                ; $10D990 |
   LDA #$0006                                ; $10D993 |
-  JSL $00BEA6                               ; $10D996 |
+  JSL CODE_00BEA6                           ; $10D996 |
   PLA                                       ; $10D99A |
   CLC                                       ; $10D99B |
   ADC #$0020                                ; $10D99C |
@@ -10502,6 +10505,7 @@ CODE_10D9EE:
 
   db $E9, $40, $50, $E9, $12, $51, $00      ; $10DA2C |
 
+gm38_load_intro_cutscene:
   JSL init_oam_and_bg3_tilemap              ; $10DA33 |
   JSL prepare_in_level_states               ; $10DA37 |
   JSL clear_all_sprites                     ; $10DA3B |
@@ -10729,7 +10733,7 @@ CODE_10DC37:
   EOR #$01                                  ; $10DC66 |
   AND #$01                                  ; $10DC68 |
   STA $0201                                 ; $10DC6A |
-  JML $1083E2                               ; $10DC6D |
+  JML increment_gamemode                    ; $10DC6D |
 
 CODE_10DC71:
   STX $00                                   ; $10DC71 |
@@ -10760,7 +10764,8 @@ CODE_10DC71:
   dw $DD7C                                  ; $10DCA9 |
   dw $DD60                                  ; $10DCAB |
 
-  JSL $008259                               ; $10DCAD |
+gm39_intro_cutscene:
+  JSL init_oam_buffer                       ; $10DCAD |
   LDA $0D27                                 ; $10DCB1 |
   ASL A                                     ; $10DCB4 |
   TAX                                       ; $10DCB5 |
@@ -10905,7 +10910,7 @@ CODE_10DDC3:
   LDA #$DC4D                                ; $10DDEA |
   JSL r_gsu_init_1                          ; $10DDED | GSU init
   LDA #$01A4                                ; $10DDF1 |
-  JSL $00BE71                               ; $10DDF4 |
+  JSL CODE_00BE71                           ; $10DDF4 |
 
   dw $552C, $5E7E, $7038                    ; $10DDF8 |
 
@@ -10925,7 +10930,7 @@ CODE_10DDC3:
   LDA #$DC4D                                ; $10DE23 |
   JSL r_gsu_init_1                          ; $10DE26 | GSU init
   LDA #$01A4                                ; $10DE2A |
-  JSL $00BE71                               ; $10DE2D |
+  JSL CODE_00BE71                           ; $10DE2D |
 
   dw $5040, $167E, $7035                    ; $10DE31 |
 
@@ -10934,11 +10939,11 @@ CODE_10DDC3:
   TSB !r_reg_hdmaen_mirror                  ; $10DE3B |
   RTS                                       ; $10DE3E |
 
-gamemode3F:
+gm3f_load_game_over:
   JSL init_oam_and_bg3_tilemap              ; $10DE3F |
   JSL clear_basic_states                    ; $10DE43 |
   JSL clear_all_sprites                     ; $10DE47 |
-  JSL $008259                               ; $10DE4B |
+  JSL init_oam_buffer                       ; $10DE4B |
   LDX #$04                                  ; $10DE4F |
   JSL init_scene_regs                       ; $10DE51 |
   LDA #$10                                  ; $10DE55 |
@@ -11066,8 +11071,8 @@ CODE_10DF20:
   dw $E17C                                  ; $10DF4F |
   dw $E199                                  ; $10DF51 |
 
-gamemode40:
-  JSL $008259                               ; $10DF53 |
+gm40_game_over:
+  JSL init_oam_buffer                       ; $10DF53 |
   LDX $8F                                   ; $10DF57 |
   JSR ($DF49,x)                             ; $10DF59 |
 
@@ -11187,7 +11192,7 @@ CODE_10E002:
   STA $01                                   ; $10E04B |
   LDA #$1000                                ; $10E04D |
   LDX #$6800                                ; $10E050 |
-  JSL $00BEA6                               ; $10E053 |
+  JSL CODE_00BEA6                           ; $10E053 |
   LDA #$3100                                ; $10E057 |
   STA $04                                   ; $10E05A |
   LDX #$0000                                ; $10E05C |
@@ -11381,21 +11386,22 @@ CODE_10E198:
   STA !reg_nmitimen                         ; $10E1BD |
   RTS                                       ; $10E1C0 |
 
-gamemode_17:
+gm17_final_cinema_sequence:
   LDA #$FF                                  ; $10E1C1 |
   STA $011A                                 ; $10E1C3 |
   LDA #$0C                                  ; $10E1C6 |
   STA !r_cur_world                          ; $10E1C8 |
   INC !r_last_world_unlocked                ; $10E1CB |
-  JML $1083E2                               ; $10E1CE |
+  JML increment_gamemode                    ; $10E1CE |
 
 ; Credits Screen BG1 tilemap init
   dw $5000, $47FF, $0000                    ; $10E1D2 |
 ; End marker
   dw $FFFF                                  ; $10E1D8 |
 
+gm1b_load_credits:
   LDA #$24                                  ; $10E1DA |
-  JSL $008279                               ; $10E1DC |
+  JSL CODE_008279                           ; $10E1DC |
   JSL clear_basic_states                    ; $10E1E0 |
   REP #$10                                  ; $10E1E4 |
   LDY #$01C3                                ; $10E1E6 |
@@ -11549,7 +11555,9 @@ CODE_10E27B:
   LDA #$B1                                  ; $10E34B |
   STA !reg_nmitimen                         ; $10E34D |
   STZ !r_reg_inidisp_mirror                 ; $10E350 |
-  JML $1083E2                               ; $10E353 |
+  JML increment_gamemode                    ; $10E353 |
+
+gm1c_credits_begin:
   LDA $8C                                   ; $10E357 |
   AND #$03                                  ; $10E359 |
   BNE CODE_10E360                           ; $10E35B |
@@ -11607,6 +11615,7 @@ CODE_10E360:
   dw $E992                                  ; $10E3C7 |
   dw $E96B                                  ; $10E3C9 |
 
+gm1d_credits:
   REP #$20                                  ; $10E3CB |
   INC $8C                                   ; $10E3CD |
   LDA $0BD3                                 ; $10E3CF |

--- a/disassembly/bank10.asm
+++ b/disassembly/bank10.asm
@@ -1314,7 +1314,7 @@ gm0e_level_fadein_to_control:
   REP #$30                                  ; $108D50 |
   JSR CODE_108F88                           ; $108D52 |
   SEP #$30                                  ; $108D55 |
-  JSL $00C71E                               ; $108D57 |
+  JSL CODE_00C71E                           ; $108D57 |
   DEC $8D                                   ; $108D5B |
   BNE CODE_108D73                           ; $108D5D |
   JSL $03954E                               ; $108D5F |
@@ -1649,7 +1649,7 @@ CODE_108FBF:
   JSR CODE_108F88                           ; $108FBF |
   SEP #$30                                  ; $108FC2 |
   JSL process_vram_dma_queue_l              ; $108FC4 |
-  JSL $00DB94                               ; $108FC8 |
+  JSL CODE_00DB94                           ; $108FC8 |
   REP #$30                                  ; $108FCC |
   DEC $8D                                   ; $108FCE |
   BNE CODE_108FBF                           ; $108FD0 |
@@ -1685,7 +1685,7 @@ CODE_109003:
   JSR CODE_108F88                           ; $109003 |
   SEP #$30                                  ; $109006 |
   JSL process_vram_dma_queue_l              ; $109008 |
-  JSL $00DB94                               ; $10900C |
+  JSL CODE_00DB94                           ; $10900C |
   REP #$30                                  ; $109010 |
   DEC $8D                                   ; $109012 |
   BNE CODE_109003                           ; $109014 |
@@ -2670,7 +2670,7 @@ CODE_1096EA:
   LDA $07                                   ; $1096FE |
   PHA                                       ; $109700 |
   JSR CODE_1098A2                           ; $109701 |
-  JSL $00E013                               ; $109704 |
+  JSL CODE_00E013                           ; $109704 |
   PLA                                       ; $109708 |
   STA $07                                   ; $109709 |
   PLA                                       ; $10970B |
@@ -3147,7 +3147,7 @@ gm2a_load_bonus_game:
   LDA !r_yoshi_color                        ; $109B30 |
   ASL A                                     ; $109B33 |
   TAX                                       ; $109B34 |
-  LDA $00BA14,x                             ; $109B35 |
+  LDA yoshi_palette_ptrs,x                  ; $109B35 |
   STA $18                                   ; $109B39 |
   LDX #$0094                                ; $109B3B |
   JSL CODE_00BB05                           ; $109B3E |
@@ -3988,7 +3988,7 @@ CODE_10A35E:
   LDX #$00                                  ; $10A36A |
   STX !s_cur_sprite_slot                    ; $10A36C |
   JSL $06BCEC                               ; $10A36F |
-  JSL $008AB6                               ; $10A373 |
+  JSL handle_ambient_sprites                ; $10A373 |
   PLD                                       ; $10A377 |
   PLB                                       ; $10A378 |
   REP #$10                                  ; $10A379 |
@@ -8070,7 +8070,7 @@ CODE_10C61B:
 
 CODE_10C624:
   LDA $117F                                 ; $10C624 |
-  JSL $008365                               ; $10C627 |
+  JSL execute_ptr                           ; $10C627 |
 
   dw $C7B2                                  ; $10C62B |
   dw $C6C5                                  ; $10C62D |
@@ -8339,7 +8339,7 @@ CODE_10C85A:
 CODE_10C885:
   LDX $1166                                 ; $10C885 |
   LDA $C869,x                               ; $10C888 |
-  JSL $008365                               ; $10C88B |
+  JSL execute_ptr                           ; $10C88B |
 
   dw $C893                                  ; $10C88F |
   dw $C8A4                                  ; $10C891 |
@@ -10775,9 +10775,9 @@ gm39_intro_cutscene:
   STA !s_cam_x_window_min                   ; $10DCBE |
   SEP #$20                                  ; $10DCC1 |
   JSL $04FD28                               ; $10DCC3 |
-  JSL $0394D3                               ; $10DCC7 |
+  JSL spr_edge_despawn_draw_check_warp      ; $10DCC7 |
   JSL draw_player                           ; $10DCCB |
-  JSL $04DD9E                               ; $10DCCF |
+  JSL main_player                           ; $10DCCF |
   JSL $0397DF                               ; $10DCD3 |
   REP #$20                                  ; $10DCD7 |
   LDX #$A908                                ; $10DCD9 |
@@ -11450,9 +11450,9 @@ CODE_10E22E:
   BPL CODE_10E22E                           ; $10E23E |
   PHB                                       ; $10E240 |\
   LDY #$1200                                ; $10E241 | |
-  LDX #$E552                                ; $10E244 | | move $00E552~$00E952 to $701200~$7015FF
-  LDA #$03FF                                ; $10E247 | |
-  MVN $70,$00                               ; $10E24A | |
+  LDX.w #div_onebyx_lut                     ; $10E244 | | move $00E552~$00E952 to $701200~$7015FF
+  LDA #(div_onebyx_lut_end-div_onebyx_lut)-1; $10E247 | | $03FF bytes
+  MVN $70,(div_onebyx_lut>>16)&$FF          ; $10E24A | |
   PLB                                       ; $10E24D |/
   SEP #$30                                  ; $10E24E |
   LDX #$26                                  ; $10E250 |

--- a/disassembly/bank11.asm
+++ b/disassembly/bank11.asm
@@ -302,7 +302,7 @@ CODE_118293:
 CODE_1182A4:
   LDA $10F8                                 ; $1182A4 |
   BEQ CODE_1182AD                           ; $1182A7 |
-  JSL $0397D3                               ; $1182A9 |
+  JSL handle_sprites                        ; $1182A9 |
 
 CODE_1182AD:
   REP #$20                                  ; $1182AD |
@@ -1966,6 +1966,7 @@ CODE_119178:
   SEP #$30                                  ; $1191B5 |
   RTS                                       ; $1191B7 |
 
+CODE_1191B8:
   SEP #$20                                  ; $1191B8 |
   PHB                                       ; $1191BA |
   LDA #$11                                  ; $1191BB |
@@ -3188,7 +3189,7 @@ CODE_119E4E:
   STA $7ECC                                 ; $119E73 |
   JSR CODE_11A008                           ; $119E76 |
   SEP #$30                                  ; $119E79 |
-  JSL $0397D3                               ; $119E7B |
+  JSL handle_sprites                        ; $119E7B |
   LDA #$09                                  ; $119E7F |
   STA !r_reg_bgmode_mirror                  ; $119E81 |
   STZ !r_reg_cgadsub_mirror                 ; $119E84 |
@@ -3235,7 +3236,7 @@ CODE_119EDB:
   LDA $10F4                                 ; $119EE5 |
   BNE CODE_119EF1                           ; $119EE8 |
   JSR CODE_119F13                           ; $119EEA |
-  JSL $04DD9E                               ; $119EED |
+  JSL main_player                           ; $119EED |
 
 CODE_119EF1:
   LDA $1104                                 ; $119EF1 |
@@ -3245,7 +3246,7 @@ CODE_119EF1:
 CODE_119EF9:
   LDA !r_msg_box_state                      ; $119EF9 |
   BNE CODE_119F05                           ; $119EFC |
-  JSL $0397D3                               ; $119EFE |
+  JSL handle_sprites                        ; $119EFE |
   JSR CODE_119F40                           ; $119F02 |
 
 CODE_119F05:
@@ -4061,7 +4062,7 @@ CODE_11A566:
   LDA #$0003                                ; $11A5A2 |
   STA $7782,y                               ; $11A5A5 |
   TYX                                       ; $11A5A8 |
-  JSL $009ABF                               ; $11A5A9 |
+  JSL CODE_009ABF                           ; $11A5A9 |
 
 CODE_11A5AD:
   LDX !s_cur_sprite_slot                    ; $11A5AD |
@@ -5138,7 +5139,7 @@ CODE_11ADF0:
   LDA #$01B3                                ; $11AE0C |
   JSL spawn_sprite_init                     ; $11AE0F |
   SEP #$30                                  ; $11AE13 |
-  JSL $0397D3                               ; $11AE15 |
+  JSL handle_sprites                        ; $11AE15 |
   RTS                                       ; $11AE19 |
 
   JSL init_oam_buffer                       ; $11AE1A |
@@ -5162,10 +5163,10 @@ CODE_11ADF0:
 
   db $06, $04                               ; $11AE45 |
 
-  JSL $04DD9E                               ; $11AE47 |
+  JSL main_player                           ; $11AE47 |
   LDA !r_msg_box_state                      ; $11AE4B |
   BNE CODE_11AEA9                           ; $11AE4E |
-  JSL $0397D3                               ; $11AE50 |
+  JSL handle_sprites                        ; $11AE50 |
   REP #$30                                  ; $11AE54 |
   JSR CODE_11AEDC                           ; $11AE56 |
   SEP #$10                                  ; $11AE59 |
@@ -5209,8 +5210,8 @@ CODE_11AEA9:
   SEP #$20                                  ; $11AEA9 |
   RTS                                       ; $11AEAB |
 
-  JSL $04DD9E                               ; $11AEAC |
-  JSL $0397D3                               ; $11AEB0 |
+  JSL main_player                           ; $11AEAC |
+  JSL handle_sprites                        ; $11AEB0 |
   LDA $10FA                                 ; $11AEB4 |
   BEQ CODE_11AEC4                           ; $11AEB7 |
   LDA !s_player_jump_state                  ; $11AEB9 |
@@ -5219,11 +5220,11 @@ CODE_11AEA9:
   INC !s_player_disable_flag                ; $11AEC1 |
 
 CODE_11AEC4:
-  JSL $1191B8                               ; $11AEC4 |
+  JSL CODE_1191B8                           ; $11AEC4 |
   RTS                                       ; $11AEC8 |
 
-  JSL $04DD9E                               ; $11AEC9 |
-  JSL $0397D3                               ; $11AECD |
+  JSL main_player                           ; $11AEC9 |
+  JSL handle_sprites                        ; $11AECD |
   LDA #$01                                  ; $11AED1 |
   STA !s_player_disable_flag                ; $11AED3 |
   STA $10FA                                 ; $11AED6 |
@@ -5526,11 +5527,11 @@ CODE_11B16D:
   AND #$00FF                                ; $11B192 |
   ASL A                                     ; $11B195 |
   TAX                                       ; $11B196 |
-  LDA $00E9D4,x                             ; $11B197 |
+  LDA raphael_mode7_matrix_b_c,x            ; $11B197 |
   ASL A                                     ; $11B19B |
   ASL A                                     ; $11B19C |
   STA !s_spr_y_speed_lo,y                   ; $11B19D |
-  LDA $00E954,x                             ; $11B1A0 |
+  LDA raphael_mode7_matrix_a_d,x            ; $11B1A0 |
   ASL A                                     ; $11B1A4 |
   STA !s_spr_x_speed_lo,y                   ; $11B1A5 |
   LDX $12                                   ; $11B1A8 |
@@ -6250,7 +6251,7 @@ CODE_11B6DB:
   STA !s_spr_x_pixel_pos,y                  ; $11B846 |
   LDA #$00C0                                ; $11B849 |
   STA !s_spr_y_pixel_pos,y                  ; $11B84C |
-  JSL $0397D3                               ; $11B84F |
+  JSL handle_sprites                        ; $11B84F |
   LDA #$15                                  ; $11B853 |
   STA $34                                   ; $11B855 |
   JSL $108B61                               ; $11B857 |
@@ -6277,17 +6278,17 @@ CODE_11B6DB:
   dw $B89D                                  ; $11B888 |
   dw $B8C2                                  ; $11B88A |
 
-  JSL $04DD9E                               ; $11B88C |
+  JSL main_player                           ; $11B88C |
   LDA !r_msg_box_state                      ; $11B890 |
   BNE CODE_11B89C                           ; $11B893 |
-  JSL $0397D3                               ; $11B895 |
+  JSL handle_sprites                        ; $11B895 |
   JSR CODE_11B8E2                           ; $11B899 |
 
 CODE_11B89C:
   RTS                                       ; $11B89C |
 
-  JSL $04DD9E                               ; $11B89D |
-  JSL $0397D3                               ; $11B8A1 |
+  JSL main_player                           ; $11B89D |
+  JSL handle_sprites                        ; $11B8A1 |
   LDA $10FA                                 ; $11B8A5 |
   BEQ CODE_11B8BF                           ; $11B8A8 |
   LDA !s_player_jump_state                  ; $11B8AA |
@@ -6301,8 +6302,8 @@ CODE_11B89C:
 
 CODE_11B8BF:
   JMP CODE_11AEC4                           ; $11B8BF |
-  JSL $04DD9E                               ; $11B8C2 |
-  JSL $0397D3                               ; $11B8C6 |
+  JSL main_player                           ; $11B8C2 |
+  JSL handle_sprites                        ; $11B8C6 |
   REP #$20                                  ; $11B8CA |
   DEC $10F0                                 ; $11B8CC |
   BNE CODE_11B8D5                           ; $11B8CF |
@@ -7860,7 +7861,7 @@ CODE_11C505:
   STA !s_spr_x_pixel_pos,y                  ; $11C5E4 |
   LDA #$00C0                                ; $11C5E7 |
   STA !s_spr_y_pixel_pos,y                  ; $11C5EA |
-  JSL $0397D3                               ; $11C5ED |
+  JSL handle_sprites                        ; $11C5ED |
   LDA #$15                                  ; $11C5F1 |
   STA $34                                   ; $11C5F3 |
   JSL $108B61                               ; $11C5F5 |
@@ -7884,10 +7885,10 @@ CODE_11C618:
   BRA CODE_11C632                           ; $11C620 |
 
 CODE_11C622:
-  JSL $04DD9E                               ; $11C622 |
+  JSL main_player                           ; $11C622 |
   LDA !r_msg_box_state                      ; $11C626 |
   BNE CODE_11C632                           ; $11C629 |
-  JSL $0397D3                               ; $11C62B |
+  JSL handle_sprites                        ; $11C62B |
   JSR CODE_11B8E2                           ; $11C62F |
 
 CODE_11C632:

--- a/disassembly/bank11.asm
+++ b/disassembly/bank11.asm
@@ -1,13 +1,13 @@
 org $118000
 ; handles bandit minigame
 ; 7E03A7 has bandit minigame type
-main_bandit_minigame:
+gm2e_main_bandit_minigame:
   SEP #$30                                  ; $118000 |
-  JSL $119D5A                               ; $118002 |
+  JSL CODE_119D5A                           ; $118002 |
   JSL init_oam_and_bg3_tilemap              ; $118006 |
   JSL prepare_in_level_states               ; $11800A |
   JSL clear_all_sprites                     ; $11800E |
-  JSL $008259                               ; $118012 |
+  JSL init_oam_buffer                       ; $118012 |
   REP #$20                                  ; $118016 |
   LDX #$1C                                  ; $118018 |
 
@@ -21,7 +21,7 @@ CODE_11801A:
   LDA $03A7                                 ; $118026 |
   LSR A                                     ; $118029 |
   TAY                                       ; $11802A |
-  JSL $00B49E                               ; $11802B |
+  JSL CODE_00B49E                           ; $11802B |
   LDX #$2A                                  ; $11802F |
   JSL init_scene_regs                       ; $118031 |
   JSL hdma_and_gradient_init                ; $118035 |
@@ -42,7 +42,7 @@ CODE_118050:
   DEY                                       ; $118056 |
   BPL CODE_118050                           ; $118057 |
   LDY $03A7                                 ; $118059 |
-  JSL $00BB70                               ; $11805C | load palette
+  JSL CODE_00BB70                           ; $11805C | load palette
   LDA #$09                                  ; $118060 |
   STA $0127                                 ; $118062 |
   JSL prepare_tilemap_dma_queue_l           ; $118065 |
@@ -207,6 +207,7 @@ CODE_118194:
   JSR CODE_119134                           ; $1181D5 |
   RTS                                       ; $1181D8 |
 
+gm30_miniboss_battle:
   LDA !r_msg_box_state                      ; $1181D9 |
   BEQ CODE_1181EA                           ; $1181DC |
   JSL $01DE5A                               ; $1181DE |
@@ -250,7 +251,7 @@ CODE_118216:
   STX $01                                   ; $11822D |
   LDX #$6800                                ; $11822F |
   LDY #$3400                                ; $118232 |
-  JSL $00BEA6                               ; $118235 |
+  JSL CODE_00BEA6                           ; $118235 |
   LDX #$0000                                ; $118239 |
 
 CODE_11823C:
@@ -275,7 +276,7 @@ CODE_11823C:
   STA !r_joy1_lo_mirror                     ; $118266 |
   LDA $093E,y                               ; $118269 |
   STA !r_joy1_lo_press_mirror               ; $11826C |
-  JSL $008259                               ; $11826F |
+  JSL init_oam_buffer                       ; $11826F |
   JSL spr_edge_despawn_draw                 ; $118273 |
   JSR CODE_118D8D                           ; $118277 |
   JSR CODE_1187FD                           ; $11827A |
@@ -1961,7 +1962,7 @@ CODE_119178:
   STA $01                                   ; $1191A9 |
   LDY #$3C00                                ; $1191AB |
   LDA #$0800                                ; $1191AE |
-  JSL $00BEA6                               ; $1191B1 |
+  JSL CODE_00BEA6                           ; $1191B1 |
   SEP #$30                                  ; $1191B5 |
   RTS                                       ; $1191B7 |
 
@@ -3062,6 +3063,7 @@ CODE_119D46:
   SEP #$30                                  ; $119D57 |
   RTL                                       ; $119D59 |
 
+CODE_119D5A:
   REP #$30                                  ; $119D5A |
   LDX #$007E                                ; $119D5C |
   LDA #$00FF                                ; $119D5F |
@@ -3192,7 +3194,7 @@ CODE_119E4E:
   STZ !r_reg_cgadsub_mirror                 ; $119E84 |
   RTS                                       ; $119E87 |
 
-  JSL $008259                               ; $119E88 |
+  JSL init_oam_buffer                       ; $119E88 |
   REP #$20                                  ; $119E8C |
   LDA !s_player_x                           ; $119E8E |
   STA $1142                                 ; $119E91 |
@@ -3572,7 +3574,7 @@ CODE_11A180:
   dw $A1E9                                  ; $11A1A5 |
   dw $A22B                                  ; $11A1A7 |
 
-  JSL $03AA52                               ; $11A1A9 |
+  JSL CODE_03AA52                           ; $11A1A9 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A1AD |
   CMP #$0020                                ; $11A1B0 |
   BCC CODE_11A1BC                           ; $11A1B3 |
@@ -3604,7 +3606,7 @@ CODE_11A1E5:
   JSR CODE_11A4F4                           ; $11A1E5 |
   RTL                                       ; $11A1E8 |
 
-  JSL $03AA52                               ; $11A1E9 |
+  JSL CODE_03AA52                           ; $11A1E9 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A1ED |
   BEQ CODE_11A1BC                           ; $11A1F0 |
   CMP #$00E0                                ; $11A1F2 |
@@ -3635,7 +3637,7 @@ CODE_11A227:
   JSR CODE_11A4F4                           ; $11A227 |
   RTL                                       ; $11A22A |
 
-  JSL $03AA52                               ; $11A22B |
+  JSL CODE_03AA52                           ; $11A22B |
   LDA !s_spr_wildcard_2_lo,x                ; $11A22F |
   SEC                                       ; $11A232 |
   SBC #$0020                                ; $11A233 |
@@ -3747,7 +3749,7 @@ CODE_11A2CC:
   JSL push_sound_queue                      ; $11A32E |/
   RTL                                       ; $11A332 |
 
-  JSL $03AA52                               ; $11A333 |
+  JSL CODE_03AA52                           ; $11A333 |
   STZ $0000                                 ; $11A337 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A33A |
   BEQ CODE_11A35D                           ; $11A33D |
@@ -3795,7 +3797,7 @@ CODE_11A38E:
   JSR CODE_11A4F4                           ; $11A38E |
   RTL                                       ; $11A391 |
 
-  JSL $03AA52                               ; $11A392 |
+  JSL CODE_03AA52                           ; $11A392 |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A396 |
   CMP #$0020                                ; $11A399 |
   BCC CODE_11A3A5                           ; $11A39C |
@@ -3826,7 +3828,7 @@ CODE_11A3CB:
   JSR CODE_11A4F4                           ; $11A3CB |
   RTL                                       ; $11A3CE |
 
-  JSL $03AA52                               ; $11A3CF |
+  JSL CODE_03AA52                           ; $11A3CF |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A3D3 |
   CMP #$0020                                ; $11A3D6 |
   BCC CODE_11A3E2                           ; $11A3D9 |
@@ -3858,7 +3860,7 @@ CODE_11A40B:
   JSR CODE_11A4F4                           ; $11A40B |
   RTL                                       ; $11A40E |
 
-  JSL $03AA52                               ; $11A40F |
+  JSL CODE_03AA52                           ; $11A40F |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A413 |
   BEQ CODE_11A424                           ; $11A416 |
   CMP #$00E0                                ; $11A418 |
@@ -3890,7 +3892,7 @@ CODE_11A44A:
   JSR CODE_11A4F4                           ; $11A44A |
   RTL                                       ; $11A44D |
 
-  JSL $03AA52                               ; $11A44E |
+  JSL CODE_03AA52                           ; $11A44E |
   LDA !s_spr_gsu_morph_2_lo,x               ; $11A452 |
   BEQ CODE_11A463                           ; $11A455 |
   CMP #$00E0                                ; $11A457 |
@@ -3921,7 +3923,7 @@ CODE_11A48C:
   JSR CODE_11A4F4                           ; $11A48C |
   RTL                                       ; $11A48F |
 
-  JSL $03AA52                               ; $11A490 |
+  JSL CODE_03AA52                           ; $11A490 |
   LDA !s_spr_wildcard_2_lo,x                ; $11A494 |
   CMP #$00C0                                ; $11A497 |
   BCC CODE_11A4AF                           ; $11A49A |
@@ -3992,7 +3994,7 @@ CODE_11A50F:
 
   dw $0001, $0002                           ; $11A510 |
 
-  JSL $03AA52                               ; $11A514 |
+  JSL CODE_03AA52                           ; $11A514 |
   LDA !s_spr_wildcard_2_lo,x                ; $11A518 |
   SEC                                       ; $11A51B |
   SBC #$0020                                ; $11A51C |
@@ -5139,7 +5141,7 @@ CODE_11ADF0:
   JSL $0397D3                               ; $11AE15 |
   RTS                                       ; $11AE19 |
 
-  JSL $008259                               ; $11AE1A |
+  JSL init_oam_buffer                       ; $11AE1A |
   JSL spr_edge_despawn_draw                 ; $11AE1E |
   JSL draw_player                           ; $11AE22 |
   STZ $03BA                                 ; $11AE26 |
@@ -6254,7 +6256,7 @@ CODE_11B6DB:
   JSL $108B61                               ; $11B857 |
   RTS                                       ; $11B85B |
 
-  JSL $008259                               ; $11B85C |
+  JSL init_oam_buffer                       ; $11B85C |
   LDA #$30                                  ; $11B860 |
   STA $6126                                 ; $11B862 |
   JSL spr_edge_despawn_draw                 ; $11B865 |
@@ -7683,6 +7685,7 @@ CODE_11C43A:
 CODE_11C44A:
   RTS                                       ; $11C44A |
 
+init_mini_battle_watermelon_pot:
   LDY !reg_slhv                             ; $11C44B |
   LDY !reg_stat78                           ; $11C44E |
   LDA !reg_ophct                            ; $11C451 |
@@ -7693,7 +7696,7 @@ CODE_11C44A:
   STA !s_spr_timer_1,x                      ; $11C45C |
   RTL                                       ; $11C45F |
 
-init_mini_battle_watermelon_pot:
+main_mini_battle_watermelon_pot:
   LDA !s_spr_wildcard_4_lo_dp,x             ; $11C460 |
   ASL A                                     ; $11C462 |
   TAY                                       ; $11C463 |
@@ -7863,7 +7866,7 @@ CODE_11C505:
   JSL $108B61                               ; $11C5F5 |
   RTS                                       ; $11C5F9 |
 
-  JSL $008259                               ; $11C5FA |
+  JSL init_oam_buffer                       ; $11C5FA |
   LDA #$30                                  ; $11C5FE |
   STA $6126                                 ; $11C600 |
   JSL spr_edge_despawn_draw                 ; $11C603 |
@@ -8337,7 +8340,7 @@ main_item_card:
   JMP ($7960)                               ; $11C9AD |
   JSL $11C91A                               ; $11C9B0 | return here after JMP
   JSL $02DABA                               ; $11C9B4 |
-  JSL $03AA52                               ; $11C9B8 |
+  JSL CODE_03AA52                           ; $11C9B8 |
   RTL                                       ; $11C9BC |
 
 item_card_ptr:

--- a/disassembly/bank12.asm
+++ b/disassembly/bank12.asm
@@ -400,6 +400,7 @@ CODE_1286FD:
 ; $2C = Y Offset
 ; Output:
 ; X = Map16 index in the level data
+CODE_128719:
   LDA $2C                                   ; $128719 |
   AND #$000F                                ; $12871B |
   ASL A                                     ; $12871E |
@@ -443,6 +444,7 @@ CODE_1286FD:
 ; $2C = Y Offset
 ; Output:
 ; X = Map16 index in the level data
+CODE_12875D:
   LDA $2C                                   ; $12875D |
   AND #$000F                                ; $12875F |
   ASL A                                     ; $128762 |
@@ -616,6 +618,7 @@ CODE_12886A:
 CODE_128874:
   RTS                                       ; $128874 |
 
+CODE_128875:
   PHP                                       ; $128875 |
   SEP #$20                                  ; $128876 |
   LDA $002137                               ; $128878 |
@@ -1455,7 +1458,7 @@ CODE_128CCC:
   dw $0002, $0002                           ; $128FB5 |
 
   REP #$20                                  ; $128FB9 |
-  JSL $128875                               ; $128FBB |
+  JSL CODE_128875                           ; $128FBB |
   AND #$0006                                ; $128FBF |
   TAY                                       ; $128FC2 |
   LDA $8FA5,y                               ; $128FC3 |
@@ -1483,7 +1486,7 @@ CODE_128CCC:
   LDA #$0002                                ; $128FF2 |
   STA $2A                                   ; $128FF5 |
   STA $2E                                   ; $128FF7 |
-  JSL $128875                               ; $128FF9 |
+  JSL CODE_128875                           ; $128FF9 |
   AND #$0004                                ; $128FFD |
   STA $A1                                   ; $129000 |
   LDA $15                                   ; $129002 |
@@ -1496,7 +1499,7 @@ CODE_128CCC:
   LDA #$0003                                ; $129013 |
   STA $2A                                   ; $129016 |
   STA $2E                                   ; $129018 |
-  JSL $128875                               ; $12901A |
+  JSL CODE_128875                           ; $12901A |
   AND #$0001                                ; $12901E |
   STA $00                                   ; $129021 |
   LDA $15                                   ; $129023 |
@@ -1539,7 +1542,7 @@ CODE_128CCC:
   TAY                                       ; $129072 |
   LDA $905B,y                               ; $129073 |
   STA $2E                                   ; $129076 |
-  JSL $128875                               ; $129078 |
+  JSL CODE_128875                           ; $129078 |
   AND #$0003                                ; $12907C |
   BEQ CODE_129084                           ; $12907F |
   EOR #$0003                                ; $129081 |
@@ -1807,7 +1810,7 @@ CODE_129280:
   dw $FFFF, $0001                           ; $1292B8 |
 
   REP #$20                                  ; $1292BC |
-  JSR $933A                                 ; $1292BE |
+  JSR CODE_12933A                           ; $1292BE |
   LDA $15                                   ; $1292C1 |
   AND #$0001                                ; $1292C3 |
   ASL A                                     ; $1292C6 |
@@ -2156,7 +2159,7 @@ CODE_1294BD:
   dw $95FD                                  ; $129581 |
 
   REP #$20                                  ; $129583 |
-  JSL $128875                               ; $129585 |
+  JSL CODE_128875                           ; $129585 |
   AND #$0002                                ; $129589 |
   STA $A1                                   ; $12958C |
   LDA $15                                   ; $12958E |
@@ -2175,7 +2178,7 @@ CODE_1294BD:
 
   REP #$20                                  ; $1295AA |
   STZ $A1                                   ; $1295AC |
-  JSL $128875                               ; $1295AE |
+  JSL CODE_128875                           ; $1295AE |
   AND #$0002                                ; $1295B2 |
   BEQ CODE_1295BC                           ; $1295B5 |
   LDA #$000B                                ; $1295B7 |
@@ -2223,7 +2226,7 @@ CODE_1295BC:
   LDA #$9A88                                ; $12960D |
   JMP CODE_12A3DB                           ; $129610 |
   REP #$20                                  ; $129613 |
-  JSL $128875                               ; $129615 |
+  JSL CODE_128875                           ; $129615 |
   AND #$0002                                ; $129619 |
   STA $15                                   ; $12961C |
   LDX #$13                                  ; $12961E |
@@ -3222,7 +3225,7 @@ CODE_129CA9:
   AND #$0F0F                                ; $129E04 |
   ORA $00                                   ; $129E07 |
   STA $1B                                   ; $129E09 |
-  JSL $128875                               ; $129E0B |
+  JSL CODE_128875                           ; $129E0B |
   AND #$0003                                ; $129E0F |
   STA $15                                   ; $129E12 |
   EOR #$0003                                ; $129E14 |
@@ -3240,7 +3243,7 @@ CODE_129CA9:
   AND #$0004                                ; $129E2A |
   LSR A                                     ; $129E2D |
   TAY                                       ; $129E2E |
-  JSL $128875                               ; $129E2F |
+  JSL CODE_128875                           ; $129E2F |
   AND #$0003                                ; $129E33 |
   STA $15                                   ; $129E36 |
   EOR #$0003                                ; $129E38 |
@@ -3697,7 +3700,7 @@ CODE_12A130:
   LDA #$F205                                ; $12A1AD |
   JMP CODE_12A3DB                           ; $12A1B0 |
   REP #$20                                  ; $12A1B3 |
-  JSL $128875                               ; $12A1B5 |
+  JSL CODE_128875                           ; $12A1B5 |
   AND #$0007                                ; $12A1B9 |
   STA $15                                   ; $12A1BC |
   LDX #$13                                  ; $12A1BE |
@@ -3719,7 +3722,7 @@ CODE_12A130:
   JMP CODE_12A3DB                           ; $12A1E5 |
   REP #$20                                  ; $12A1E8 |
   STZ $A1                                   ; $12A1EA |
-  JSL $128875                               ; $12A1EC |
+  JSL CODE_128875                           ; $12A1EC |
   AND #$0003                                ; $12A1F0 |
   BEQ CODE_12A1F8                           ; $12A1F3 |
   EOR #$0003                                ; $12A1F5 |
@@ -4637,7 +4640,7 @@ CODE_12ABB2:
   dw $5F00, $5F01, $5F03, $5F03             ; $12ABF7 |
 
   REP #$30                                  ; $12ABFF |
-  JSL $128875                               ; $12AC01 |
+  JSL CODE_128875                           ; $12AC01 |
   AND #$0003                                ; $12AC05 |
   ASL A                                     ; $12AC08 |
   TAX                                       ; $12AC09 |
@@ -5979,7 +5982,7 @@ CODE_12BAE4:
   BNE CODE_12BB1F                           ; $12BB0B |
   LDA $1B                                   ; $12BB0D |
   STA $0E                                   ; $12BB0F |
-  JSL $12875D                               ; $12BB11 |
+  JSL CODE_12875D                           ; $12BB11 |
   LDA $BAE9,y                               ; $12BB15 |
   CLC                                       ; $12BB18 |
   ADC $28                                   ; $12BB19 |
@@ -6042,7 +6045,7 @@ CODE_12BB5C:
 
   LDA $1B                                   ; $12BB82 |
   STA $0E                                   ; $12BB84 |
-  JSL $128719                               ; $12BB86 |
+  JSL CODE_128719                           ; $12BB86 |
   LDA $1C66                                 ; $12BB8A |
   STA $7F8000,x                             ; $12BB8D |
   LDA $1B                                   ; $12BB91 |
@@ -6059,14 +6062,14 @@ CODE_12BB5C:
   AND #$0F0F                                ; $12BBAD |
   ORA $00                                   ; $12BBB0 |
   STA $0E                                   ; $12BBB2 |
-  JSL $128719                               ; $12BBB4 |
+  JSL CODE_128719                           ; $12BBB4 |
   LDA #$0000                                ; $12BBB8 |
   STA $7F8000,x                             ; $12BBBB |
   RTS                                       ; $12BBBF |
 
   LDA $1B                                   ; $12BBC0 |
   STA $0E                                   ; $12BBC2 |
-  JSL $128719                               ; $12BBC4 |
+  JSL CODE_128719                           ; $12BBC4 |
   LDA $1C60                                 ; $12BBC8 |
   STA $7F8000,x                             ; $12BBCB |
   LDA $1B                                   ; $12BBCF |
@@ -6084,7 +6087,7 @@ CODE_12BB5C:
   AND #$0F0F                                ; $12BBEE |
   ORA $00                                   ; $12BBF1 |
   STA $0E                                   ; $12BBF3 |
-  JSL $128719                               ; $12BBF5 |
+  JSL CODE_128719                           ; $12BBF5 |
   LDA #$0000                                ; $12BBF9 |
   STA $7F8000,x                             ; $12BBFC |
   RTS                                       ; $12BC00 |
@@ -6218,7 +6221,7 @@ CODE_12BD77:
   SEP #$30                                  ; $12BDAF |
   RTL                                       ; $12BDB1 |
 
-  JSL $128719                               ; $12BDB2 |
+  JSL CODE_128719                           ; $12BDB2 |
   RTS                                       ; $12BDB6 |
 
   JSL $1287A1                               ; $12BDB7 |
@@ -6237,7 +6240,7 @@ CODE_12BD77:
   STA $7F8000,x                             ; $12BDD0 |
   LDA $1B                                   ; $12BDD4 |
   STA $0E                                   ; $12BDD6 |
-  JSL $12875D                               ; $12BDD8 |
+  JSL CODE_12875D                           ; $12BDD8 |
   LDA $15                                   ; $12BDDC |
   LSR A                                     ; $12BDDE |
   CLC                                       ; $12BDDF |
@@ -6249,7 +6252,7 @@ CODE_12BD77:
   REP #$30                                  ; $12BDEA |
   LDA $1B                                   ; $12BDEC |
   STA $0E                                   ; $12BDEE |
-  JSL $128719                               ; $12BDF0 |
+  JSL CODE_128719                           ; $12BDF0 |
   LDA $7F8000,x                             ; $12BDF4 |
   CMP #$7942                                ; $12BDF8 |
   BEQ CODE_12BE02                           ; $12BDFB |
@@ -6298,7 +6301,7 @@ CODE_12BE31:
   REP #$30                                  ; $12BE42 |
   LDA $1B                                   ; $12BE44 |
   STA $0E                                   ; $12BE46 |
-  JSL $12875D                               ; $12BE48 |
+  JSL CODE_12875D                           ; $12BE48 |
   LDA $7F8000,x                             ; $12BE4C |
   CMP #$7948                                ; $12BE50 |
   BEQ CODE_12BE5A                           ; $12BE53 |
@@ -6346,7 +6349,7 @@ CODE_12BE88:
   REP #$30                                  ; $12BE99 |
   LDA $1B                                   ; $12BE9B |
   STA $0E                                   ; $12BE9D |
-  JSL $12875D                               ; $12BE9F |
+  JSL CODE_12875D                           ; $12BE9F |
   LDA $7F8000,x                             ; $12BEA3 |
   CMP #$793D                                ; $12BEA7 |
   BEQ CODE_12BEB1                           ; $12BEAA |
@@ -6395,7 +6398,7 @@ CODE_12BEE0:
   REP #$30                                  ; $12BEF1 |
   LDA $1B                                   ; $12BEF3 |
   STA $0E                                   ; $12BEF5 |
-  JSL $12875D                               ; $12BEF7 |
+  JSL CODE_12875D                           ; $12BEF7 |
   LDA $7F8000,x                             ; $12BEFB |
   CMP #$794F                                ; $12BEFF |
   BEQ CODE_12BF09                           ; $12BF02 |
@@ -6792,7 +6795,7 @@ CODE_12C2BE:
 CODE_12C2D8:
   LDA $1B                                   ; $12C2D8 |
   STA $0E                                   ; $12C2DA |
-  JSL $12875D                               ; $12C2DC |
+  JSL CODE_12875D                           ; $12C2DC |
   LDA $7F8000,x                             ; $12C2E0 |
   CMP #$8DA5                                ; $12C2E4 |
   BEQ CODE_12C2F3                           ; $12C2E7 |
@@ -6822,7 +6825,7 @@ CODE_12C2F9:
   STA $7F8000,x                             ; $12C30C |
   LDA $1B                                   ; $12C310 |
   STA $0E                                   ; $12C312 |
-  JSL $128719                               ; $12C314 |
+  JSL CODE_128719                           ; $12C314 |
   LDA $7F8000,x                             ; $12C318 |
   CMP #$152A                                ; $12C31C |
   BEQ CODE_12C326                           ; $12C31F |
@@ -7081,7 +7084,7 @@ CODE_12C3FC:
   BNE CODE_12C6DF                           ; $12C6B9 |
   LDA $1B                                   ; $12C6BB |
   STA $0E                                   ; $12C6BD |
-  JSL $12875D                               ; $12C6BF |
+  JSL CODE_12875D                           ; $12C6BF |
   LDY #$0000                                ; $12C6C3 |
   LDA $7F8000,x                             ; $12C6C6 |
 

--- a/disassembly/bank13.asm
+++ b/disassembly/bank13.asm
@@ -47,7 +47,7 @@ CODE_138055:
   BNE CODE_138072                           ; $138058 |
   LDA $1B                                   ; $13805A |
   STA $0E                                   ; $13805C |
-  JSL $128719                               ; $13805E |
+  JSL CODE_128719                           ; $13805E |
   LDA $7F8000,x                             ; $138062 |
   CMP $1CA0                                 ; $138066 |
   BEQ CODE_138070                           ; $138069 |
@@ -137,7 +137,7 @@ CODE_1380F9:
 
 CODE_138105:
   JSR CODE_138131                           ; $138105 |
-  JSL $128875                               ; $138108 |
+  JSL CODE_128875                           ; $138108 |
   AND #$0007                                ; $13810C |
   ASL A                                     ; $13810F |
   TAY                                       ; $138110 |
@@ -165,7 +165,7 @@ CODE_138131:
   STA $7F8000,x                             ; $138141 |
   LDA $1B                                   ; $138145 |
   STA $0E                                   ; $138147 |
-  JSL $12875D                               ; $138149 |
+  JSL CODE_12875D                           ; $138149 |
   LDA $1CC4                                 ; $13814D |
   STA $7F8000,x                             ; $138150 |
 
@@ -175,7 +175,7 @@ CODE_138154:
   BNE CODE_13816E                           ; $13815A |
   LDA $1CCC                                 ; $13815C |
   STA $7F8000,x                             ; $13815F |
-  JSL $12875D                               ; $138163 |
+  JSL CODE_12875D                           ; $138163 |
   LDA $1CC2                                 ; $138167 |
   STA $7F8000,x                             ; $13816A |
 
@@ -197,7 +197,7 @@ CODE_13816F:
 CODE_13818B:
   LDA $1B                                   ; $13818B |
   STA $0E                                   ; $13818D |
-  JSL $12875D                               ; $13818F |
+  JSL CODE_12875D                           ; $13818F |
   LDA $1CC2                                 ; $138193 |
   STA $7F8000,x                             ; $138196 |
   LDA #$1CCC                                ; $13819A |
@@ -217,7 +217,7 @@ CODE_13819F:
 CODE_1381B6:
   LDA $1B                                   ; $1381B6 |
   STA $0E                                   ; $1381B8 |
-  JSL $12875D                               ; $1381BA |
+  JSL CODE_12875D                           ; $1381BA |
   LDA $1CC4                                 ; $1381BE |
   STA $7F8000,x                             ; $1381C1 |
   LDA #$1CCA                                ; $1381C5 |
@@ -284,7 +284,7 @@ CODE_138214:
   dw $1D00                                  ; $13822F |
 
   REP #$30                                  ; $138231 |
-  JSL $128875                               ; $138233 |
+  JSL CODE_128875                           ; $138233 |
   AND #$0003                                ; $138237 |
   STA $00                                   ; $13823A |
   LDA $15                                   ; $13823C |
@@ -312,7 +312,7 @@ CODE_138214:
 CODE_138269:
   LDA $1B                                   ; $138269 |
   STA $0E                                   ; $13826B |
-  JSL $128719                               ; $13826D |
+  JSL CODE_128719                           ; $13826D |
   LDA $7F8000,x                             ; $138271 |
   CMP $1CFE                                 ; $138275 |
   BEQ CODE_13828C                           ; $138278 |
@@ -359,7 +359,7 @@ CODE_1382B8:
   BEQ CODE_13830A                           ; $1382CC |
   LDA $1B                                   ; $1382CE |
   STA $0E                                   ; $1382D0 |
-  JSL $12875D                               ; $1382D2 |
+  JSL CODE_12875D                           ; $1382D2 |
   LDA $1CC4                                 ; $1382D6 |
   STA $7F8000,x                             ; $1382D9 |
   LDA #$1CA2                                ; $1382DD |
@@ -375,7 +375,7 @@ CODE_1382E4:
   BEQ CODE_13830A                           ; $1382F4 |
   LDA $1B                                   ; $1382F6 |
   STA $0E                                   ; $1382F8 |
-  JSL $12875D                               ; $1382FA |
+  JSL CODE_12875D                           ; $1382FA |
   LDA $1CC2                                 ; $1382FE |
   STA $7F8000,x                             ; $138301 |
   LDA #$1CA0                                ; $138305 |
@@ -1045,7 +1045,7 @@ CODE_13873B:
   RTS                                       ; $13873D |
 
 CODE_13873E:
-  JSL $128719                               ; $13873E |
+  JSL CODE_128719                           ; $13873E |
   LDA $7F8000,x                             ; $138742 |
   CMP $1C5C                                 ; $138746 |
   BEQ CODE_138750                           ; $138749 |
@@ -1356,7 +1356,7 @@ CODE_138D8C:
   STA $7F8000,x                             ; $138D95 |
   LDA $2C                                   ; $138D99 |
   BNE CODE_138DB1                           ; $138D9B |
-  JSL $12875D                               ; $138D9D |
+  JSL CODE_12875D                           ; $138D9D |
   LDA $7F8000,x                             ; $138DA1 |
   AND #$FF00                                ; $138DA5 |
   CMP #$1600                                ; $138DA8 |
@@ -1648,7 +1648,7 @@ CODE_138FA6:
   ASL A                                     ; $13900A |
   TAY                                       ; $13900B |
   BNE CODE_139017                           ; $13900C |
-  JSL $128875                               ; $13900E |
+  JSL CODE_128875                           ; $13900E |
   AND #$0003                                ; $139012 |
   STA $A1                                   ; $139015 |
 
@@ -1686,7 +1686,7 @@ CODE_139033:
   BRA CODE_139056                           ; $139047 |
 
 CODE_139049:
-  JSL $128875                               ; $139049 |
+  JSL CODE_128875                           ; $139049 |
   ADC $2C                                   ; $13904D |
   AND #$001E                                ; $13904F |
   TAY                                       ; $139052 |
@@ -1738,12 +1738,12 @@ CODE_13909B:
   STA $0A                                   ; $1390AA |
   LDA $1B                                   ; $1390AC |
   STA $0E                                   ; $1390AE |
-  JSL $128719                               ; $1390B0 |
+  JSL CODE_128719                           ; $1390B0 |
   LDA $06                                   ; $1390B4 |
   STA $7F8000,x                             ; $1390B6 |
   LDA $1B                                   ; $1390BA |
   STA $0E                                   ; $1390BC |
-  JSL $12875D                               ; $1390BE |
+  JSL CODE_12875D                           ; $1390BE |
   LDA $08                                   ; $1390C2 |
   STA $7F8000,x                             ; $1390C4 |
   LDA $1B                                   ; $1390C8 |
@@ -1805,7 +1805,7 @@ CODE_139118:
   STA $08                                   ; $139125 |
   LDA $1B                                   ; $139127 |
   STA $0E                                   ; $139129 |
-  JSL $12875D                               ; $13912B |
+  JSL CODE_12875D                           ; $13912B |
   LDA $06                                   ; $13912F |
   STA $7F8000,x                             ; $139131 |
   LDA $1B                                   ; $139135 |
@@ -1818,7 +1818,7 @@ CODE_139118:
   AND #$0F0F                                ; $139145 |
   ORA $00                                   ; $139148 |
   STA $0E                                   ; $13914A |
-  JSL $12875D                               ; $13914C |
+  JSL CODE_12875D                           ; $13914C |
   LDA $08                                   ; $139150 |
   STA $7F8000,x                             ; $139152 |
   LDX $04                                   ; $139156 |
@@ -1848,7 +1848,7 @@ CODE_139177:
   BRA CODE_13919F                           ; $139183 |
 
 CODE_139185:
-  JSL $128875                               ; $139185 |
+  JSL CODE_128875                           ; $139185 |
   AND #$0001                                ; $139189 |
   CLC                                       ; $13918C |
   ADC #$909E                                ; $13918D |
@@ -1893,7 +1893,7 @@ CODE_1391C6:
   BRA CODE_1391F0                           ; $1391D4 |
 
 CODE_1391D6:
-  JSL $128875                               ; $1391D6 |
+  JSL CODE_128875                           ; $1391D6 |
   AND #$0001                                ; $1391DA |
   CLC                                       ; $1391DD |
   ADC #$9062                                ; $1391DE |
@@ -1954,7 +1954,7 @@ CODE_139223:
   JMP CODE_139049                           ; $139231 |
 
 CODE_139234:
-  JSL $128875                               ; $139234 |
+  JSL CODE_128875                           ; $139234 |
   AND #$0003                                ; $139238 |
   STA $00                                   ; $13923B |
   LDA $2C                                   ; $13923D |
@@ -1995,7 +1995,7 @@ CODE_139267:
   STA $7F8000,x                             ; $139288 |
   LDA $1B                                   ; $13928C |
   STA $0E                                   ; $13928E |
-  JSL $128719                               ; $139290 |
+  JSL CODE_128719                           ; $139290 |
   LDA #$964D                                ; $139294 |
   STA $7F8000,x                             ; $139297 |
   LDA $1B                                   ; $13929B |
@@ -2037,7 +2037,7 @@ CODE_1392DF:
   STA $7F8000,x                             ; $1392F0 |
   LDA $1B                                   ; $1392F4 |
   STA $0E                                   ; $1392F6 |
-  JSL $128719                               ; $1392F8 |
+  JSL CODE_128719                           ; $1392F8 |
   LDA #$964E                                ; $1392FC |
   STA $7F8000,x                             ; $1392FF |
   LDA $1B                                   ; $139303 |
@@ -2100,7 +2100,7 @@ CODE_139373:
 CODE_13937F:
   LDA $1B                                   ; $13937F |
   STA $0E                                   ; $139381 |
-  JSL $128719                               ; $139383 |
+  JSL CODE_128719                           ; $139383 |
   LDA #$9204                                ; $139387 |
   STA $7F8000,x                             ; $13938A |
   JSR CODE_13FD54                           ; $13938E |
@@ -2114,7 +2114,7 @@ CODE_13939D:
   BRA CODE_1393D7                           ; $1393A0 |
 
 CODE_1393A2:
-  JSL $128875                               ; $1393A2 |
+  JSL CODE_128875                           ; $1393A2 |
   AND #$0001                                ; $1393A6 |
   STA $00                                   ; $1393A9 |
   LDA $2C                                   ; $1393AB |
@@ -2180,7 +2180,7 @@ CODE_13940B:
 CODE_139417:
   LDA $1B                                   ; $139417 |
   STA $0E                                   ; $139419 |
-  JSL $128719                               ; $13941B |
+  JSL CODE_128719                           ; $13941B |
   LDA #$9205                                ; $13941F |
   STA $7F8000,x                             ; $139422 |
   JSR CODE_13FD61                           ; $139426 |
@@ -2194,7 +2194,7 @@ CODE_139435:
   BRA CODE_13946F                           ; $139438 |
 
 CODE_13943A:
-  JSL $128875                               ; $13943A |
+  JSL CODE_128875                           ; $13943A |
   AND #$0001                                ; $13943E |
   STA $00                                   ; $139441 |
   LDA $2C                                   ; $139443 |
@@ -2250,7 +2250,7 @@ CODE_13946F:
   STZ $9B                                   ; $1394DB |
   LDA $2C                                   ; $1394DD |
   BNE CODE_1394F1                           ; $1394DF |
-  JSL $128875                               ; $1394E1 |
+  JSL CODE_128875                           ; $1394E1 |
   AND #$0002                                ; $1394E5 |
   STA $A1                                   ; $1394E8 |
   BRA CODE_1394F1                           ; $1394EA |
@@ -2326,7 +2326,7 @@ CODE_139542:
 CODE_139558:
   LDA $28                                   ; $139558 |
   BNE CODE_139569                           ; $13955A |
-  JSL $128875                               ; $13955C |
+  JSL CODE_128875                           ; $13955C |
   AND #$0006                                ; $139560 |
   CLC                                       ; $139563 |
   ADC #$90DA                                ; $139564 |
@@ -2426,7 +2426,7 @@ CODE_1395FD:
   CMP #$02                                  ; $13960D |
   BCC CODE_139651                           ; $13960F |
   REP #$30                                  ; $139611 |
-  JSL $128875                               ; $139613 |
+  JSL CODE_128875                           ; $139613 |
   AND #$0002                                ; $139617 |
   BEQ CODE_13964F                           ; $13961A |
   LDA $1B                                   ; $13961C |
@@ -2488,7 +2488,7 @@ CODE_139682:
   BRA CODE_1396A1                           ; $13968F |
 
 CODE_139691:
-  JSL $128875                               ; $139691 |
+  JSL CODE_128875                           ; $139691 |
   AND #$0002                                ; $139695 |
   LSR A                                     ; $139698 |
   ADC #$990B                                ; $139699 |
@@ -2518,7 +2518,7 @@ CODE_1396A1:
 CODE_1396C7:
   LDA $1B                                   ; $1396C7 |
   STA $0E                                   ; $1396C9 |
-  JSL $128719                               ; $1396CB |
+  JSL CODE_128719                           ; $1396CB |
   LDY #$0000                                ; $1396CF |
   LDA $7F8000,x                             ; $1396D2 |
   CMP #$963B                                ; $1396D6 |
@@ -2555,7 +2555,7 @@ CODE_139706:
   BRA CODE_13975A                           ; $13970B |
 
 CODE_13970D:
-  JSL $128875                               ; $13970D |
+  JSL CODE_128875                           ; $13970D |
   AND #$0001                                ; $139711 |
   STA $00                                   ; $139714 |
   LDA $2C                                   ; $139716 |
@@ -2617,7 +2617,7 @@ CODE_139760:
   BIT $C51A                                 ; $139774 |
   ROL $27F0                                 ; $139777 |
   REP #$30                                  ; $13977A |
-  JSL $128875                               ; $13977C |
+  JSL CODE_128875                           ; $13977C |
   AND #$0007                                ; $139780 |
   CMP #$0006                                ; $139783 |
   BCS CODE_13979F                           ; $139786 |
@@ -2710,7 +2710,7 @@ CODE_1397FD:
   INY                                       ; $139811 |
   CPY $2A                                   ; $139812 |
   BEQ CODE_139821                           ; $139814 |
-  JSL $128875                               ; $139816 |
+  JSL CODE_128875                           ; $139816 |
   AND #$0001                                ; $13981A |
   CLC                                       ; $13981D |
   ADC #$90BE                                ; $13981E |
@@ -2720,7 +2720,7 @@ CODE_139821:
 
   dw $984A, $9879, $9881                    ; $139822 |
 
-  JSL $128875                               ; $139828 |
+  JSL CODE_128875                           ; $139828 |
   AND #$0007                                ; $13982C |
   TAY                                       ; $13982F |
   LDX #$0000                                ; $139830 |
@@ -2812,7 +2812,7 @@ CODE_1398AF:
   INX                                       ; $1398C2 |
   CPX $2A                                   ; $1398C3 |
   BEQ CODE_1398EC                           ; $1398C5 |
-  JSL $128875                               ; $1398C7 |
+  JSL CODE_128875                           ; $1398C7 |
   AND #$0003                                ; $1398CB |
   CLC                                       ; $1398CE |
   ADC #$90CE                                ; $1398CF |
@@ -2826,7 +2826,7 @@ CODE_1398D4:
   INX                                       ; $1398DC |
   CPX $2A                                   ; $1398DD |
   BEQ CODE_1398EC                           ; $1398DF |
-  JSL $128875                               ; $1398E1 |
+  JSL CODE_128875                           ; $1398E1 |
   AND #$0003                                ; $1398E5 |
   CLC                                       ; $1398E8 |
   ADC #$90B2                                ; $1398E9 |
@@ -2862,7 +2862,7 @@ CODE_139905:
   INX                                       ; $139919 |
   CPX $2A                                   ; $13991A |
   BEQ CODE_139929                           ; $13991C |
-  JSL $128875                               ; $13991E |
+  JSL CODE_128875                           ; $13991E |
   AND #$0003                                ; $139922 |
   CLC                                       ; $139925 |
   ADC #$90C0                                ; $139926 |
@@ -2887,7 +2887,7 @@ CODE_139929:
   REP #$30                                  ; $13998A |
   LDA $2C                                   ; $13998C |
   BNE CODE_139999                           ; $13998E |
-  JSL $128875                               ; $139990 |
+  JSL CODE_128875                           ; $139990 |
   AND #$001E                                ; $139994 |
   STA $A1                                   ; $139997 |
 
@@ -2948,7 +2948,7 @@ CODE_1399D6:
 CODE_139A10:
   LDA $00                                   ; $139A10 |
   BNE CODE_139A1D                           ; $139A12 |
-  JSL $128875                               ; $139A14 |
+  JSL CODE_128875                           ; $139A14 |
   AND #$0006                                ; $139A18 |
   STA $15                                   ; $139A1B |
 
@@ -2984,7 +2984,7 @@ CODE_139A43:
 CODE_139A4E:
   CMP #$0002                                ; $139A4E |
   BCS CODE_139A60                           ; $139A51 |
-  JSL $128875                               ; $139A53 |
+  JSL CODE_128875                           ; $139A53 |
   AND #$0006                                ; $139A57 |
   TAY                                       ; $139A5A |
   LDA $99F1,y                               ; $139A5B |
@@ -3100,7 +3100,7 @@ CODE_139B4E:
 
   LDA $1B                                   ; $139B5B |
   STA $0E                                   ; $139B5D |
-  JSL $128719                               ; $139B5F |
+  JSL CODE_128719                           ; $139B5F |
   STX $04                                   ; $139B63 |
   LDA $7F8000,x                             ; $139B65 |
   AND #$FF00                                ; $139B69 |
@@ -3127,7 +3127,7 @@ CODE_139B4E:
   AND #$0F0F                                ; $139B9D |
   ORA $00                                   ; $139BA0 |
   STA $0E                                   ; $139BA2 |
-  JSL $128719                               ; $139BA4 |
+  JSL CODE_128719                           ; $139BA4 |
   LDA $7F8000,x                             ; $139BA8 |
   AND #$FF00                                ; $139BAC |
   CMP #$9D00                                ; $139BAF |
@@ -3163,7 +3163,7 @@ CODE_139BE4:
   AND #$0F0F                                ; $139BF2 |
   ORA $04                                   ; $139BF5 |
   STA $0E                                   ; $139BF7 |
-  JSL $128719                               ; $139BF9 |
+  JSL CODE_128719                           ; $139BF9 |
   LDA $7F8000,x                             ; $139BFD |
   AND #$FF00                                ; $139C01 |
   CMP #$9D00                                ; $139C04 |
@@ -3175,14 +3175,14 @@ CODE_139BE4:
   AND #$0F0F                                ; $139C12 |
   ORA $04                                   ; $139C15 |
   STA $0E                                   ; $139C17 |
-  JSL $128719                               ; $139C19 |
+  JSL CODE_128719                           ; $139C19 |
   LDA $7F8000,x                             ; $139C1D |
   AND #$FF00                                ; $139C21 |
   CMP #$9D00                                ; $139C24 |
   BNE CODE_139C5F                           ; $139C27 |
   LDA $1B                                   ; $139C29 |
   STA $0E                                   ; $139C2B |
-  JSL $128719                               ; $139C2D |
+  JSL CODE_128719                           ; $139C2D |
   LDA $7F8000,x                             ; $139C31 |
   AND #$FF00                                ; $139C35 |
   CMP #$9D00                                ; $139C38 |
@@ -3204,7 +3204,7 @@ CODE_139C5F:
 
   LDA $1B                                   ; $139C60 |
   STA $0E                                   ; $139C62 |
-  JSL $128719                               ; $139C64 |
+  JSL CODE_128719                           ; $139C64 |
   STX $04                                   ; $139C68 |
   LDA $7F8000,x                             ; $139C6A |
   AND #$FF00                                ; $139C6E |
@@ -3232,7 +3232,7 @@ CODE_139C5F:
   AND #$0F0F                                ; $139CA5 |
   ORA $00                                   ; $139CA8 |
   STA $0E                                   ; $139CAA |
-  JSL $128719                               ; $139CAC |
+  JSL CODE_128719                           ; $139CAC |
   LDA $7F8000,x                             ; $139CB0 |
   AND #$FF00                                ; $139CB4 |
   CMP #$9D00                                ; $139CB7 |
@@ -3268,7 +3268,7 @@ CODE_139CEC:
   AND #$0F0F                                ; $139CFA |
   ORA $08                                   ; $139CFD |
   STA $0E                                   ; $139CFF |
-  JSL $128719                               ; $139D01 |
+  JSL CODE_128719                           ; $139D01 |
   LDA $7F8000,x                             ; $139D05 |
   AND #$FF00                                ; $139D09 |
   CMP #$9D00                                ; $139D0C |
@@ -3279,7 +3279,7 @@ CODE_139CEC:
   AND #$0F0F                                ; $139D17 |
   ORA $08                                   ; $139D1A |
   STA $0E                                   ; $139D1C |
-  JSL $12875D                               ; $139D1E |
+  JSL CODE_12875D                           ; $139D1E |
   LDA $7F8000,x                             ; $139D22 |
   AND #$FF00                                ; $139D26 |
   CMP #$9D00                                ; $139D29 |
@@ -3316,7 +3316,7 @@ CODE_139D5B:
   AND #$0F0F                                ; $139D6D |
   ORA $08                                   ; $139D70 |
   STA $0E                                   ; $139D72 |
-  JSL $128719                               ; $139D74 |
+  JSL CODE_128719                           ; $139D74 |
   LDA $7F8000,x                             ; $139D78 |
   AND #$FF00                                ; $139D7C |
   CMP #$9D00                                ; $139D7F |
@@ -3328,7 +3328,7 @@ CODE_139D5B:
   AND #$0F0F                                ; $139D8D |
   ORA $08                                   ; $139D90 |
   STA $0E                                   ; $139D92 |
-  JSL $12875D                               ; $139D94 |
+  JSL CODE_12875D                           ; $139D94 |
   LDA $7F8000,x                             ; $139D98 |
   AND #$FF00                                ; $139D9C |
   CMP #$9D00                                ; $139D9F |
@@ -3354,7 +3354,7 @@ CODE_139DD1:
 
   LDA $1B                                   ; $139DD2 |
   STA $0E                                   ; $139DD4 |
-  JSL $12875D                               ; $139DD6 |
+  JSL CODE_12875D                           ; $139DD6 |
   STX $04                                   ; $139DDA |
   LDA $7F8000,x                             ; $139DDC |
   AND #$FF00                                ; $139DE0 |
@@ -3381,7 +3381,7 @@ CODE_139DD1:
   AND #$0F0F                                ; $139E14 |
   ORA $00                                   ; $139E17 |
   STA $0E                                   ; $139E19 |
-  JSL $12875D                               ; $139E1B |
+  JSL CODE_12875D                           ; $139E1B |
   LDA $7F8000,x                             ; $139E1F |
   AND #$FF00                                ; $139E23 |
   CMP #$9D00                                ; $139E26 |
@@ -3417,7 +3417,7 @@ CODE_139E5B:
   AND #$0F0F                                ; $139E69 |
   ORA $08                                   ; $139E6C |
   STA $0E                                   ; $139E6E |
-  JSL $12875D                               ; $139E70 |
+  JSL CODE_12875D                           ; $139E70 |
   LDA $7F8000,x                             ; $139E74 |
   AND #$FF00                                ; $139E78 |
   CMP #$9D00                                ; $139E7B |
@@ -3429,14 +3429,14 @@ CODE_139E5B:
   AND #$0F0F                                ; $139E89 |
   ORA $08                                   ; $139E8C |
   STA $0E                                   ; $139E8E |
-  JSL $12875D                               ; $139E90 |
+  JSL CODE_12875D                           ; $139E90 |
   LDA $7F8000,x                             ; $139E94 |
   AND #$FF00                                ; $139E98 |
   CMP #$9D00                                ; $139E9B |
   BNE CODE_139ED6                           ; $139E9E |
   LDA $1B                                   ; $139EA0 |
   STA $0E                                   ; $139EA2 |
-  JSL $12875D                               ; $139EA4 |
+  JSL CODE_12875D                           ; $139EA4 |
   LDA $7F8000,x                             ; $139EA8 |
   AND #$FF00                                ; $139EAC |
   CMP #$9D00                                ; $139EAF |
@@ -3458,7 +3458,7 @@ CODE_139ED6:
 
   LDA $1B                                   ; $139ED7 |
   STA $0E                                   ; $139ED9 |
-  JSL $12875D                               ; $139EDB |
+  JSL CODE_12875D                           ; $139EDB |
   STX $04                                   ; $139EDF |
   LDA $7F8000,x                             ; $139EE1 |
   AND #$FF00                                ; $139EE5 |
@@ -3486,7 +3486,7 @@ CODE_139ED6:
   AND #$0F0F                                ; $139F1C |
   ORA $00                                   ; $139F1F |
   STA $0E                                   ; $139F21 |
-  JSL $12875D                               ; $139F23 |
+  JSL CODE_12875D                           ; $139F23 |
   LDA $7F8000,x                             ; $139F27 |
   AND #$FF00                                ; $139F2B |
   CMP #$9D00                                ; $139F2E |
@@ -3855,7 +3855,7 @@ CODE_13A1A6:
 CODE_13A1D3:
   LDA $1B                                   ; $13A1D3 |
   STA $0E                                   ; $13A1D5 |
-  JSL $12875D                               ; $13A1D7 |
+  JSL CODE_12875D                           ; $13A1D7 |
   LDA $7F8000,x                             ; $13A1DB |
   LDY #$0000                                ; $13A1DF |
 
@@ -3913,7 +3913,7 @@ CODE_13A225:
 CODE_13A272:
   LDA $1B                                   ; $13A272 |
   STA $0E                                   ; $13A274 |
-  JSL $12875D                               ; $13A276 |
+  JSL CODE_12875D                           ; $13A276 |
   LDA $7F8000,x                             ; $13A27A |
   LDY #$0000                                ; $13A27E |
 
@@ -3973,7 +3973,7 @@ CODE_13A2FB:
   LDA $2C                                   ; $13A300 |
   CMP #$0001                                ; $13A302 |
   BNE CODE_13A314                           ; $13A305 |
-  JSL $128875                               ; $13A307 |
+  JSL CODE_128875                           ; $13A307 |
   AND #$0006                                ; $13A30B |
   TAY                                       ; $13A30E |
   LDA $A297,y                               ; $13A30F |
@@ -4007,7 +4007,7 @@ CODE_13A333:
   AND #$F0F0                                ; $13A340 |
   ORA $0E                                   ; $13A343 |
   STA $0E                                   ; $13A345 |
-  JSL $12875D                               ; $13A347 |
+  JSL CODE_12875D                           ; $13A347 |
   LDA $7F8000,x                             ; $13A34B |
   LDY #$0000                                ; $13A34F |
 
@@ -4193,7 +4193,7 @@ CODE_13A47E:
 CODE_13A495:
   LDA $1B                                   ; $13A495 |
   STA $0E                                   ; $13A497 |
-  JSL $128719                               ; $13A499 |
+  JSL CODE_128719                           ; $13A499 |
   LDA $7F8000,x                             ; $13A49D |
   CMP #$00C5                                ; $13A4A1 |
   BNE CODE_13A4EF                           ; $13A4A4 |
@@ -4204,7 +4204,7 @@ CODE_13A4AB:
   LDY #$0000                                ; $13A4AB |
   LDA $1B                                   ; $13A4AE |
   STA $0E                                   ; $13A4B0 |
-  JSL $128719                               ; $13A4B2 |
+  JSL CODE_128719                           ; $13A4B2 |
   LDA $7F8000,x                             ; $13A4B6 |
   CMP #$0151                                ; $13A4BA |
   BEQ CODE_13A4DF                           ; $13A4BD |
@@ -4247,7 +4247,7 @@ CODE_13A4EF:
 CODE_13A4F8:
   LDA $1B                                   ; $13A4F8 |
   STA $0E                                   ; $13A4FA |
-  JSL $128719                               ; $13A4FC |
+  JSL CODE_128719                           ; $13A4FC |
   LDA $7F8000,x                             ; $13A500 |
   CMP #$0151                                ; $13A504 |
   BEQ CODE_13A521                           ; $13A507 |
@@ -4355,7 +4355,7 @@ CODE_13A5BE:
   LDY #$0000                                ; $13A5BE |
   LDA $1B                                   ; $13A5C1 |
   STA $0E                                   ; $13A5C3 |
-  JSL $128719                               ; $13A5C5 |
+  JSL CODE_128719                           ; $13A5C5 |
   LDA $7F8000,x                             ; $13A5C9 |
   CMP #$015A                                ; $13A5CD |
   BEQ CODE_13A5FF                           ; $13A5D0 |
@@ -4428,7 +4428,7 @@ CODE_13A637:
   BNE CODE_13A69A                           ; $13A650 |
   LDA $1B                                   ; $13A652 |
   STA $0E                                   ; $13A654 |
-  JSL $128719                               ; $13A656 |
+  JSL CODE_128719                           ; $13A656 |
   LDA #$0005                                ; $13A65A |
   STA $00                                   ; $13A65D |
   LDY #$0000                                ; $13A65F |
@@ -4454,7 +4454,7 @@ CODE_13A677:
   BRA CODE_13A6A3                           ; $13A688 |
 
 CODE_13A68A:
-  JSL $128875                               ; $13A68A |
+  JSL CODE_128875                           ; $13A68A |
   AND #$000E                                ; $13A68E |
   TAY                                       ; $13A691 |
   LDA $A638,y                               ; $13A692 |
@@ -4539,7 +4539,7 @@ CODE_13A717:
 CODE_13A724:
   LDA $1B                                   ; $13A724 |
   STA $0E                                   ; $13A726 |
-  JSL $12875D                               ; $13A728 |
+  JSL CODE_12875D                           ; $13A728 |
   LDY #$0000                                ; $13A72C |
   LDA $7F8000,x                             ; $13A72F |
 
@@ -4793,7 +4793,7 @@ CODE_13A8DD:
   BNE CODE_13A90C                           ; $13A8DF |
   LDA $1B                                   ; $13A8E1 |
   STA $0E                                   ; $13A8E3 |
-  JSL $128719                               ; $13A8E5 |
+  JSL CODE_128719                           ; $13A8E5 |
   LDY #$0000                                ; $13A8E9 |
   LDA $7F8000,x                             ; $13A8EC |
   CMP #$7E00                                ; $13A8F0 |
@@ -5436,13 +5436,13 @@ CODE_13AC3C:
   REP #$30                                  ; $13B13F |
   LDA $1B                                   ; $13B141 |
   STA $0E                                   ; $13B143 |
-  JSL $128719                               ; $13B145 |
+  JSL CODE_128719                           ; $13B145 |
   LDA #$B1B0                                ; $13B149 |
   STA $0A                                   ; $13B14C |
   JSR CODE_13B190                           ; $13B14E |
   LDA $1B                                   ; $13B151 |
   STA $0E                                   ; $13B153 |
-  JSL $12875D                               ; $13B155 |
+  JSL CODE_12875D                           ; $13B155 |
   LDA #$B32E                                ; $13B159 |
   STA $0A                                   ; $13B15C |
   JSR CODE_13B190                           ; $13B15E |
@@ -6108,7 +6108,7 @@ CODE_13BBCB:
   BNE CODE_13BBEF                           ; $13BBCD |
   LDA $1B                                   ; $13BBCF |
   STA $0E                                   ; $13BBD1 |
-  JSL $12875D                               ; $13BBD3 |
+  JSL CODE_12875D                           ; $13BBD3 |
   LDA $7F8000,x                             ; $13BBD7 |
   CMP $1CE8                                 ; $13BBDB |
   BEQ CODE_13BBEF                           ; $13BBDE |
@@ -6238,7 +6238,7 @@ CODE_13BCDB:
   BNE CODE_13BCFF                           ; $13BCDD |
   LDA $1B                                   ; $13BCDF |
   STA $0E                                   ; $13BCE1 |
-  JSL $12875D                               ; $13BCE3 |
+  JSL CODE_12875D                           ; $13BCE3 |
   LDA $7F8000,x                             ; $13BCE7 |
   CMP $1CE8                                 ; $13BCEB |
   BEQ CODE_13BCFF                           ; $13BCEE |
@@ -6839,7 +6839,7 @@ CODE_13C116:
   dw $5303, $5503, $5B05                    ; $13C159 |
 
 CODE_13C15F:
-  JSL $128875                               ; $13C15F |
+  JSL CODE_128875                           ; $13C15F |
   AND #$0007                                ; $13C163 |
   ASL A                                     ; $13C166 |
   TAY                                       ; $13C167 |
@@ -7093,7 +7093,7 @@ CODE_13C539:
   AND #$0F0F                                ; $13C546 |
   ORA $00                                   ; $13C549 |
   STA $0E                                   ; $13C54B |
-  JSL $128719                               ; $13C54D |
+  JSL CODE_128719                           ; $13C54D |
   LDA $7F8000,x                             ; $13C551 |
   TAY                                       ; $13C555 |
   AND #$FF00                                ; $13C556 |
@@ -7140,7 +7140,7 @@ CODE_13C58E:
   AND #$0F0F                                ; $13C59B |
   ORA $00                                   ; $13C59E |
   STA $0E                                   ; $13C5A0 |
-  JSL $12875D                               ; $13C5A2 |
+  JSL CODE_12875D                           ; $13C5A2 |
   LDA $7F8000,x                             ; $13C5A6 |
   TAY                                       ; $13C5AA |
   AND #$FF00                                ; $13C5AB |
@@ -7161,7 +7161,7 @@ CODE_13C5C4:
 CODE_13C5C5:
   LDA $1B                                   ; $13C5C5 |
   STA $0E                                   ; $13C5C7 |
-  JSL $128719                               ; $13C5C9 |
+  JSL CODE_128719                           ; $13C5C9 |
   LDA $7F8000,x                             ; $13C5CD |
   TAY                                       ; $13C5D1 |
   AND #$FF00                                ; $13C5D2 |
@@ -7182,7 +7182,7 @@ CODE_13C5EB:
 CODE_13C5EC:
   LDA $1B                                   ; $13C5EC |
   STA $0E                                   ; $13C5EE |
-  JSL $12875D                               ; $13C5F0 |
+  JSL CODE_12875D                           ; $13C5F0 |
   LDA $7F8000,x                             ; $13C5F4 |
   TAY                                       ; $13C5F8 |
   AND #$FF00                                ; $13C5F9 |
@@ -7212,7 +7212,7 @@ CODE_13C613:
   AND #$0F0F                                ; $13C623 |
   ORA $00                                   ; $13C626 |
   STA $0E                                   ; $13C628 |
-  JSL $128719                               ; $13C62A |
+  JSL CODE_128719                           ; $13C62A |
   LDA $7F8000,x                             ; $13C62E |
   TAY                                       ; $13C632 |
   AND #$FF00                                ; $13C633 |
@@ -7260,7 +7260,7 @@ CODE_13C66B:
   AND #$0F0F                                ; $13C67B |
   ORA $00                                   ; $13C67E |
   STA $0E                                   ; $13C680 |
-  JSL $12875D                               ; $13C682 |
+  JSL CODE_12875D                           ; $13C682 |
   LDA $7F8000,x                             ; $13C686 |
   TAY                                       ; $13C68A |
   AND #$FF00                                ; $13C68B |
@@ -7279,7 +7279,7 @@ CODE_13C6A4:
   RTS                                       ; $13C6A4 |
 
   REP #$30                                  ; $13C6A5 |
-  JSL $128875                               ; $13C6A7 |
+  JSL CODE_128875                           ; $13C6A7 |
   AND #$003F                                ; $13C6AB |
   CMP #$000B                                ; $13C6AE |
   BCC CODE_13C6B8                           ; $13C6B1 |
@@ -7464,7 +7464,7 @@ CODE_13C7D2:
   dw $1DD6, $1DD0, $1DD2                    ; $13C7E2 |
 
   REP #$30                                  ; $13C7E8 |
-  JSL $128875                               ; $13C7EA |
+  JSL CODE_128875                           ; $13C7EA |
   AND #$0007                                ; $13C7EE |
   ASL A                                     ; $13C7F1 |
   TAY                                       ; $13C7F2 |
@@ -7500,7 +7500,7 @@ CODE_13C829:
 
 CODE_13C831:
   REP #$30                                  ; $13C831 |
-  JSL $128875                               ; $13C833 |
+  JSL CODE_128875                           ; $13C833 |
   AND #$0003                                ; $13C837 |
   ASL A                                     ; $13C83A |
   TAY                                       ; $13C83B |
@@ -7762,7 +7762,7 @@ CODE_13CA0B:
 CODE_13CA10:
   LDA $1B                                   ; $13CA10 |
   STA $0E                                   ; $13CA12 |
-  JSL $12875D                               ; $13CA14 |
+  JSL CODE_12875D                           ; $13CA14 |
   LDA $7F8000,x                             ; $13CA18 |
   CMP $1D9C                                 ; $13CA1C |
   BNE CODE_13CA26                           ; $13CA1F |
@@ -7791,7 +7791,7 @@ CODE_13CA3A:
 CODE_13CA3F:
   LDA $1B                                   ; $13CA3F |
   STA $0E                                   ; $13CA41 |
-  JSL $12875D                               ; $13CA43 |
+  JSL CODE_12875D                           ; $13CA43 |
   LDA $7F8000,x                             ; $13CA47 |
   CMP $1D9E                                 ; $13CA4B |
   BNE CODE_13CA55                           ; $13CA4E |
@@ -8723,7 +8723,7 @@ CODE_13D215:
 
 CODE_13D218:
   STA $0E                                   ; $13D218 |
-  JSL $12875D                               ; $13D21A |
+  JSL CODE_12875D                           ; $13D21A |
   LDA $7F8000,x                             ; $13D21E |
   CMP $1C04                                 ; $13D222 |
   BNE CODE_13D22E                           ; $13D225 |
@@ -8735,7 +8735,7 @@ CODE_13D22E:
 
 CODE_13D22F:
   STA $0E                                   ; $13D22F |
-  JSL $12875D                               ; $13D231 |
+  JSL CODE_12875D                           ; $13D231 |
   LDA $7F8000,x                             ; $13D235 |
   CMP $1C04                                 ; $13D239 |
   BNE CODE_13D245                           ; $13D23C |
@@ -8799,7 +8799,7 @@ CODE_13D2AB:
   BRA CODE_13D2C5                           ; $13D2AE |
 
 CODE_13D2B0:
-  JSL $128875                               ; $13D2B0 |
+  JSL CODE_128875                           ; $13D2B0 |
   AND #$0003                                ; $13D2B4 |
   ASL A                                     ; $13D2B7 |
   STA $00                                   ; $13D2B8 |
@@ -8987,7 +8987,7 @@ CODE_13D3E4:
   INC A                                     ; $13D3F6 |
   CMP $2E                                   ; $13D3F7 |
   BEQ CODE_13D402                           ; $13D3F9 |
-  JSL $128875                               ; $13D3FB |
+  JSL CODE_128875                           ; $13D3FB |
   AND #$A801                                ; $13D3FF |
 
 CODE_13D402:
@@ -10312,7 +10312,7 @@ CODE_13DD67:
   STZ $04                                   ; $13DD67 |
   LDA $1B                                   ; $13DD69 |
   STA $0E                                   ; $13DD6B |
-  JSL $128719                               ; $13DD6D |
+  JSL CODE_128719                           ; $13DD6D |
   LDA $7F8000,x                             ; $13DD71 |
   CMP #$7C00                                ; $13DD75 |
   BNE CODE_13DD7F                           ; $13DD78 |
@@ -10327,7 +10327,7 @@ CODE_13DD7F:
   BNE CODE_13DD9D                           ; $13DD85 |
   LDA $1B                                   ; $13DD87 |
   STA $0E                                   ; $13DD89 |
-  JSL $12875D                               ; $13DD8B |
+  JSL CODE_12875D                           ; $13DD8B |
   LDA $7F8000,x                             ; $13DD8F |
   CMP #$7C00                                ; $13DD93 |
   BNE CODE_13DD9D                           ; $13DD96 |
@@ -10912,7 +10912,7 @@ CODE_13E2D8:
   BNE CODE_13E317                           ; $13E2FA |
   LDA $1B                                   ; $13E2FC |
   STA $0E                                   ; $13E2FE |
-  JSL $12875D                               ; $13E300 |
+  JSL CODE_12875D                           ; $13E300 |
   LDA $7F8000,x                             ; $13E304 |
   CMP #$779F                                ; $13E308 |
   BEQ CODE_13E312                           ; $13E30B |
@@ -10948,7 +10948,7 @@ CODE_13E31F:
   BNE CODE_13E35C                           ; $13E33F |
   LDA $1B                                   ; $13E341 |
   STA $0E                                   ; $13E343 |
-  JSL $128719                               ; $13E345 |
+  JSL CODE_128719                           ; $13E345 |
   LDA $7F8000,x                             ; $13E349 |
   CMP #$7799                                ; $13E34D |
   BEQ CODE_13E357                           ; $13E350 |
@@ -10984,7 +10984,7 @@ CODE_13E364:
   BNE CODE_13E3A3                           ; $13E386 |
   LDA $1B                                   ; $13E388 |
   STA $0E                                   ; $13E38A |
-  JSL $128719                               ; $13E38C |
+  JSL CODE_128719                           ; $13E38C |
   LDA $7F8000,x                             ; $13E390 |
   CMP #$7799                                ; $13E394 |
   BEQ CODE_13E39E                           ; $13E397 |
@@ -11300,7 +11300,7 @@ CODE_13E6A1:
   BNE CODE_13E6C8                           ; $13E6A4 |
   LDA $1B                                   ; $13E6A6 |
   STA $0E                                   ; $13E6A8 |
-  JSL $12875D                               ; $13E6AA |
+  JSL CODE_12875D                           ; $13E6AA |
   LDY #$002E                                ; $13E6AE |
   LDA $7F8000,x                             ; $13E6B1 |
 
@@ -11775,7 +11775,7 @@ CODE_13EAAB:
   AND #$F0F0                                ; $13EAB8 |
   ORA $0E                                   ; $13EABB |
   STA $0E                                   ; $13EABD |
-  JSL $128719                               ; $13EABF |
+  JSL CODE_128719                           ; $13EABF |
   LDA $7F8000,x                             ; $13EAC3 |
   CMP #$0153                                ; $13EAC7 |
   BCC CODE_13EAD6                           ; $13EACA |
@@ -11809,7 +11809,7 @@ CODE_13EAE9:
   AND #$F0F0                                ; $13EAF6 |
   ORA $0E                                   ; $13EAF9 |
   STA $0E                                   ; $13EAFB |
-  JSL $128719                               ; $13EAFD |
+  JSL CODE_128719                           ; $13EAFD |
   LDA $7F8000,x                             ; $13EB01 |
   CMP #$0153                                ; $13EB05 |
   BCC CODE_13EB18                           ; $13EB08 |
@@ -11829,7 +11829,7 @@ CODE_13EB18:
 CODE_13EB2C:
   LDA $1B                                   ; $13EB2C |
   STA $0E                                   ; $13EB2E |
-  JSL $128719                               ; $13EB30 |
+  JSL CODE_128719                           ; $13EB30 |
   LDA $7F8000,x                             ; $13EB34 |
   CMP #$0153                                ; $13EB38 |
   BCC CODE_13EB47                           ; $13EB3B |
@@ -11918,7 +11918,7 @@ CODE_13EBBB:
   AND #$F0F0                                ; $13EBC8 |
   ORA $0E                                   ; $13EBCB |
   STA $0E                                   ; $13EBCD |
-  JSL $128719                               ; $13EBCF |
+  JSL CODE_128719                           ; $13EBCF |
   LDA $7F8000,x                             ; $13EBD3 |
   CMP #$0153                                ; $13EBD7 |
   BCC CODE_13EBE8                           ; $13EBDA |
@@ -11963,7 +11963,7 @@ CODE_13EC10:
   BEQ CODE_13EC46                           ; $13EC1E |
   LDA $1B                                   ; $13EC20 |
   STA $0E                                   ; $13EC22 |
-  JSL $128719                               ; $13EC24 |
+  JSL CODE_128719                           ; $13EC24 |
   LDA $7F8000,x                             ; $13EC28 |
   CMP #$0153                                ; $13EC2C |
   BCC CODE_13EC46                           ; $13EC2F |
@@ -12119,7 +12119,7 @@ CODE_13ED5C:
   BRA CODE_13ED9F                           ; $13ED65 |
 
 CODE_13ED67:
-  JSL $128875                               ; $13ED67 |
+  JSL CODE_128875                           ; $13ED67 |
   AND #$0007                                ; $13ED6B |
   ASL A                                     ; $13ED6E |
   TAY                                       ; $13ED6F |
@@ -12154,7 +12154,7 @@ CODE_13ED9F:
   SEP #$30                                  ; $13ED9F |
   RTL                                       ; $13EDA1 |
 
-  JSL $128719                               ; $13EDA2 |
+  JSL CODE_128719                           ; $13EDA2 |
   LDA #$7980                                ; $13EDA6 |
   STA $7F8000,x                             ; $13EDA9 |
   JSR CODE_13FD54                           ; $13EDAD |
@@ -12165,7 +12165,7 @@ CODE_13ED9F:
   STA $7F8000,x                             ; $13EDBC |
   RTS                                       ; $13EDC0 |
 
-  JSL $12875D                               ; $13EDC1 |
+  JSL CODE_12875D                           ; $13EDC1 |
   LDA #$7988                                ; $13EDC5 |
   STA $7F8000,x                             ; $13EDC8 |
   JSR CODE_13FD54                           ; $13EDCC |
@@ -12243,7 +12243,7 @@ CODE_13EE66:
   BRA CODE_13EEA9                           ; $13EE6F |
 
 CODE_13EE71:
-  JSL $128875                               ; $13EE71 |
+  JSL CODE_128875                           ; $13EE71 |
   AND #$0007                                ; $13EE75 |
   ASL A                                     ; $13EE78 |
   TAY                                       ; $13EE79 |
@@ -12278,7 +12278,7 @@ CODE_13EEA9:
   SEP #$30                                  ; $13EEA9 |
   RTL                                       ; $13EEAB |
 
-  JSL $128719                               ; $13EEAC |
+  JSL CODE_128719                           ; $13EEAC |
   LDA #$7983                                ; $13EEB0 |
   STA $7F8000,x                             ; $13EEB3 |
   JSR CODE_13FD61                           ; $13EEB7 |
@@ -12289,7 +12289,7 @@ CODE_13EEA9:
   STA $7F8000,x                             ; $13EEC6 |
   RTS                                       ; $13EECA |
 
-  JSL $12875D                               ; $13EECB |
+  JSL CODE_12875D                           ; $13EECB |
   LDA #$798B                                ; $13EECF |
   STA $7F8000,x                             ; $13EED2 |
   JSR CODE_13FD61                           ; $13EED6 |
@@ -12371,7 +12371,7 @@ CODE_13EF8C:
   BRA CODE_13EFD4                           ; $13EF95 |
 
 CODE_13EF97:
-  JSL $128875                               ; $13EF97 |
+  JSL CODE_128875                           ; $13EF97 |
   AND #$0007                                ; $13EF9B |
   ASL A                                     ; $13EF9E |
   TAY                                       ; $13EF9F |
@@ -12398,7 +12398,7 @@ CODE_13EFB2:
 CODE_13EFC5:
   LDA $1B                                   ; $13EFC5 |
   STA $0E                                   ; $13EFC7 |
-  JSL $128719                               ; $13EFC9 |
+  JSL CODE_128719                           ; $13EFC9 |
   LDA $EF13,y                               ; $13EFCD |
 
 CODE_13EFD0:
@@ -12408,7 +12408,7 @@ CODE_13EFD4:
   SEP #$30                                  ; $13EFD4 |
   RTL                                       ; $13EFD6 |
 
-  JSL $128719                               ; $13EFD7 |
+  JSL CODE_128719                           ; $13EFD7 |
   LDA #$7980                                ; $13EFDB |
   STA $7F8000,x                             ; $13EFDE |
   JSR CODE_13FD54                           ; $13EFE2 |
@@ -12419,7 +12419,7 @@ CODE_13EFD4:
   STA $7F8000,x                             ; $13EFF1 |
   RTS                                       ; $13EFF5 |
 
-  JSL $128719                               ; $13EFF6 |
+  JSL CODE_128719                           ; $13EFF6 |
   LDA #$7983                                ; $13EFFA |
   STA $7F8000,x                             ; $13EFFD |
   JSR CODE_13FD61                           ; $13F001 |
@@ -12438,7 +12438,7 @@ CODE_13F01D:
   STA $7F8000,x                             ; $13F022 |
   LDA $1B                                   ; $13F026 |
   STA $0E                                   ; $13F028 |
-  JSL $128719                               ; $13F02A |
+  JSL CODE_128719                           ; $13F02A |
   LDA $F00D,y                               ; $13F02E |
   STA $7F8000,x                             ; $13F031 |
   RTS                                       ; $13F035 |
@@ -12496,7 +12496,7 @@ CODE_13F0A1:
   BRA CODE_13F0E9                           ; $13F0AA |
 
 CODE_13F0AC:
-  JSL $128875                               ; $13F0AC |
+  JSL CODE_128875                           ; $13F0AC |
   AND #$0007                                ; $13F0B0 |
   ASL A                                     ; $13F0B3 |
   TAY                                       ; $13F0B4 |
@@ -12523,7 +12523,7 @@ CODE_13F0C7:
 CODE_13F0DA:
   LDA $1B                                   ; $13F0DA |
   STA $0E                                   ; $13F0DC |
-  JSL $12875D                               ; $13F0DE |
+  JSL CODE_12875D                           ; $13F0DE |
   LDA $F042,y                               ; $13F0E2 |
 
 CODE_13F0E5:
@@ -12533,7 +12533,7 @@ CODE_13F0E9:
   SEP #$30                                  ; $13F0E9 |
   RTL                                       ; $13F0EB |
 
-  JSL $12875D                               ; $13F0EC |
+  JSL CODE_12875D                           ; $13F0EC |
   LDA #$7988                                ; $13F0F0 |
   STA $7F8000,x                             ; $13F0F3 |
   JSR CODE_13FD54                           ; $13F0F7 |
@@ -12544,7 +12544,7 @@ CODE_13F0E9:
   STA $7F8000,x                             ; $13F106 |
   RTS                                       ; $13F10A |
 
-  JSL $12875D                               ; $13F10B |
+  JSL CODE_12875D                           ; $13F10B |
   LDA #$798B                                ; $13F10F |
   STA $7F8000,x                             ; $13F112 |
   JSR CODE_13FD61                           ; $13F116 |
@@ -12563,7 +12563,7 @@ CODE_13F132:
   STA $7F8000,x                             ; $13F137 |
   LDA $1B                                   ; $13F13B |
   STA $0E                                   ; $13F13D |
-  JSL $12875D                               ; $13F13F |
+  JSL CODE_12875D                           ; $13F13F |
   LDA $F122,y                               ; $13F143 |
   STA $7F8000,x                             ; $13F146 |
   RTS                                       ; $13F14A |
@@ -12606,7 +12606,7 @@ CODE_13F132:
   BNE CODE_13F1BB                           ; $13F1A6 |
   LDA $12                                   ; $13F1A8 |
   BNE CODE_13F1DD                           ; $13F1AA |
-  JSL $128875                               ; $13F1AC |
+  JSL CODE_128875                           ; $13F1AC |
   AND #$0006                                ; $13F1B0 |
   TAY                                       ; $13F1B3 |
   LDA $F194,y                               ; $13F1B4 |
@@ -12664,7 +12664,7 @@ CODE_13F21C:
   BNE CODE_13F230                           ; $13F21F |
   LDA $1B                                   ; $13F221 |
   STA $0E                                   ; $13F223 |
-  JSL $128719                               ; $13F225 |
+  JSL CODE_128719                           ; $13F225 |
   LDA #$0000                                ; $13F229 |
   STA $7F8000,x                             ; $13F22C |
 
@@ -13043,7 +13043,7 @@ CODE_13F53A:
   BNE CODE_13F553                           ; $13F542 |
   LDA $1B                                   ; $13F544 |
   STA $0E                                   ; $13F546 |
-  JSL $128719                               ; $13F548 |
+  JSL CODE_128719                           ; $13F548 |
   LDA #$0000                                ; $13F54C |
   STA $7F8000,x                             ; $13F54F |
 
@@ -13103,7 +13103,7 @@ CODE_13F602:
   BNE CODE_13F619                           ; $13F609 |
   LDA $2C                                   ; $13F60B |
   BNE CODE_13F619                           ; $13F60D |
-  JSL $128875                               ; $13F60F |
+  JSL CODE_128875                           ; $13F60F |
   AND #$000F                                ; $13F613 |
   ASL A                                     ; $13F616 |
   STA $A1                                   ; $13F617 |
@@ -13132,7 +13132,7 @@ CODE_13F631:
   dw $79E0, $79E0, $79E0, $79E0             ; $13F64C |
 
 CODE_13F654:
-  JSL $128875                               ; $13F654 |
+  JSL CODE_128875                           ; $13F654 |
   AND #$000F                                ; $13F658 |
   CLC                                       ; $13F65B |
   ADC $00                                   ; $13F65C |
@@ -13207,7 +13207,7 @@ CODE_13F707:
   BNE CODE_13F735                           ; $13F709 |
   LDA $2C                                   ; $13F70B |
   BNE CODE_13F735                           ; $13F70D |
-  JSL $128875                               ; $13F70F |
+  JSL CODE_128875                           ; $13F70F |
   AND #$0007                                ; $13F713 |
   ASL A                                     ; $13F716 |
   STA $A1                                   ; $13F717 |
@@ -13265,7 +13265,7 @@ CODE_13F78A:
   STA $9B                                   ; $13F78D |
   LDA $2C                                   ; $13F78F |
   BNE CODE_13F79D                           ; $13F791 |
-  JSL $128875                               ; $13F793 |
+  JSL CODE_128875                           ; $13F793 |
   AND #$0007                                ; $13F797 |
   ASL A                                     ; $13F79A |
   STA $A1                                   ; $13F79B |
@@ -13300,7 +13300,7 @@ CODE_13F79D:
   STA $9B                                   ; $13F7E4 |
   LDA $2C                                   ; $13F7E6 |
   BNE CODE_13F7F4                           ; $13F7E8 |
-  JSL $128875                               ; $13F7EA |
+  JSL CODE_128875                           ; $13F7EA |
   AND #$0007                                ; $13F7EE |
   ASL A                                     ; $13F7F1 |
   STA $A1                                   ; $13F7F2 |
@@ -13398,7 +13398,7 @@ CODE_13F8BD:
   BNE CODE_13F8EB                           ; $13F8BF |
   LDA $2C                                   ; $13F8C1 |
   BNE CODE_13F8EB                           ; $13F8C3 |
-  JSL $128875                               ; $13F8C5 |
+  JSL CODE_128875                           ; $13F8C5 |
   AND #$0007                                ; $13F8C9 |
   ASL A                                     ; $13F8CC |
   STA $A1                                   ; $13F8CD |
@@ -13482,7 +13482,7 @@ CODE_13F962:
   STA $9B                                   ; $13F965 |
   LDA $2C                                   ; $13F967 |
   BNE CODE_13F975                           ; $13F969 |
-  JSL $128875                               ; $13F96B |
+  JSL CODE_128875                           ; $13F96B |
   AND #$0007                                ; $13F96F |
   ASL A                                     ; $13F972 |
   STA $A1                                   ; $13F973 |
@@ -13517,7 +13517,7 @@ CODE_13F975:
   STA $9B                                   ; $13F9BC |
   LDA $2C                                   ; $13F9BE |
   BNE CODE_13F9CC                           ; $13F9C0 |
-  JSL $128875                               ; $13F9C2 |
+  JSL CODE_128875                           ; $13F9C2 |
   AND #$0007                                ; $13F9C6 |
   ASL A                                     ; $13F9C9 |
   STA $A1                                   ; $13F9CA |
@@ -13587,7 +13587,7 @@ CODE_13FA28:
   CMP #$7900                                ; $13FA42 |
   BNE CODE_13FA5A                           ; $13FA45 |
   STX $00                                   ; $13FA47 |
-  JSL $128875                               ; $13FA49 |
+  JSL CODE_128875                           ; $13FA49 |
   AND #$0006                                ; $13FA4D |
   TAY                                       ; $13FA50 |
   LDX $00                                   ; $13FA51 |
@@ -13643,7 +13643,7 @@ CODE_13FA9B:
   CMP #$7900                                ; $13FAB5 |
   BNE CODE_13FACD                           ; $13FAB8 |
   STX $00                                   ; $13FABA |
-  JSL $128875                               ; $13FABC |
+  JSL CODE_128875                           ; $13FABC |
   AND #$0006                                ; $13FAC0 |
   TAY                                       ; $13FAC3 |
   LDX $00                                   ; $13FAC4 |
@@ -13702,7 +13702,7 @@ CODE_13FB1D:
   LDA $2C                                   ; $13FB2B |
   AND #$0001                                ; $13FB2D |
   BEQ CODE_13FB41                           ; $13FB30 |
-  JSL $128875                               ; $13FB32 |
+  JSL CODE_128875                           ; $13FB32 |
   AND #$0002                                ; $13FB36 |
   BEQ CODE_13FB41                           ; $13FB39 |
   INC $00                                   ; $13FB3B |
@@ -13941,7 +13941,7 @@ CODE_13FCD2:
   DEC A                                     ; $13FCD6 |
   CMP #$0006                                ; $13FCD7 |
   BCC CODE_13FCE7                           ; $13FCDA |
-  JSL $128875                               ; $13FCDC |
+  JSL CODE_128875                           ; $13FCDC |
   AND #$0002                                ; $13FCE0 |
   CLC                                       ; $13FCE3 |
   ADC #$0004                                ; $13FCE4 |
@@ -13953,14 +13953,14 @@ CODE_13FCE7:
   BRA CODE_13FD0F                           ; $13FCEE |
 
 CODE_13FCF0:
-  JSL $128875                               ; $13FCF0 |
+  JSL CODE_128875                           ; $13FCF0 |
   AND #$0003                                ; $13FCF4 |
   CLC                                       ; $13FCF7 |
   ADC $2C                                   ; $13FCF8 |
   ASL A                                     ; $13FCFA |
   CMP #$0016                                ; $13FCFB |
   BCC CODE_13FD0B                           ; $13FCFE |
-  JSL $128875                               ; $13FD00 |
+  JSL CODE_128875                           ; $13FD00 |
   AND #$0002                                ; $13FD04 |
   CLC                                       ; $13FD07 |
   ADC #$0012                                ; $13FD08 |

--- a/disassembly/bank17.asm
+++ b/disassembly/bank17.asm
@@ -177,7 +177,7 @@ CODE_1781A4:
   BPL CODE_1781A4                           ; $1781D6 |
   LDA #$0D                                  ; $1781D8 |
   STA $09A0                                 ; $1781DA |
-  JSL $00B3CF                               ; $1781DD |
+  JSL CODE_00B3CF                           ; $1781DD |
   LDX #$00                                  ; $1781E1 |
   JSL init_scene_regs                       ; $1781E3 |
   LDA #$3C                                  ; $1781E7 |
@@ -415,7 +415,7 @@ CODE_1783CE:
   DEX                                       ; $1783E5 |
 
 CODE_1783E6:
-  JSL $00BAEA                               ; $1783E6 |
+  JSL CODE_00BAEA                           ; $1783E6 |
   PHB                                       ; $1783EA |
   LDA #$7E                                  ; $1783EB |
   PHA                                       ; $1783ED |
@@ -738,7 +738,7 @@ CODE_178649:
   LDY #$04                                  ; $17864F |
 
 CODE_178651:
-  LDA $00C214,x                             ; $178651 |
+  LDA DATA_00C214,x                         ; $178651 |
   STA $0996,y                               ; $178655 |
   INX                                       ; $178658 |
   DEY                                       ; $178659 |
@@ -1078,7 +1078,7 @@ CODE_1789D2:
   AND #$00FF                                ; $1789D6 |
   ASL A                                     ; $1789D9 |
   TAX                                       ; $1789DA |
-  LDA $00E954,x                             ; $1789DB |
+  LDA raphael_mode7_matrix_a_d,x            ; $1789DB |
   STA $03                                   ; $1789DF |
   BPL CODE_1789E7                           ; $1789E1 |
   EOR #$FFFF                                ; $1789E3 |
@@ -1115,7 +1115,7 @@ CODE_178A0E:
   ADC $00                                   ; $178A0F |
   STA $702D,y                               ; $178A11 |
   REP #$20                                  ; $178A14 |
-  LDA $00E9D4,x                             ; $178A16 |
+  LDA raphael_mode7_matrix_b_c,x            ; $178A16 |
   STA $03                                   ; $178A1A |
   BPL CODE_178A22                           ; $178A1C |
   EOR #$FFFF                                ; $178A1E |
@@ -4463,10 +4463,10 @@ gm20_prepare_overworld:
   STA $4305                                 ; $17A5FC |
   STY !reg_mdmaen                           ; $17A5FF |
   SEP #$20                                  ; $17A602 |
-  JSL $00B439                               ; $17A604 |
+  JSL CODE_00B439                           ; $17A604 |
   REP #$30                                  ; $17A608 |
   STZ !r_yoshi_color                        ; $17A60A |
-  JSL $00BB47                               ; $17A60D |
+  JSL CODE_00BB47                           ; $17A60D |
   REP #$20                                  ; $17A611 |
   JSL $17CD0B                               ; $17A613 |
   SEP #$20                                  ; $17A617 |
@@ -8851,7 +8851,7 @@ CODE_17CD96:
   STZ $112E                                 ; $17CDA1 |
   JSL $17A86D                               ; $17CDA4 |
   REP #$30                                  ; $17CDA8 |
-  JSL $00BB47                               ; $17CDAA |
+  JSL CODE_00BB47                           ; $17CDAA |
   SEP #$30                                  ; $17CDAE |
   JSR CODE_17C6EC                           ; $17CDB0 |
   INC !r_map_state_index                    ; $17CDB3 |
@@ -8875,7 +8875,7 @@ CODE_17CDCF:
   CLC                                       ; $17CDD6 |
   ADC $00                                   ; $17CDD7 |
   TAX                                       ; $17CDD9 |
-  LDA $00B3F4,x                             ; $17CDDA |
+  LDA bg1_bg2_world_map_tilemaps,x          ; $17CDDA |
   AND #$00FF                                ; $17CDDE |
   STA $0C                                   ; $17CDE1 |
   ASL A                                     ; $17CDE3 |
@@ -8966,7 +8966,7 @@ CODE_17CE9F:
   ASL A                                     ; $17CEA7 |
   ADC $00                                   ; $17CEA8 |
   TAX                                       ; $17CEAA |
-  LDA $00B409,x                             ; $17CEAB |
+  LDA world_map_gfx,x                       ; $17CEAB |
   AND #$00FF                                ; $17CEAF |
   STA $0C                                   ; $17CEB2 |
   ASL A                                     ; $17CEB4 |

--- a/disassembly/bank17.asm
+++ b/disassembly/bank17.asm
@@ -67,9 +67,9 @@ save_data_6_8_ptr:
   dw $7C46, $7CAE, $7D16                    ; $1780D0 | 6-8 completed / score save data pointers file 1, 2, 3
 
 ; title screen init
-gamemode_18:
+gm_load_title_screen:
   LDA #$12                                  ; $1780D6 |
-  JSL $008279                               ; $1780D8 |
+  JSL CODE_008279                           ; $1780D8 |
   JSL clear_basic_states                    ; $1780DC | init some ram
   JSL copy_division_lookup_to_sram          ; $1780E0 |
   REP #$20                                  ; $1780E4 |
@@ -675,13 +675,13 @@ CODE_1785B8:
   STA $01                                   ; $1785CF |
   LDY #$3020                                ; $1785D1 |
   LDA #$0300                                ; $1785D4 |
-  JSL $00BEA6                               ; $1785D7 |
+  JSL CODE_00BEA6                           ; $1785D7 |
   LDX #$2800                                ; $1785DB |
   LDA #$0070                                ; $1785DE |
   STA $01                                   ; $1785E1 |
   LDY #$2000                                ; $1785E3 |
   LDA #$1000                                ; $1785E6 |
-  JSL $00BEA6                               ; $1785E9 |
+  JSL CODE_00BEA6                           ; $1785E9 |
   SEP #$30                                  ; $1785ED |
   JSL process_vram_dma_queue_l              ; $1785EF |
 
@@ -714,7 +714,7 @@ CODE_17860F:
 
 CODE_17861F:
   STZ $098E                                 ; $17861F |
-  JSL $008245                               ; $178622 |
+  JSL enable_nmi                            ; $178622 |
   JSL $1787D2                               ; $178626 |
   LDA $0982                                 ; $17862A |
   STA $0980                                 ; $17862D |
@@ -814,7 +814,7 @@ CODE_178673:
   PHK                                       ; $1787D3 |
   PLB                                       ; $1787D4 |
 
-gamemode19:
+gm_fade_to_title_screen:
   JSL init_oam                              ; $1787D5 |
   REP #$30                                  ; $1787D9 |
   LDX #$009E                                ; $1787DB |
@@ -2428,7 +2428,7 @@ CODE_179466:
   LDA #$0070                                ; $1794AB |
   STA $01                                   ; $1794AE |
   LDA #$0C00                                ; $1794B0 |
-  JSL $00BEA6                               ; $1794B3 |
+  JSL CODE_00BEA6                           ; $1794B3 |
   SEP #$30                                  ; $1794B7 |
   RTS                                       ; $1794B9 |
 
@@ -3118,7 +3118,7 @@ CODE_17998B:
   TAX                                       ; $17999D |
   LDY #$3020                                ; $17999E |
   LDA #$0300                                ; $1799A1 |
-  JSL $00BEA6                               ; $1799A4 |
+  JSL CODE_00BEA6                           ; $1799A4 |
   SEP #$10                                  ; $1799A8 |
   RTS                                       ; $1799AA |
 
@@ -3139,19 +3139,19 @@ CODE_1799AB:
   STA $01                                   ; $1799D0 |
   LDX #$2800                                ; $1799D2 |
   LDA #$0080                                ; $1799D5 |
-  JSL $00BEA6                               ; $1799D8 |
+  JSL CODE_00BEA6                           ; $1799D8 |
   LDY #$7D80                                ; $1799DC |
   LDX #$2A00                                ; $1799DF |
   LDA #$0080                                ; $1799E2 |
-  JSL $00BEA6                               ; $1799E5 |
+  JSL CODE_00BEA6                           ; $1799E5 |
   LDY #$7E80                                ; $1799E9 |
   LDX #$2C00                                ; $1799EC |
   LDA #$0080                                ; $1799EF |
-  JSL $00BEA6                               ; $1799F2 |
+  JSL CODE_00BEA6                           ; $1799F2 |
   LDY #$7F80                                ; $1799F6 |
   LDX #$2E00                                ; $1799F9 |
   LDA #$0080                                ; $1799FC |
-  JSL $00BEA6                               ; $1799FF |
+  JSL CODE_00BEA6                           ; $1799FF |
   SEP #$30                                  ; $179A03 |
   RTS                                       ; $179A05 |
 
@@ -3182,7 +3182,7 @@ CODE_1799AB:
   TAX                                       ; $179A3F |
   LDY #$3220                                ; $179A40 |
   LDA #$0300                                ; $179A43 |
-  JSL $00BEA6                               ; $179A46 |
+  JSL CODE_00BEA6                           ; $179A46 |
   SEP #$30                                  ; $179A4A |
   INC $1130                                 ; $179A4C |
   RTS                                       ; $179A4F |
@@ -3249,7 +3249,7 @@ CODE_179A88:
   LDA #$0070                                ; $179AD0 |
   STA $01                                   ; $179AD3 |
   LDA #$0400                                ; $179AD5 |
-  JSL $00BEA6                               ; $179AD8 |
+  JSL CODE_00BEA6                           ; $179AD8 |
   LDA $1129                                 ; $179ADC |
   ASL A                                     ; $179ADF |
   TAX                                       ; $179AE0 |
@@ -3349,7 +3349,7 @@ CODE_179B6E:
   LDA #$0070                                ; $179BA8 |
   STA $01                                   ; $179BAB |
   LDA #$0800                                ; $179BAD |
-  JSL $00BEA6                               ; $179BB0 |
+  JSL CODE_00BEA6                           ; $179BB0 |
   SEP #$30                                  ; $179BB4 |
   RTS                                       ; $179BB6 |
 
@@ -3462,7 +3462,7 @@ CODE_179CC3:
   TAX                                       ; $179D1B |
   LDY #$3020                                ; $179D1C |
   LDA #$0300                                ; $179D1F |
-  JSL $00BEA6                               ; $179D22 |
+  JSL CODE_00BEA6                           ; $179D22 |
   SEP #$30                                  ; $179D26 |
   STZ !r_reg_tmw_mirror                     ; $179D28 |
   STZ !r_reg_wobjsel_mirror                 ; $179D2B |
@@ -3528,19 +3528,19 @@ CODE_179DA2:
   STA $01                                   ; $179DAA |
   LDX #$2800                                ; $179DAC |
   LDA #$0080                                ; $179DAF |
-  JSL $00BEA6                               ; $179DB2 |
+  JSL CODE_00BEA6                           ; $179DB2 |
   LDY #$7DC0                                ; $179DB6 |
   LDX #$2A00                                ; $179DB9 |
   LDA #$0080                                ; $179DBC |
-  JSL $00BEA6                               ; $179DBF |
+  JSL CODE_00BEA6                           ; $179DBF |
   LDY #$7EC0                                ; $179DC3 |
   LDX #$2C00                                ; $179DC6 |
   LDA #$0080                                ; $179DC9 |
-  JSL $00BEA6                               ; $179DCC |
+  JSL CODE_00BEA6                           ; $179DCC |
   LDY #$7FC0                                ; $179DD0 |
   LDX #$2E00                                ; $179DD3 |
   LDA #$0080                                ; $179DD6 |
-  JSL $00BEA6                               ; $179DD9 |
+  JSL CODE_00BEA6                           ; $179DD9 |
   SEP #$30                                  ; $179DDD |
   RTS                                       ; $179DDF |
 
@@ -3949,11 +3949,11 @@ CODE_17A08A:
   STA $01                                   ; $17A0D1 |
   LDX #$2C00                                ; $17A0D3 |
   LDA #$0100                                ; $17A0D6 |
-  JSL $00BEA6                               ; $17A0D9 |
+  JSL CODE_00BEA6                           ; $17A0D9 |
   LDY #$7F00                                ; $17A0DD |
   LDX #$2E00                                ; $17A0E0 |
   LDA #$0100                                ; $17A0E3 |
-  JSL $00BEA6                               ; $17A0E6 |
+  JSL CODE_00BEA6                           ; $17A0E6 |
   SEP #$30                                  ; $17A0EA |
   STZ $1136                                 ; $17A0EC |
   JSR CODE_17A378                           ; $17A0EF |
@@ -4233,7 +4233,7 @@ CODE_17A30F:
   STA $707E70,x                             ; $17A333 |
   STA $707E76,x                             ; $17A337 |
   SEP #$20                                  ; $17A33B |
-  JSL $108000                               ; $17A33D |
+  JSL CODE_108000                           ; $17A33D |
   INC $111B                                 ; $17A341 |
   RTS                                       ; $17A344 |
 
@@ -4420,18 +4420,18 @@ CODE_17A409:
   db $56, $53, $50, $4D, $4A, $47, $43, $3F ; $17A57C |
   db $3B, $37, $32, $2D, $27, $20, $17, $00 ; $17A584 |
 
-  db $BF, $01, $22, $77, $82, $00, $22, $1C ; $17A58C |
-  db $83, $00                               ; $17A594 |
+  db $BF, $01                               ; $17A58C |
+gm20_prepare_overworld:
+  JSL init_oam_and_bg3_tilemap              ; $17A58E |
+  JSL clear_basic_states                    ; $17A592 |
 
   LDA #$15                                  ; $17A596 |
-  JSL $008279                               ; $17A598 |
+  JSL CODE_008279                           ; $17A598 |
   JSL copy_division_lookup_to_sram          ; $17A59C |
   JSL clear_all_sprites                     ; $17A5A0 |
-  JSL $008259                               ; $17A5A4 |
+  JSL init_oam_buffer                       ; $17A5A4 |
   LDX #$28                                  ; $17A5A8 |\ play sound #$28
   JSL init_scene_regs                       ; $17A5AA |/
-
-gamemode20:
   LDA #$03                                  ; $17A5AE |
   STA !r_reg_obsel_mirror                   ; $17A5B0 |
   STA !reg_obsel                            ; $17A5B3 |
@@ -4700,7 +4700,7 @@ CODE_17A810:
   DEC $4D                                   ; $17A817 |
 
 CODE_17A819:
-  JSL $008245                               ; $17A819 |
+  JSL enable_nmi                            ; $17A819 |
   LDA #$FE                                  ; $17A81D |
   STA !r_reg_hdmaen_mirror                  ; $17A81F |
   JMP CODE_17B38A                           ; $17A822 |
@@ -4842,8 +4842,8 @@ CODE_17A908:
   dw $AA7A                                  ; $17A92E |
   dw $A9DE                                  ; $17A930 |
 
-gamemode28:
-  JSL $008259                               ; $17A932 |
+gm28_world_score_flip_cutscene:
+  JSL init_oam_buffer                       ; $17A932 |
   LDA $1127                                 ; $17A936 |
   BEQ CODE_17A943                           ; $17A939 |
   ASL A                                     ; $17A93B |
@@ -4958,8 +4958,8 @@ CODE_17A9DD:
   dw $AB69                                  ; $17AA16 |
   dw $AB24                                  ; $17AA18 |
 
-gamemode26:
-  JSL $008259                               ; $17AA1A | init OAM buffer
+gm26_level_score_update:
+  JSL init_oam_buffer                       ; $17AA1A | init OAM buffer
   LDA $1127                                 ; $17AA1E |
   BEQ CODE_17AA3E                           ; $17AA21 |
   ASL A                                     ; $17AA23 |
@@ -5268,7 +5268,7 @@ CODE_17AC43:
   LDY #$6800                                ; $17AC56 |
   LDX #$5800                                ; $17AC59 |
   LDA #$1000                                ; $17AC5C |
-  JSL $00BEA6                               ; $17AC5F |
+  JSL CODE_00BEA6                           ; $17AC5F |
   SEP #$10                                  ; $17AC63 |
   LDX #$0C                                  ; $17AC65 |
   STZ $00                                   ; $17AC67 |
@@ -5439,7 +5439,7 @@ CODE_17ADEE:
   LDY #$6800                                ; $17ADFD |
   LDX #$5800                                ; $17AE00 |
   LDA #$1000                                ; $17AE03 |
-  JSL $00BEA6                               ; $17AE06 |
+  JSL CODE_00BEA6                           ; $17AE06 |
   SEP #$10                                  ; $17AE0A |
   RTS                                       ; $17AE0C |
 
@@ -6076,8 +6076,8 @@ CODE_17B35F:
   STX !r_game_mode                          ; $17B35F |
   RTS                                       ; $17B362 |
 
-gamemode24:
-  JSL $008259                               ; $17B363 | init OAM buffer
+gm24_overworld_level_progression:
+  JSL init_oam_buffer                       ; $17B363 | init OAM buffer
   LDA $1131                                 ; $17B367 |
   BNE CODE_17B373                           ; $17B36A |
   REP #$30                                  ; $17B36C |
@@ -6144,8 +6144,8 @@ CODE_17B3AA:
   dw $C5C5                                  ; $17B3CB |
 
 ; map screen
-gamemode22:
-  JSL $008259                               ; $17B3CD |
+gm22_overworld:
+  JSL init_oam_buffer                       ; $17B3CD |
   JSL $17C757                               ; $17B3D1 |
   JMP CODE_17B430                           ; $17B3D5 |
 
@@ -8698,7 +8698,7 @@ CODE_17CC6F:
   TAX                                       ; $17CC81 |
   LDY #$1E20                                ; $17CC82 |
   LDA #$0380                                ; $17CC85 |
-  JSL $00BEA6                               ; $17CC88 |
+  JSL CODE_00BEA6                           ; $17CC88 |
   SEP #$30                                  ; $17CC8C |
   RTS                                       ; $17CC8E |
 
@@ -8716,7 +8716,7 @@ CODE_17CC93:
   LDA $CCB6,y                               ; $17CCA5 |
   TAY                                       ; $17CCA8 |
   LDA #$0800                                ; $17CCA9 |
-  JSL $00BEA6                               ; $17CCAC |
+  JSL CODE_00BEA6                           ; $17CCAC |
   SEP #$30                                  ; $17CCB0 |
   INC !r_map_state_index                    ; $17CCB2 |
   RTS                                       ; $17CCB5 |
@@ -8735,7 +8735,7 @@ CODE_17CCBA:
   LDA $CCF1,y                               ; $17CCCC |
   TAY                                       ; $17CCCF |
   LDA #$0800                                ; $17CCD0 |
-  JSL $00BEA6                               ; $17CCD3 |
+  JSL CODE_00BEA6                           ; $17CCD3 |
   SEP #$10                                  ; $17CCD7 |
   LDA #$FF00                                ; $17CCD9 |
   STA $7E55C0                               ; $17CCDC |
@@ -8810,7 +8810,7 @@ CODE_17CD23:
   TAX                                       ; $17CD52 |
   LDY #$1C20                                ; $17CD53 |
   LDA #$0380                                ; $17CD56 |
-  JSL $00BEA6                               ; $17CD59 |
+  JSL CODE_00BEA6                           ; $17CD59 |
   SEP #$30                                  ; $17CD5D |
   INC !r_map_state_index                    ; $17CD5F |
 
@@ -8846,7 +8846,7 @@ CODE_17CD96:
   RTS                                       ; $17CD96 |
 
   JSL clear_all_sprites                     ; $17CD97 |
-  JSL $008259                               ; $17CD9B |
+  JSL init_oam_buffer                       ; $17CD9B |
   REP #$30                                  ; $17CD9F |
   STZ $112E                                 ; $17CDA1 |
   JSL $17A86D                               ; $17CDA4 |
@@ -8903,7 +8903,7 @@ CODE_17CE11:
   STA $01                                   ; $17CE17 |
   LDY $0E                                   ; $17CE19 |
   LDA #$0800                                ; $17CE1B |
-  JSL $00BEA6                               ; $17CE1E |
+  JSL CODE_00BEA6                           ; $17CE1E |
   INC !r_map_state_index                    ; $17CE22 |
   RTS                                       ; $17CE25 |
 
@@ -8921,7 +8921,7 @@ CODE_17CE11:
   LDA $CE25,y                               ; $17CE40 |
   TAY                                       ; $17CE43 |
   LDA #$0800                                ; $17CE44 |
-  JSL $00BEA6                               ; $17CE47 |
+  JSL CODE_00BEA6                           ; $17CE47 |
   SEP #$30                                  ; $17CE4B |
   INC !r_map_state_index                    ; $17CE4D |
   RTS                                       ; $17CE50 |
@@ -8996,7 +8996,7 @@ CODE_17CEC1:
   LDA #$0070                                ; $17CEE9 |
   STA $01                                   ; $17CEEC |
   LDA #$0800                                ; $17CEEE |
-  JSL $00BEA6                               ; $17CEF1 |
+  JSL CODE_00BEA6                           ; $17CEF1 |
   INC !r_map_state_index                    ; $17CEF5 |
   SEP #$30                                  ; $17CEF8 |
   RTS                                       ; $17CEFA |
@@ -9208,19 +9208,19 @@ CODE_17D08B:
   LDY #$7CC0                                ; $17D092 |
   LDX #$5800                                ; $17D095 |
   LDA #$0080                                ; $17D098 |
-  JSL $00BEA6                               ; $17D09B |
+  JSL CODE_00BEA6                           ; $17D09B |
   LDY #$7DC0                                ; $17D09F |
   LDX #$5A00                                ; $17D0A2 |
   LDA #$0080                                ; $17D0A5 |
-  JSL $00BEA6                               ; $17D0A8 |
+  JSL CODE_00BEA6                           ; $17D0A8 |
   LDY #$7EC0                                ; $17D0AC |
   LDX #$5C00                                ; $17D0AF |
   LDA #$0080                                ; $17D0B2 |
-  JSL $00BEA6                               ; $17D0B5 |
+  JSL CODE_00BEA6                           ; $17D0B5 |
   LDY #$7FC0                                ; $17D0B9 |
   LDX #$5E00                                ; $17D0BC |
   LDA #$0080                                ; $17D0BF |
-  JSL $00BEA6                               ; $17D0C2 |
+  JSL CODE_00BEA6                           ; $17D0C2 |
   SEP #$30                                  ; $17D0C6 |
   RTS                                       ; $17D0C8 |
 
@@ -9782,7 +9782,7 @@ CODE_17D52B:
   TAX                                       ; $17D53D |
   LDY $04                                   ; $17D53E |
   LDA #$0380                                ; $17D540 |
-  JSL $00BEA6                               ; $17D543 |
+  JSL CODE_00BEA6                           ; $17D543 |
   SEP #$10                                  ; $17D547 |
   RTS                                       ; $17D549 |
 
@@ -11700,7 +11700,7 @@ CODE_17E61E:
   TAX                                       ; $17E634 |
   LDY #$1C80                                ; $17E635 |
   LDA #$0200                                ; $17E638 |
-  JSL $00BEA6                               ; $17E63B |
+  JSL CODE_00BEA6                           ; $17E63B |
   SEP #$30                                  ; $17E63F |
   RTS                                       ; $17E641 |
 
@@ -11739,19 +11739,19 @@ CODE_17E683:
   LDY #$7E00                                ; $17E68A |
   LDX #$5800                                ; $17E68D |
   LDA #$0080                                ; $17E690 |
-  JSL $00BEA6                               ; $17E693 |
+  JSL CODE_00BEA6                           ; $17E693 |
   LDY #$7F00                                ; $17E697 |
   LDX #$5A00                                ; $17E69A |
   LDA #$0080                                ; $17E69D |
-  JSL $00BEA6                               ; $17E6A0 |
+  JSL CODE_00BEA6                           ; $17E6A0 |
   LDY #$7E40                                ; $17E6A4 |
   LDX #$5C00                                ; $17E6A7 |
   LDA #$0080                                ; $17E6AA |
-  JSL $00BEA6                               ; $17E6AD |
+  JSL CODE_00BEA6                           ; $17E6AD |
   LDY #$7F40                                ; $17E6B1 |
   LDX #$5E00                                ; $17E6B4 |
   LDA #$0080                                ; $17E6B7 |
-  JSL $00BEA6                               ; $17E6BA |
+  JSL CODE_00BEA6                           ; $17E6BA |
   SEP #$30                                  ; $17E6BE |
   RTS                                       ; $17E6C0 |
 
@@ -12296,7 +12296,7 @@ CODE_17EB1F:
   TAX                                       ; $17EB31 |
   LDY #$1E20                                ; $17EB32 |
   LDA #$0380                                ; $17EB35 |
-  JSL $00BEA6                               ; $17EB38 |
+  JSL CODE_00BEA6                           ; $17EB38 |
   SEP #$30                                  ; $17EB3C |
   RTS                                       ; $17EB3E |
 
@@ -12328,7 +12328,7 @@ CODE_17EB5F:
   LDA $CCF1,y                               ; $17EB74 |
   TAY                                       ; $17EB77 |
   LDA #$0800                                ; $17EB78 |
-  JSL $00BEA6                               ; $17EB7B |
+  JSL CODE_00BEA6                           ; $17EB7B |
   SEP #$30                                  ; $17EB7F |
   INC !r_map_state_index                    ; $17EB81 |
   RTS                                       ; $17EB84 |
@@ -12457,7 +12457,7 @@ CODE_17EC6D:
   TAX                                       ; $17EC82 |
   LDY #$1C20                                ; $17EC83 |
   LDA #$0380                                ; $17EC86 |
-  JSL $00BEA6                               ; $17EC89 |
+  JSL CODE_00BEA6                           ; $17EC89 |
   SEP #$30                                  ; $17EC8D |
   BRA CODE_17ECA0                           ; $17EC8F |
 

--- a/disassembly/macros.asm
+++ b/disassembly/macros.asm
@@ -1,2 +1,3 @@
 function hirom_mirror(label) = $400000+(((bank(label))*$8000)+((label&$FFFF)-$8000))
 
+function rom_to_wram_rt(wrambank, romlabel) = (romlabel&$FFFF)|((wrambank&$FF)<<16)


### PR DESCRIPTION
Label a bunch of stuff:
Lots of bank 00 stuff, all long jump/subroutine calls to bank 00 code converted to labels, and all calls in bank 00 to other banks were also given labels.
Gamemode pointers all use labels, previous generic 'gamemodeXX' labels given more descriptive names
Sprite init/main/bonk/ride routines used labels in tables.
Ambient sprite routines labelled, along with some of their data tables. Some of this code was reformatted and disassembled as needed.
Some other assorted routines were given generic labels and had their usage sites updated (many that were used frequently through out the game). Some others had named labels already, so those were used instead.